### PR TITLE
ci: change install path from cargo to XDG_BIN_HOME to use XDG_*

### DIFF
--- a/.github/workflows/release-canary.yml
+++ b/.github/workflows/release-canary.yml
@@ -448,7 +448,7 @@ jobs:
       - name: Verify installed binary
         shell: bash
         run: |
-          export PATH="${CARGO_HOME:-$HOME/.cargo}/bin:$PATH"
+          export PATH="${XDG_BIN_HOME:-$HOME/.local/bin}:$PATH"
           bt --version | grep -i canary
           bt self update --check
 
@@ -471,7 +471,7 @@ jobs:
       - name: Verify installed binary
         shell: bash
         run: |
-          export PATH="${CARGO_HOME:-$HOME/.cargo}/bin:$PATH"
+          export PATH="${XDG_BIN_HOME:-$HOME/.local/bin}:$PATH"
           bt --version | grep -i canary
           bt self update --check
 
@@ -494,8 +494,8 @@ jobs:
       - name: Verify installed binary
         shell: pwsh
         run: |
-          $cargoHome = if ($env:CARGO_HOME) { $env:CARGO_HOME } else { Join-Path $HOME ".cargo" }
-          $btExe = Join-Path $cargoHome "bin\bt.exe"
+          $binDir = if ($env:XDG_BIN_HOME) { $env:XDG_BIN_HOME } else { Join-Path $HOME ".local/bin" }
+          $btExe = Join-Path $binDir "bt.exe"
           if (!(Test-Path $btExe)) {
             throw "bt.exe not found at $btExe"
           }
@@ -503,5 +503,5 @@ jobs:
           if ($version -notmatch "canary") {
             throw "expected canary version string, got: $version"
           }
-          $env:PATH = "$(Join-Path $cargoHome 'bin');$env:PATH"
+          $env:PATH = "$binDir;$env:PATH"
           & $btExe self update --check

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -329,13 +329,13 @@ jobs:
       - name: Verify installed binary
         shell: bash
         run: |
-          export PATH="${CARGO_HOME:-$HOME/.cargo}/bin:$PATH"
+          export PATH="${XDG_BIN_HOME:-$HOME/.local/bin}:$PATH"
           bt --version
 
       - name: Verify self-update check
         shell: bash
         run: |
-          export PATH="${CARGO_HOME:-$HOME/.cargo}/bin:$PATH"
+          export PATH="${XDG_BIN_HOME:-$HOME/.local/bin}:$PATH"
           bt self update --check --channel stable
 
   smoke-install-macos:
@@ -357,7 +357,7 @@ jobs:
       - name: Verify installed binary
         shell: bash
         run: |
-          export PATH="${CARGO_HOME:-$HOME/.cargo}/bin:$PATH"
+          export PATH="${XDG_BIN_HOME:-$HOME/.local/bin}:$PATH"
           bt --version
           bt self update --check --channel stable
 
@@ -380,11 +380,11 @@ jobs:
       - name: Verify installed binary
         shell: pwsh
         run: |
-          $cargoHome = if ($env:CARGO_HOME) { $env:CARGO_HOME } else { Join-Path $HOME ".cargo" }
-          $btExe = Join-Path $cargoHome "bin\bt.exe"
+          $binDir = if ($env:XDG_BIN_HOME) { $env:XDG_BIN_HOME } else { Join-Path $HOME ".local/bin" }
+          $btExe = Join-Path $binDir "bt.exe"
           if (!(Test-Path $btExe)) {
             throw "bt.exe not found at $btExe"
           }
           & $btExe --version
-          $env:PATH = "$(Join-Path $cargoHome 'bin');$env:PATH"
+          $env:PATH = "$binDir;$env:PATH"
           & $btExe self update --check --channel stable

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -298,9 +298,9 @@ dependencies = [
 
 [[package]]
 name = "async-compression"
-version = "0.4.40"
+version = "0.4.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d67d43201f4d20c78bcda740c142ca52482d81da80681533d33bf3f0596c8e2"
+checksum = "d0f9ee0f6e02ffd7ad5816e9464499fba7b3effd01123b515c41d1697c43dad1"
 dependencies = [
  "compression-codecs",
  "compression-core",
@@ -437,7 +437,7 @@ dependencies = [
 
 [[package]]
 name = "bt"
-version = "0.1.2"
+version = "0.2.0"
 dependencies = [
  "actix-web",
  "anyhow",


### PR DESCRIPTION
update release workflows to use new cargo-dist install paths