### PR TITLE
installer script

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -63,6 +63,7 @@ unix-archive = ".tar.gz"
 windows-archive = ".zip"
 install-path = "CARGO_HOME"
 install-updater = true
+install-success-msg = ""
 
 [dev-dependencies]
 tempfile = "3"

--- a/README.md
+++ b/README.md
@@ -6,48 +6,40 @@
 
 ## Install
 
-### Stable (latest release)
-
-Unix-like systems:
+### Unix (macOS / Linux)
 
 ```bash
-curl -fsSL https://github.com/braintrustdata/bt/releases/latest/download/bt-installer.sh | sh
+curl -fsSL https://raw.githubusercontent.com/braintrustdata/bt/main/install.sh | bash
 ```
 
-Windows (PowerShell):
-
-```powershell
-powershell -ExecutionPolicy Bypass -c "irm https://github.com/braintrustdata/bt/releases/latest/download/bt-installer.ps1 | iex"
-```
-
-### Canary (latest `main`)
-
-Unix-like systems:
+Install a specific version:
 
 ```bash
-curl -fsSL https://github.com/braintrustdata/bt/releases/download/canary/bt-installer.sh | sh
+curl -fsSL https://raw.githubusercontent.com/braintrustdata/bt/main/install.sh | bash -s -- --version 0.1.2
 ```
 
-Windows (PowerShell):
-
-```powershell
-powershell -ExecutionPolicy Bypass -c "irm https://github.com/braintrustdata/bt/releases/download/canary/bt-installer.ps1 | iex"
-```
-
-### Canary (exact `main` commit build)
-
-Exact `main` canary builds are published as `canary-<shortsha>`.
-
-Unix-like systems:
+Install the latest canary build (latest `main`):
 
 ```bash
-curl -fsSL https://github.com/braintrustdata/bt/releases/download/canary-<shortsha>/bt-installer.sh | sh
+curl -fsSL https://raw.githubusercontent.com/braintrustdata/bt/main/install.sh | bash -s -- --canary
 ```
 
