### PR TITLE
Add env var parity for bt eval flags

### DIFF
--- a/src/eval.rs
+++ b/src/eval.rs
@@ -2666,9 +2666,49 @@ fn convert_color(color: Color) -> CtColor {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use clap::Parser;
     use std::fs;
     use std::path::PathBuf;
+    use std::sync::{Mutex, OnceLock};
     use std::time::{SystemTime, UNIX_EPOCH};
+
+    #[derive(Debug, Parser)]
+    struct EvalArgsHarness {
+        #[command(flatten)]
+        eval: EvalArgs,
+    }
+
+    fn env_test_lock() -> &'static Mutex<()> {
+        static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+        LOCK.get_or_init(|| Mutex::new(()))
+    }
+
+    fn set_env_var(key: &str, value: &str) -> Option<String> {
+        let previous = std::env::var(key).ok();
+        // Safe in tests because access is serialized with env_test_lock().
+        unsafe { std::env::set_var(key, value) };
+        previous
+    }
+
+    fn clear_env_var(key: &str) -> Option<String> {
+        let previous = std::env::var(key).ok();
+        // Safe in tests because access is serialized with env_test_lock().
+        unsafe { std::env::remove_var(key) };
+        previous
+    }
+
+    fn restore_env_var(key: &str, previous: Option<String>) {
+        match previous {
+            Some(value) => {
+                // Safe in tests because access is serialized with env_test_lock().
+                unsafe { std::env::set_var(key, value) };
+            }
+            None => {
+                // Safe in tests because access is serialized with env_test_lock().
+                unsafe { std::env::remove_var(key) };
+            }
+        }
+    }
 
     fn make_temp_dir(prefix: &str) -> PathBuf {
         let now = SystemTime::now()
@@ -2955,5 +2995,59 @@ mod tests {
             err.to_string().contains("Invalid filter"),
             "unexpected error: {err}"
         );
+    }
+
+    #[test]
+    fn eval_args_from_env_populates_supported_fields() {
+        let _guard = env_test_lock()
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        let keys = [
+            "BT_EVAL_JSONL",
+            "BT_EVAL_TERMINATE_ON_FAILURE",
+            "BT_EVAL_NUM_WORKERS",
+            "BT_EVAL_LIST",
+            "BT_EVAL_FILTER",
+            "BT_EVAL_WATCH",
+            "BT_EVAL_DEV",
+            "BT_EVAL_DEV_HOST",
+            "BT_EVAL_DEV_PORT",
+            "BT_EVAL_DEV_ORG_NAME",
+        ];
+        let previous: Vec<(&str, Option<String>)> =
+            keys.iter().map(|key| (*key, clear_env_var(key))).collect();
+        set_env_var("BT_EVAL_JSONL", "true");
+        set_env_var("BT_EVAL_TERMINATE_ON_FAILURE", "1");
+        set_env_var("BT_EVAL_NUM_WORKERS", "4");
+        set_env_var("BT_EVAL_LIST", "yes");
+        set_env_var("BT_EVAL_FILTER", "metadata.case=smoke.*,metadata.kind=fast");
+        set_env_var("BT_EVAL_WATCH", "on");
+        set_env_var("BT_EVAL_DEV", "true");
+        set_env_var("BT_EVAL_DEV_HOST", "127.0.0.1");
+        set_env_var("BT_EVAL_DEV_PORT", "9999");
+        set_env_var("BT_EVAL_DEV_ORG_NAME", "acme");
+
+        let parsed = EvalArgsHarness::try_parse_from(["bt", "sample.eval.ts"])
+            .expect("env vars should parse into eval args");
+        assert!(parsed.eval.jsonl);
+        assert!(parsed.eval.terminate_on_failure);
+        assert_eq!(parsed.eval.num_workers, Some(4));
+        assert!(parsed.eval.list);
+        assert_eq!(
+            parsed.eval.filter,
+            vec![
+                "metadata.case=smoke.*".to_string(),
+                "metadata.kind=fast".to_string()
+            ]
+        );
+        assert!(parsed.eval.watch);
+        assert!(parsed.eval.dev);
+        assert_eq!(parsed.eval.dev_host, "127.0.0.1");
+        assert_eq!(parsed.eval.dev_port, 9999);
+        assert_eq!(parsed.eval.dev_org_name, Some("acme".to_string()));
+
+        for (key, value) in previous {
+            restore_env_var(key, value);
+        }
     }
 }


### PR DESCRIPTION
## Summary
- add `#[arg(env = ...)]` bindings for `bt eval` flags that were previously CLI-only
- use boolish env parsing for boolean flags to match existing CLI behavior
- add a dedicated unit test that verifies env-variable parsing into `EvalArgs`

## Changes
- `--jsonl` <-> `BT_EVAL_JSONL`
- `--terminate-on-failure` <-> `BT_EVAL_TERMINATE_ON_FAILURE`
- `--num-workers` <-> `BT_EVAL_NUM_WORKERS`
- `--list` <-> `BT_EVAL_LIST`
- `--filter` <-> `BT_EVAL_FILTER` (comma-delimited)
- `--watch` <-> `BT_EVAL_WATCH`
- `--dev` <-> `BT_EVAL_DEV`
- `--dev-host` <-> `BT_EVAL_DEV_HOST`
- `--dev-port` <-> `BT_EVAL_DEV_PORT`
- `--dev-org-name` <-> `BT_EVAL_DEV_ORG_NAME`

## Tests Run
- `cargo fmt --all`
- `CARGO_HOME=/tmp/bt-cargo-home cargo test eval::tests:: -- --nocapture`

### Test Results
- eval unit tests: `20 passed, 0 failed`
- filtered integration tests in `tests/eval_fixtures.rs`: `0 run, 0 failed` (6 filtered by test selection)

## Notes
- build produced one pre-existing warning unrelated to this change: `ApiClient::with_org_name` is currently unused.