-Windows (PowerShell):
+### Windows (PowerShell)
 
 ```powershell
-powershell -ExecutionPolicy Bypass -c "irm https://github.com/braintrustdata/bt/releases/download/canary-<shortsha>/bt-installer.ps1 | iex"
+powershell -ExecutionPolicy Bypass -c "irm https://raw.githubusercontent.com/braintrustdata/bt/main/install.ps1 | iex"
+```
+
+Install a specific version:
+
+```powershell
+$env:BT_VERSION='0.1.2'; powershell -ExecutionPolicy Bypass -c "irm https://raw.githubusercontent.com/braintrustdata/bt/main/install.ps1 | iex"
+```
+
+Canary:
+
+```powershell
+$env:BT_CHANNEL='canary'; powershell -ExecutionPolicy Bypass -c "irm https://raw.githubusercontent.com/braintrustdata/bt/main/install.ps1 | iex"
 ```
 
 ### PR/branch builds (no release)

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,141 @@
+#!/bin/bash
+set -euo pipefail
+
+REPO="braintrustdata/bt"
+BASE_URL="https://github.com/${REPO}/releases"
+
+usage() {
+  cat <<EOF
+install.sh — install the Braintrust CLI (bt)
+
+Usage:
+  curl -fsSL https://raw.githubusercontent.com/${REPO}/main/install.sh | bash
+  curl -fsSL ... | bash -s -- [OPTIONS]
+
+Options:
+  --canary             Install the latest canary build (latest main)
+  --version <VERSION>  Install a specific version (e.g. 0.1.2)
+  --help               Show this help message
+
+Environment variables:
+  BT_CHANNEL=canary    Same as --canary
+  BT_VERSION=0.1.2     Same as --version 0.1.2
+
+All other flags are passed through to the underlying installer.
+
+Examples:
+  curl -fsSL ... | bash                          # latest stable
+  curl -fsSL ... | bash -s -- --canary           # latest canary
+  curl -fsSL ... | bash -s -- --version 0.1.2    # pinned version
+EOF
+  exit 0
+}
+
+# --- Parse arguments ----------------------------------------------------------
+
+channel="${BT_CHANNEL:-stable}"
+version="${BT_VERSION:-}"
+passthrough_args=""
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --canary) channel="canary"; shift ;;
+    --version=*) version="${1#--version=}"; shift ;;
+    --version)
+      if [[ -z "${2:-}" ]]; then
+        echo "Error: --version requires a value" >&2
+        exit 1
+      fi
+      version="$2"; shift 2
+      ;;
+    --help) usage ;;
+    *) passthrough_args="${passthrough_args} $1"; shift ;;
+  esac
+done
+
+# Strip v prefix (accept both "0.1.2" and "v0.1.2")
+version="${version#v}"
+
+if [[ -n "$version" && "$channel" == "canary" ]]; then
+  echo "Error: --canary and --version are mutually exclusive" >&2
+  exit 1
+fi
+
+# --- Build installer URL ------------------------------------------------------
+
+if [[ -n "$version" ]]; then
+  installer_url="${BASE_URL}/download/v${version}/bt-installer.sh"
+elif [[ "$channel" == "canary" ]]; then
+  installer_url="${BASE_URL}/download/canary/bt-installer.sh"
+else
+  installer_url="${BASE_URL}/latest/download/bt-installer.sh"
+fi
+
+# --- Require curl -------------------------------------------------------------
+
+if ! command -v curl >/dev/null 2>&1; then
+  echo "Error: curl is required to install bt." >&2
+  exit 1
+fi
+
+# --- Pre-flight check (pinned versions only) ----------------------------------
+
+if [[ -n "$version" ]]; then
+  status=$(curl -sSL -o /dev/null -w '%{http_code}' --head "$installer_url")
+  if [[ "$status" == "404" ]]; then
+    echo "Error: bt version ${version} not found." >&2
+    echo "See available releases: ${BASE_URL}" >&2
+    exit 1
+  elif [[ "$status" != "200" ]]; then
+    echo "Error: failed to verify version ${version} (HTTP ${status})" >&2
+    exit 1
+  fi
+fi
+
+# --- First-install detection --------------------------------------------------
+
+cargo_bin="${CARGO_HOME:-$HOME/.cargo}/bin"
+is_first_install=false
+if [[ ! -f "${cargo_bin}/bt" ]]; then
+  is_first_install=true
+fi
+
+# --- Install ------------------------------------------------------------------
+
+label="stable"
+if [[ -n "$version" ]]; then
+  label="v${version}"
+elif [[ "$channel" == "canary" ]]; then
+  label="canary"
+fi
+
+cat <<'LOGO'
+
+  ███  ███
+███      ███
+  ███  ███
+███      ███
+  ███  ███
+
+LOGO
+echo "Installing bt (${label})..."
+echo ""
+
+tmpfile=$(mktemp)
+trap 'rm -f "$tmpfile"' EXIT
+
+if ! curl -fsSL "$installer_url" -o "$tmpfile"; then
+  echo "Error: failed to download installer" >&2
+  exit 1
+fi
+
+# shellcheck disable=SC2086
+bash "$tmpfile" $passthrough_args | grep -v "everything's installed"
+
+# --- Post-install -------------------------------------------------------------
+
+if [[ "$is_first_install" == true ]]; then
+  echo ""
+  echo "Run 'bt setup' to get started."
+  echo ""
+fi


### PR DESCRIPTION
## feat: add unified install script with version selection

- **feat(install): add unified install.sh script with version and channel selection**
  - Supports installing latest stable, specific versions via `--version`, and canary builds via `--canary`
  - Includes environment variable support (`BT_CHANNEL`, `BT_VERSION`) and argument passthrough
  - Features ASCII logo display and first-install detection with setup guidance

- **docs(readme): consolidate installation instructions around new unified script**
  - Replaces separate stable/canary installation sections with streamlined Unix and Windows instructions
  - Removes references to exact commit builds and simplifies version-specific installation examples

- **config: suppress cargo-dist install success message**