### PR TITLE
emit progress events from the python dev server

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,6 +61,8 @@ targets = [
   "x86_64-apple-darwin",
   "aarch64-unknown-linux-gnu",
   "x86_64-unknown-linux-gnu",
+  "aarch64-unknown-linux-musl",
+  "x86_64-unknown-linux-musl",
   "x86_64-pc-windows-msvc",
 ]
 unix-archive = ".tar.gz"

--- a/scripts/eval-runner.py
+++ b/scripts/eval-runner.py
@@ -23,9 +23,10 @@ try:
         run_evaluator,
         set_thread_pool_max_workers,
     )
-    from braintrust.logger import Dataset, init as init_logger_experiment
+    from braintrust.logger import Dataset, init as init_logger_experiment, parent_context, _internal_get_global_state
     from braintrust.parameters import parameters_to_json_schema, validate_parameters
     from braintrust.util import eprint
+    from braintrust.span_identifier_v4 import parse_parent
 except Exception as exc:  # pragma: no cover - runtime guard
     print(
         "Unable to import the braintrust package. Please install it in your Python environment.",
@@ -534,10 +535,12 @@ def send_experiment_start(
             sse.send(
                 "start",
                 {
-                    "project_name": getattr(summary, "project_name", None),
-                    "experiment_name": getattr(summary, "experiment_name", None),
-                    "project_url": getattr(summary, "project_url", None),
-                    "experiment_url": getattr(summary, "experiment_url", None),
+                    "projectName": getattr(summary, "project_name", None),
+                    "experimentName": getattr(summary, "experiment_name", None),
+                    "projectId": getattr(summary, "project_id", None),
+                    "experimentId": getattr(summary, "experiment_id", None),
+                    "projectUrl": getattr(summary, "project_url", None),
+                    "experimentUrl": getattr(summary, "experiment_url", None),
                 },
             )
             return
@@ -548,14 +551,12 @@ def send_experiment_start(
         evaluator, "eval_name", None
     )
     if experiment_name:
-        sse.send("start", {"experiment_name": experiment_name})
+        sse.send("start", {"experimentName": experiment_name})
 
 
 def run_evaluator_progress_mode() -> str:
     try:
-        from inspect import signature
-
-        parameters = signature(run_evaluator).parameters
+        parameters = inspect.signature(run_evaluator).parameters
         if "progress" in parameters:
             return "progress"
         if "stream" in parameters:
@@ -621,8 +622,14 @@ def infer_evaluator_total(evaluator: Any) -> int | None:
     return data_total * trial_count
 
 
-def wrap_task_with_progress(task: Any, progress_cb: Callable[[str, int | None], None] | None) -> Any:
-    if not callable(task) or progress_cb is None:
+def wrap_task(
+    task: Any,
+    progress_cb: Callable[[str, int | None], None] | None = None,
+    stream_results: bool = False,
+) -> Any:
+    if not callable(task):
+        return task
+    if progress_cb is None and not stream_results:
         return task
 
     task_signature = None
@@ -631,17 +638,32 @@ def wrap_task_with_progress(task: Any, progress_cb: Callable[[str, int | None], 
     except Exception:
         task_signature = None
 
-    async def wrapped_task(*args: Any, **kwargs: Any) -> Any:
+    takes_hooks = task_signature is not None and len(task_signature.parameters) >= 2
+
+    async def wrapped_task(input, hooks):
+        result = None
         try:
-            result = task(*args, **kwargs)
+            if takes_hooks:
+                result = task(input, hooks)
+            else:
+                result = task(input)
             if inspect.isawaitable(result):
-                return await result
+                result = await result
             return result
         finally:
-            progress_cb("increment", None)
+            if progress_cb is not None:
+                progress_cb("increment", None)
+            if stream_results and result is not None:
+                try:
+                    hooks.report_progress({
+                        "format": "code",
+                        "output_type": "completion",
+                        "event": "json_delta",
+                        "data": json.dumps(result),
+                    })
+                except Exception:
+                    pass
 
-    if task_signature is not None:
-        setattr(wrapped_task, "__signature__", task_signature)
     if hasattr(task, "__name__"):
         setattr(wrapped_task, "__name__", getattr(task, "__name__"))
     if hasattr(task, "__qualname__"):
@@ -650,37 +672,62 @@ def wrap_task_with_progress(task: Any, progress_cb: Callable[[str, int | None], 
     return wrapped_task
 
 
+def run_evaluator_supports_stream() -> bool:
+    try:
+        return "stream" in inspect.signature(run_evaluator).parameters
+    except Exception:
+        return False
+
+
 async def run_evaluator_task(
-    evaluator, position: int, no_send_logs: bool, progress_cb, progress_mode: str, sse: SseWriter | None
+    evaluator, position: int, no_send_logs: bool, progress_cb, progress_mode: str, sse: SseWriter | None,
+    parent: str | None = None,
 ):
     experiment = None
-    if not no_send_logs:
+    if not no_send_logs and parent is None:
         experiment = _init_experiment_for_eval(evaluator)
     send_experiment_start(sse, evaluator, experiment)
 
     fallback_progress = progress_cb is not None and progress_mode != "progress"
-    original_task = None
+    original_task = evaluator.task
+    supports_stream = run_evaluator_supports_stream()
+
     if fallback_progress:
         progress_cb("start", infer_evaluator_total(evaluator))
-        original_task = getattr(evaluator, "task", None)
-        if original_task is not None:
-            evaluator.task = wrap_task_with_progress(original_task, progress_cb)
+
+    evaluator.task = wrap_task(
+        original_task,
+        progress_cb=progress_cb if fallback_progress else None,
+        stream_results=bool(sse and supports_stream),
+    )
 
     try:
         kwargs = {}
         if progress_cb and progress_mode == "progress":
             kwargs["progress"] = progress_cb
-        return await run_evaluator(
-            experiment,
-            evaluator,
-            None,
-            [],
-            **kwargs,
-        )
+        if sse and supports_stream:
+            kwargs["stream"] = lambda event: sse.send("progress", event if isinstance(event, dict) else event.__dict__)
+
+        if parent:
+            with parent_context(parent):
+                return await run_evaluator(
+                    experiment,
+                    evaluator,
+                    None,
+                    [],
+                    **kwargs,
+                )
+        else:
+            return await run_evaluator(
+                experiment,
+                evaluator,
+                None,
+                [],
+                **kwargs,
+            )
     finally:
+        evaluator.task = original_task
         if fallback_progress:
-            if original_task is not None:
-                evaluator.task = original_task
             progress_cb("stop", None)
         if experiment:
             experiment.flush()
@@ -717,15 +764,17 @@ async def run_requested_eval(
         if "project_id" in request:
             evaluator.project_id = request["project_id"]
 
+        request_parameters = request.get("parameters")
         if evaluator.parameters is not None:
-            request_parameters = request.get("parameters", {})
+            if request_parameters is None:
+                request_parameters = {}
             if not isinstance(request_parameters, dict):
                 raise ValueError("parameters must be an object")
             evaluator.parameters = validate_parameters(request_parameters, evaluator.parameters)
-        elif "parameters" in request:
-            if not isinstance(request["parameters"], dict):
+        elif request_parameters is not None:
+            if not isinstance(request_parameters, dict):
                 raise ValueError("parameters must be an object")
-            evaluator.parameters = request["parameters"]
+            evaluator.parameters = request_parameters
 
         if "scores" in request and request["scores"]:
             scorer_functions = [
@@ -751,6 +800,10 @@ async def run_requested_eval(
     progress_mode = run_evaluator_progress_mode()
     progress_cb = create_progress_reporter(sse, evaluator.eval_name)
 
+    parent = request.get("parent")
+    if parent is not None:
+        parent = parse_parent(parent)
+
     try:
         result = await run_evaluator_task(
             evaluator,
@@ -759,6 +812,7 @@ async def run_requested_eval(
             progress_cb,
             progress_mode,
             sse,
+            parent=parent,
         )
     except Exception as exc:
         message = str(exc)
@@ -918,6 +972,15 @@ def main(argv: list[str] | None = None) -> int:
     cwd = os.path.abspath(os.getcwd())
     try:
         success = asyncio.run(run_once(files, local, sse, config))
+
+        if not local:
+            try:
+                state = _internal_get_global_state()
+                if state:
+                    state.flush()
+            except Exception:
+                pass
+
         if sse:
             sse.send("dependencies", {"files": collect_dependency_files(cwd, files)})
             sse.send("done", {"success": success})

--- a/src/eval.rs
+++ b/src/eval.rs
@@ -1485,13 +1485,26 @@ async fn dev_server_eval(
         let (tx, rx) = mpsc::unbounded_channel::<String>();
         tokio::spawn(async move {
             let mut saw_error = false;
-            let mut saw_done = false;
+            let mut stderr_lines: Vec<String> = Vec::new();
             let output = drive_eval_runner(spawned.process, ConsolePolicy::Forward, |event| {
                 if matches!(event, EvalEvent::Error { .. }) {
                     saw_error = true;
                 }
                 if matches!(event, EvalEvent::Done) {
-                    saw_done = true;
+                    return;
+                }
+                if let EvalEvent::Console {
+                    ref stream,
+                    ref message,
+                } = event
+                {
+                    for line in message.lines() {
+                        let _ = tx.send(format!(": [{stream}] {line}\n"));
+                    }
+                    if stream == "stderr" {
+                        stderr_lines.push(message.clone());
+                    }
+                    return;
                 }
                 if let Some(encoded) = encode_eval_event_for_http(&event) {
                     let _ = tx.send(encoded);
@@ -1502,10 +1515,13 @@ async fn dev_server_eval(
             match output {
                 Ok(output) => {
                     if !output.status.success() && !saw_error {
-                        let error = serialize_sse_event(
-                            "error",
-                            &json!({ "message": "Eval runner exited with an error." }).to_string(),
-                        );
+                        let mut detail = format!("Eval runner exited with {}.", output.status);
+                        for line in stderr_lines.iter() {
+                            detail.push('\n');
+                            detail.push_str(line);
+                        }
+                        let error =
+                            serialize_sse_event("error", &json!({ "message": detail }).to_string());
                         let _ = tx.send(error);
                     }
                 }
@@ -1518,9 +1534,7 @@ async fn dev_server_eval(
                 }
             }
 
-            if !saw_done {
-                let _ = tx.send(serialize_sse_event("done", ""));
-            }
+            let _ = tx.send(serialize_sse_event("done", ""));
         });
 
         let response_stream = stream::unfold(rx, |mut rx| async {
@@ -2486,6 +2500,10 @@ struct ExperimentStart {
     project_name: Option<String>,
     #[serde(default, alias = "experiment_name")]
     experiment_name: Option<String>,
+    #[serde(default, alias = "project_id")]
+    project_id: Option<String>,
+    #[serde(default, alias = "experiment_id")]
+    experiment_id: Option<String>,
     #[serde(default, alias = "project_url")]
     project_url: Option<String>,
     #[serde(default, alias = "experiment_url")]

--- a/src/setup/mod.rs
+++ b/src/setup/mod.rs
@@ -2364,7 +2364,10 @@ fn scope_root<'a>(
 }
 
 fn find_git_root() -> Option<PathBuf> {
-    let mut current = std::env::current_dir().ok()?;
+    find_git_root_from(std::env::current_dir().ok()?)
+}
+
+fn find_git_root_from(mut current: PathBuf) -> Option<PathBuf> {
     loop {
         if current.join(".git").exists() {
             return Some(current);
@@ -2604,13 +2607,7 @@ mod tests {
         fs::create_dir_all(&nested).expect("create nested");
         fs::write(root.join(".git"), "gitdir: /tmp/fake").expect("write git file");
 
-        let old = std::env::current_dir().expect("cwd");
-        std::env::set_current_dir(&nested).expect("cd nested");
-        let detected = find_git_root();
-        std::env::set_current_dir(old).expect("restore cwd");
-
-        let detected = detected
-            .as_deref()
+        let detected = find_git_root_from(nested)
             .and_then(|p| p.canonicalize().ok())
             .expect("canonical detected path");
         let expected = root.canonicalize().expect("canonical expected path");

--- a/tests/eval_dev_server.rs
+++ b/tests/eval_dev_server.rs
@@ -1,0 +1,911 @@
+use std::io::{BufRead, BufReader, Read, Write};
+use std::net::TcpListener;
+use std::path::{Path, PathBuf};
+use std::process::{Child, Command, Stdio};
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::{Arc, Mutex};
+use std::thread;
+use std::time::{Duration, Instant};
+
+/// Parsed SSE event from the streaming response.
+#[derive(Debug)]
+struct SseEvent {
+    event: String,
+    data: String,
+}
+
+/// Start a minimal HTTP server that always responds with a valid Braintrust
+/// login payload so that the dev server's `authenticate_dev_request` succeeds.
+fn start_mock_auth_server() -> (u16, thread::JoinHandle<()>) {
+    let listener = TcpListener::bind("127.0.0.1:0").expect("bind mock auth server");
+    let port = listener.local_addr().unwrap().port();
+    listener
+        .set_nonblocking(false)
+        .expect("set mock listener blocking");
+
+    let handle = thread::spawn(move || {
+        let response_body = r#"{"org_info": [{"name": "test-org"}]}"#;
+        let http_response = format!(
+            "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
+            response_body.len(),
+            response_body,
+        );
+        for stream in listener.incoming() {
+            let mut stream = match stream {
+                Ok(s) => s,
+                Err(_) => break,
+            };
+            let _ = stream.set_read_timeout(Some(Duration::from_secs(5)));
+            let mut buf = [0u8; 4096];
+            let _ = stream.read(&mut buf);
+            let _ = stream.write_all(http_response.as_bytes());
+            let _ = stream.flush();
+        }
+    });
+
+    (port, handle)
+}
+
+/// Mock API server that handles auth, experiment registration, and log ingestion.
+/// Counts the number of log rows received via the `/logs3` endpoint so that
+/// tests can verify all SDK log events were flushed before a given point.
+fn start_mock_api_server() -> (u16, Arc<AtomicUsize>, thread::JoinHandle<()>) {
+    let listener = TcpListener::bind("127.0.0.1:0").expect("bind mock api server");
+    let port = listener.local_addr().unwrap().port();
+    listener
+        .set_nonblocking(false)
+        .expect("set mock api listener blocking");
+
+    let log_row_count = Arc::new(AtomicUsize::new(0));
+    let count_clone = Arc::clone(&log_row_count);
+
+    let handle = thread::spawn(move || {
+        for stream in listener.incoming() {
+            let mut stream = match stream {
+                Ok(s) => s,
+                Err(_) => break,
+            };
+            let _ = stream.set_read_timeout(Some(Duration::from_secs(5)));
+            let mut buf = vec![0u8; 262144];
+            let n = match stream.read(&mut buf) {
+                Ok(n) => n,
+                Err(_) => continue,
+            };
+            let request = String::from_utf8_lossy(&buf[..n]).to_string();
+
+            // Extract first line to determine the method + path.
+            let first_line = request.lines().next().unwrap_or("");
+            let body = request
+                .find("\r\n\r\n")
+                .map(|pos| &request[pos + 4..])
+                .unwrap_or("");
+
+            let response_body = if first_line.contains("/logs3") {
+                if let Ok(parsed) = serde_json::from_str::<serde_json::Value>(body) {
+                    if let Some(arr) = parsed.get("rows").and_then(|r| r.as_array()) {
+                        count_clone.fetch_add(arr.len(), Ordering::SeqCst);
+                    }
+                }
+                r#"{}"#.to_string()
+            } else if first_line.contains("/apikey") || first_line.contains("/login") {
+                format!(
+                    r#"{{"org_info": [{{"name": "test-org", "id": "org-test", "api_url": "http://127.0.0.1:{port}", "proxy_url": "http://127.0.0.1:{port}"}}]}}"#
+                )
+            } else if first_line.contains("/experiment/register") {
+                r#"{"project": {"id": "proj-test", "name": "test"}, "experiment": {"id": "exp-test", "name": "test"}}"#.to_string()
+            } else {
+                r#"{}"#.to_string()
+            };
+
+            let http_response = format!(
+                "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
+                response_body.len(),
+                response_body,
+            );
+            let _ = stream.write_all(http_response.as_bytes());
+            let _ = stream.flush();
+        }
+    });
+
+    (port, log_row_count, handle)
+}
+
+/// Find an available TCP port.
+fn free_port() -> u16 {
+    let listener = TcpListener::bind("127.0.0.1:0").expect("bind for free port");
+    listener.local_addr().unwrap().port()
+}
+
+/// Parse SSE events from a text body (after stripping HTTP chunked encoding).
+fn parse_sse_events(body: &str) -> Vec<SseEvent> {
+    let mut events = Vec::new();
+    let mut current_event = String::new();
+    let mut current_data = Vec::<String>::new();
+
+    for line in body.lines() {
+        if line.starts_with("event: ") {
+            current_event = line["event: ".len()..].to_string();
+        } else if line.starts_with("data: ") {
+            current_data.push(line["data: ".len()..].to_string());
+        } else if line.is_empty() && !current_event.is_empty() {
+            events.push(SseEvent {
+                event: std::mem::take(&mut current_event),
+                data: current_data.join("\n"),
+            });
+            current_data.clear();
+        }
+    }
+
+    // Trailing event without a blank line terminator.
+    if !current_event.is_empty() {
+        events.push(SseEvent {
+            event: current_event,
+            data: current_data.join("\n"),
+        });
+    }
+
+    events
+}
+
+fn spawn_output_collector<R: Read + Send + 'static>(
+    reader: R,
+    output: Arc<Mutex<String>>,
+) -> thread::JoinHandle<()> {
+    thread::spawn(move || {
+        let mut buffered = BufReader::new(reader);
+        let mut line = String::new();
+        loop {
+            line.clear();
+            match buffered.read_line(&mut line) {
+                Ok(0) => break,
+                Ok(_) => {
+                    let mut guard = output.lock().expect("output lock");
+                    guard.push_str(&line);
+                }
+                Err(_) => break,
+            }
+        }
+    })
+}
+
+fn wait_for_output(
+    child: &mut Child,
+    output: &Arc<Mutex<String>>,
+    needle: &str,
+    timeout: Duration,
+) {
+    let started = Instant::now();
+    loop {
+        if output.lock().expect("lock").contains(needle) {
+            return;
+        }
+        if let Some(status) = child.try_wait().expect("try_wait") {
+            let captured = output.lock().expect("lock").clone();
+            panic!(
+                "process exited early with status {status} while waiting for '{needle}'.\n{captured}"
+            );
+        }
+        if started.elapsed() > timeout {
+            let captured = output.lock().expect("lock").clone();
+            panic!("timed out waiting for '{needle}'.\n{captured}");
+        }
+        thread::sleep(Duration::from_millis(100));
+    }
+}
+
+/// Use curl to make an HTTP request and return the response body.
+/// This handles chunked transfer encoding and other HTTP details.
+fn curl_get(url: &str, headers: &[(&str, &str)]) -> String {
+    let mut cmd = Command::new("curl");
+    cmd.args(["-s", "--max-time", "60", url]);
+    for (key, value) in headers {
+        cmd.arg("-H").arg(format!("{key}: {value}"));
+    }
+    let output = cmd.output().expect("run curl");
+    assert!(
+        output.status.success(),
+        "curl GET {url} failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    String::from_utf8_lossy(&output.stdout).to_string()
+}
+
+fn curl_post(url: &str, headers: &[(&str, &str)], body: &str) -> String {
+    let mut cmd = Command::new("curl");
+    cmd.args(["-s", "--max-time", "60", "-X", "POST", "-d", body, url]);
+    for (key, value) in headers {
+        cmd.arg("-H").arg(format!("{key}: {value}"));
+    }
+    let output = cmd.output().expect("run curl");
+    assert!(
+        output.status.success(),
+        "curl POST {url} failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    String::from_utf8_lossy(&output.stdout).to_string()
+}
+
+fn ensure_python_env(fixtures_py_root: &std::path::Path) -> Option<PathBuf> {
+    if !command_exists("uv") {
+        return None;
+    }
+    let venv_dir = fixtures_py_root.join(".venv");
+    let python = venv_python_path(&venv_dir);
+    if !python.is_file() {
+        let status = Command::new("uv")
+            .args(["venv", venv_dir.to_string_lossy().as_ref()])
+            .status()
+            .ok()?;
+        if !status.success() {
+            return None;
+        }
+    }
+    if !python_can_import("braintrust", python.to_string_lossy().as_ref()) {
+        let status = Command::new("uv")
+            .args([
+                "pip",
+                "install",
+                "--python",
+                python.to_string_lossy().as_ref(),
+                "braintrust",
+            ])
+            .status()
+            .ok()?;
+        if !status.success() {
+            return None;
+        }
+    }
+    Some(python)
+}
+
+fn venv_python_path(venv: &std::path::Path) -> PathBuf {
+    if cfg!(windows) {
+        venv.join("Scripts").join("python.exe")
+    } else {
+        venv.join("bin").join("python")
+    }
+}
+
+fn python_can_import(module: &str, python: &str) -> bool {
+    Command::new(python)
+        .args(["-c", &format!("import {module}")])
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .status()
+        .map(|s| s.success())
+        .unwrap_or(false)
+}
+
+fn command_exists(command: &str) -> bool {
+    std::env::var_os("PATH")
+        .map(|paths| std::env::split_paths(&paths).any(|dir| dir.join(command).is_file()))
+        .unwrap_or(false)
+}
+
+fn bt_binary_path(root: &std::path::Path) -> PathBuf {
+    match std::env::var("CARGO_BIN_EXE_bt") {
+        Ok(path) => PathBuf::from(path),
+        Err(_) => {
+            let candidate = root.join("target").join("debug").join("bt");
+            if !candidate.is_file() {
+                let status = Command::new("cargo")
+                    .args(["build", "--bin", "bt"])
+                    .current_dir(root)
+                    .status()
+                    .expect("cargo build");
+                assert!(status.success(), "cargo build --bin bt failed");
+            }
+            candidate
+        }
+    }
+}
+
+#[test]
+fn eval_dev_server_streams_python_events() {
+    let root = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    let fixtures_root = root.join("tests").join("evals");
+    let fixture_dir = fixtures_root.join("py").join("streaming");
+
+    if !fixture_dir.join("fixture.json").exists() {
+        eprintln!("Skipping eval_dev_server_streams_python_events (streaming fixture missing).");
+        return;
+    }
+
+    let python = match ensure_python_env(&fixtures_root.join("py")) {
+        Some(python) => python,
+        None => {
+            eprintln!("Skipping eval_dev_server_streams_python_events (python/uv not available).");
+            return;
+        }
+    };
+
+    let bt_path = bt_binary_path(&root);
+
+    // 1. Start mock auth server.
+    let (mock_auth_port, _mock_handle) = start_mock_auth_server();
+
+    // 2. Start bt eval --dev on the streaming fixture.
+    let dev_port = free_port();
+    let mut child = Command::new(&bt_path)
+        .args([
+            "eval",
+            "--dev",
+            "--dev-port",
+            &dev_port.to_string(),
+            "--no-send-logs",
+            "eval_streaming.py",
+        ])
+        .current_dir(&fixture_dir)
+        .env(
+            "BRAINTRUST_APP_URL",
+            format!("http://127.0.0.1:{mock_auth_port}"),
+        )
+        .env("BRAINTRUST_API_KEY", "test-key")
+        .env("BT_EVAL_PYTHON_RUNNER", &python)
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("spawn bt eval --dev");
+
+    let output = Arc::new(Mutex::new(String::new()));
+    let mut threads = Vec::new();
+    if let Some(stdout) = child.stdout.take() {
+        threads.push(spawn_output_collector(stdout, Arc::clone(&output)));
+    }
+    if let Some(stderr) = child.stderr.take() {
+        threads.push(spawn_output_collector(stderr, Arc::clone(&output)));
+    }
+
+    // Wait for the dev server to be ready.
+    wait_for_output(
+        &mut child,
+        &output,
+        "Starting eval dev server",
+        Duration::from_secs(60),
+    );
+    // Give the server a moment to bind the port.
+    thread::sleep(Duration::from_millis(500));
+
+    let base_url = format!("http://127.0.0.1:{dev_port}");
+    let auth_headers: Vec<(&str, &str)> = vec![
+        ("x-bt-auth-token", "test-key"),
+        ("x-bt-org-name", "test-org"),
+    ];
+
+    // 3. Health check.
+    let health = curl_get(&base_url, &[]);
+    assert!(
+        health.contains("Hello"),
+        "health check should return greeting, got: {health}"
+    );
+
+    // 4. List evaluators.
+    let list_body = curl_get(&format!("{base_url}/list"), &auth_headers);
+    let list_json: serde_json::Value =
+        serde_json::from_str(&list_body).expect("parse /list JSON response");
+    assert!(
+        list_json.get("cli-streaming").is_some(),
+        "/list should include 'cli-streaming' evaluator, got: {list_body}"
+    );
+
+    // 5. Streaming eval.
+    let eval_body = serde_json::json!({
+        "name": "cli-streaming",
+        "data": {
+            "data": [
+                {"input": "hello", "expected": "hello"},
+                {"input": "world", "expected": "world"}
+            ]
+        },
+        "stream": true
+    })
+    .to_string();
+
+    let mut post_headers = auth_headers.clone();
+    post_headers.push(("Content-Type", "application/json"));
+    let sse_response = curl_post(&format!("{base_url}/eval"), &post_headers, &eval_body);
+
+    let events = parse_sse_events(&sse_response);
+
+    // Collect event names.
+    let event_names: Vec<&str> = events.iter().map(|e| e.event.as_str()).collect();
+
+    // Should have one progress event per data row.
+    let progress_events: Vec<&SseEvent> = events.iter().filter(|e| e.event == "progress").collect();
+    assert_eq!(
+        progress_events.len(),
+        2,
+        "expected one progress event per data row (2), got {}: {event_names:?}\nfull response:\n{sse_response}",
+        progress_events.len()
+    );
+
+    // Each progress event should carry a json_delta payload.
+    for pe in &progress_events {
+        let parsed: serde_json::Value =
+            serde_json::from_str(&pe.data).expect("parse progress event data");
+        assert_eq!(
+            parsed.get("event").and_then(|v| v.as_str()),
+            Some("json_delta"),
+            "progress event should have event=json_delta, got: {}",
+            pe.data
+        );
+    }
+
+    // Should have exactly one summary event.
+    let summary_events: Vec<&SseEvent> = events.iter().filter(|e| e.event == "summary").collect();
+    assert_eq!(
+        summary_events.len(),
+        1,
+        "expected exactly one summary event, got events: {event_names:?}"
+    );
+
+    // Summary should contain scores.
+    let summary: serde_json::Value =
+        serde_json::from_str(&summary_events[0].data).expect("parse summary data");
+    assert!(
+        summary.get("scores").is_some(),
+        "summary should contain scores, got: {}",
+        summary_events[0].data
+    );
+
+    // Should have exactly one done event, and it should be last.
+    let done_events: Vec<&SseEvent> = events.iter().filter(|e| e.event == "done").collect();
+    assert_eq!(
+        done_events.len(),
+        1,
+        "expected exactly one done event, got events: {event_names:?}"
+    );
+    assert_eq!(
+        events.last().unwrap().event,
+        "done",
+        "done should be the last event, got events: {event_names:?}"
+    );
+
+    // Summary should come before done.
+    let summary_idx = events.iter().position(|e| e.event == "summary").unwrap();
+    let done_idx = events.iter().position(|e| e.event == "done").unwrap();
+    assert!(
+        summary_idx < done_idx,
+        "summary should come before done, got events: {event_names:?}"
+    );
+
+    // 6. Clean up.
+    let _ = child.kill();
+    let _ = child.wait();
+    for handle in threads {
+        let _ = handle.join();
+    }
+}
+
+struct StreamingEvalResult {
+    events: Vec<SseEvent>,
+    marker_existed_at_done: bool,
+    log_rows_at_done: usize,
+}
+
+fn streaming_eval_post(
+    base_url: &str,
+    body: &str,
+    marker_path: &Path,
+    log_row_count: &AtomicUsize,
+) -> StreamingEvalResult {
+    let mut curl = Command::new("curl")
+        .args(["-s", "-N", "--max-time", "120", "-X", "POST"])
+        .arg("-d")
+        .arg(body)
+        .arg("-H")
+        .arg("Content-Type: application/json")
+        .arg("-H")
+        .arg("x-bt-auth-token: test-key")
+        .arg("-H")
+        .arg("x-bt-org-name: test-org")
+        .arg(format!("{base_url}/eval"))
+        .stdout(Stdio::piped())
+        .spawn()
+        .expect("spawn streaming curl");
+
+    let stdout = curl.stdout.take().unwrap();
+    let reader = BufReader::new(stdout);
+
+    let mut events = Vec::new();
+    let mut current_event = String::new();
+    let mut current_data = Vec::<String>::new();
+    let mut marker_existed_at_done = false;
+    let mut log_rows_at_done = 0;
+
+    for line_result in reader.lines() {
+        let line = match line_result {
+            Ok(l) => l,
+            Err(_) => break,
+        };
+        if line.starts_with("event: ") {
+            current_event = line["event: ".len()..].to_string();
+        } else if line.starts_with("data: ") {
+            current_data.push(line["data: ".len()..].to_string());
+        } else if line.is_empty() && !current_event.is_empty() {
+            let event = SseEvent {
+                event: std::mem::take(&mut current_event),
+                data: current_data.join("\n"),
+            };
+            if event.event == "done" {
+                marker_existed_at_done = marker_path.exists();
+                log_rows_at_done = log_row_count.load(Ordering::SeqCst);
+            }
+            events.push(event);
+            current_data.clear();
+        }
+    }
+
+    let _ = curl.wait();
+
+    StreamingEvalResult {
+        events,
+        marker_existed_at_done,
+        log_rows_at_done,
+    }
+}
+
+/// Verify that the `done` SSE event is only delivered to the client after the
+/// eval-runner process has fully exited (including atexit handlers) and all SDK
+/// log events have been flushed to the API.
+///
+/// The eval fixture registers an atexit handler that sleeps 1 second then writes
+/// a marker file. A streaming HTTP client checks for the marker at the instant
+/// it receives the `done` event. Without the fix (deferring `done` until after
+/// process exit), the marker will not yet exist.
+#[test]
+fn eval_dev_server_done_deferred_until_process_exit() {
+    let root = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    let fixtures_root = root.join("tests").join("evals");
+    let fixture_dir = fixtures_root.join("py").join("atexit_flush");
+
+    if !fixture_dir.join("fixture.json").exists() {
+        eprintln!("Skipping (atexit_flush fixture missing).");
+        return;
+    }
+
+    let python = match ensure_python_env(&fixtures_root.join("py")) {
+        Some(python) => python,
+        None => {
+            eprintln!("Skipping (python/uv not available).");
+            return;
+        }
+    };
+
+    let bt_path = bt_binary_path(&root);
+    let (mock_api_port, log_row_count, _mock_handle) = start_mock_api_server();
+
+    let marker_dir = tempfile::tempdir().expect("create temp dir");
+    let marker_path = marker_dir.path().join("atexit_marker");
+
+    let dev_port = free_port();
+    let mut child = Command::new(&bt_path)
+        .args([
+            "eval",
+            "--dev",
+            "--dev-port",
+            &dev_port.to_string(),
+            "eval_atexit.py",
+        ])
+        .current_dir(&fixture_dir)
+        .env(
+            "BRAINTRUST_APP_URL",
+            format!("http://127.0.0.1:{mock_api_port}"),
+        )
+        .env("BRAINTRUST_API_KEY", "test-key")
+        .env("BT_EVAL_PYTHON_RUNNER", &python)
+        .env("ATEXIT_MARKER_FILE", marker_path.to_string_lossy().as_ref())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("spawn bt eval --dev");
+
+    let output = Arc::new(Mutex::new(String::new()));
+    let mut threads = Vec::new();
+    if let Some(stdout) = child.stdout.take() {
+        threads.push(spawn_output_collector(stdout, Arc::clone(&output)));
+    }
+    if let Some(stderr) = child.stderr.take() {
+        threads.push(spawn_output_collector(stderr, Arc::clone(&output)));
+    }
+
+    wait_for_output(
+        &mut child,
+        &output,
+        "Starting eval dev server",
+        Duration::from_secs(60),
+    );
+    thread::sleep(Duration::from_millis(500));
+
+    let base_url = format!("http://127.0.0.1:{dev_port}");
+
+    let eval_body = serde_json::json!({
+        "name": "cli-atexit-flush",
+        "data": {
+            "data": [
+                {"input": "hello", "expected": "hello"},
+                {"input": "world", "expected": "world"}
+            ]
+        },
+        "stream": true
+    })
+    .to_string();
+
+    let result = streaming_eval_post(&base_url, &eval_body, &marker_path, &log_row_count);
+
+    let event_names: Vec<&str> = result.events.iter().map(|e| e.event.as_str()).collect();
+
+    // The done event must only arrive after the process has fully exited,
+    // which means the atexit handler (with its 1s sleep) has completed.
+    assert!(
+        result.marker_existed_at_done,
+        "atexit marker should exist when done event arrives, proving done \
+         is deferred until after process exit. Events: {event_names:?}"
+    );
+
+    // All SDK log rows must have been flushed to the mock API before done.
+    let final_log_rows = log_row_count.load(Ordering::SeqCst);
+    assert!(
+        final_log_rows > 0,
+        "mock API should have received log rows, got 0"
+    );
+    assert_eq!(
+        result.log_rows_at_done, final_log_rows,
+        "all log rows should be flushed before done event: \
+         {} at done vs {} final",
+        result.log_rows_at_done, final_log_rows,
+    );
+
+    // Verify all expected SSE events are present.
+    assert!(
+        result.events.iter().any(|e| e.event == "summary"),
+        "expected at least one summary event, got: {event_names:?}"
+    );
+    assert_eq!(
+        result.events.last().map(|e| e.event.as_str()),
+        Some("done"),
+        "done should be the last event, got: {event_names:?}"
+    );
+    assert_eq!(
+        result.events.iter().filter(|e| e.event == "done").count(),
+        1,
+        "expected exactly one done event, got: {event_names:?}"
+    );
+
+    let _ = child.kill();
+    let _ = child.wait();
+    for handle in threads {
+        let _ = handle.join();
+    }
+}
+
+/// Verify that when a `parent` is included in the eval request, the eval
+/// completes successfully and no error events are emitted. With --no-send-logs
+/// we avoid needing a mock API server; the important thing is that the parent
+/// reaches the SDK's parent_context() without crashing.
+#[test]
+fn eval_dev_server_parent_accepted() {
+    let root = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    let fixtures_root = root.join("tests").join("evals");
+    let fixture_dir = fixtures_root.join("py").join("streaming");
+
+    if !fixture_dir.join("fixture.json").exists() {
+        eprintln!("Skipping eval_dev_server_parent_accepted (fixture missing).");
+        return;
+    }
+
+    let python = match ensure_python_env(&fixtures_root.join("py")) {
+        Some(python) => python,
+        None => {
+            eprintln!("Skipping eval_dev_server_parent_accepted (python/uv not available).");
+            return;
+        }
+    };
+
+    let bt_path = bt_binary_path(&root);
+    let (mock_auth_port, _mock_handle) = start_mock_auth_server();
+
+    let dev_port = free_port();
+    let mut child = Command::new(&bt_path)
+        .args([
+            "eval",
+            "--dev",
+            "--dev-port",
+            &dev_port.to_string(),
+            "--no-send-logs",
+            "eval_streaming.py",
+        ])
+        .current_dir(&fixture_dir)
+        .env(
+            "BRAINTRUST_APP_URL",
+            format!("http://127.0.0.1:{mock_auth_port}"),
+        )
+        .env("BRAINTRUST_API_KEY", "test-key")
+        .env("BT_EVAL_PYTHON_RUNNER", &python)
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("spawn bt eval --dev");
+
+    let output = Arc::new(Mutex::new(String::new()));
+    let mut threads = Vec::new();
+    if let Some(stdout) = child.stdout.take() {
+        threads.push(spawn_output_collector(stdout, Arc::clone(&output)));
+    }
+    if let Some(stderr) = child.stderr.take() {
+        threads.push(spawn_output_collector(stderr, Arc::clone(&output)));
+    }
+
+    wait_for_output(
+        &mut child,
+        &output,
+        "Starting eval dev server",
+        Duration::from_secs(60),
+    );
+    thread::sleep(Duration::from_millis(500));
+
+    let base_url = format!("http://127.0.0.1:{dev_port}");
+
+    // SpanComponentsV3: object_type=PLAYGROUND_LOGS, object_id=00000000-...-000042
+    let parent_str = "AwMBAQAAAAAAAAAAAAAAAAAAAEI=";
+
+    let eval_body = serde_json::json!({
+        "name": "cli-streaming",
+        "data": {
+            "data": [
+                {"input": "hello", "expected": "hello"},
+                {"input": "world", "expected": "world"}
+            ]
+        },
+        "parent": parent_str,
+        "stream": true
+    })
+    .to_string();
+
+    let post_headers = vec![
+        ("x-bt-auth-token", "test-key"),
+        ("x-bt-org-name", "test-org"),
+        ("Content-Type", "application/json"),
+    ];
+    let sse_response = curl_post(&format!("{base_url}/eval"), &post_headers, &eval_body);
+    let events = parse_sse_events(&sse_response);
+    let event_names: Vec<&str> = events.iter().map(|e| e.event.as_str()).collect();
+
+    assert!(
+        !events.iter().any(|e| e.event == "error"),
+        "expected no error events when parent is provided, got: {event_names:?}"
+    );
+    assert!(
+        events.iter().any(|e| e.event == "summary"),
+        "expected a summary event, got: {event_names:?}"
+    );
+    assert_eq!(
+        events.last().map(|e| e.event.as_str()),
+        Some("done"),
+        "expected done as last event, got: {event_names:?}"
+    );
+
+    let _ = child.kill();
+    let _ = child.wait();
+    for handle in threads {
+        let _ = handle.join();
+    }
+}
+
+/// Verify that when `parent` is provided as a dict (the format the playground
+/// sends), the eval runner correctly parses it via `parse_parent` and completes
+/// successfully. Previously, non-string parents were silently discarded.
+#[test]
+fn eval_dev_server_parent_dict_accepted() {
+    let root = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    let fixtures_root = root.join("tests").join("evals");
+    let fixture_dir = fixtures_root.join("py").join("streaming");
+
+    if !fixture_dir.join("fixture.json").exists() {
+        eprintln!("Skipping eval_dev_server_parent_dict_accepted (fixture missing).");
+        return;
+    }
+
+    let python = match ensure_python_env(&fixtures_root.join("py")) {
+        Some(python) => python,
+        None => {
+            eprintln!("Skipping eval_dev_server_parent_dict_accepted (python/uv not available).");
+            return;
+        }
+    };
+
+    let bt_path = bt_binary_path(&root);
+    let (mock_auth_port, _mock_handle) = start_mock_auth_server();
+
+    let dev_port = free_port();
+    let mut child = Command::new(&bt_path)
+        .args([
+            "eval",
+            "--dev",
+            "--dev-port",
+            &dev_port.to_string(),
+            "--no-send-logs",
+            "eval_streaming.py",
+        ])
+        .current_dir(&fixture_dir)
+        .env(
+            "BRAINTRUST_APP_URL",
+            format!("http://127.0.0.1:{mock_auth_port}"),
+        )
+        .env("BRAINTRUST_API_KEY", "test-key")
+        .env("BT_EVAL_PYTHON_RUNNER", &python)
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("spawn bt eval --dev");
+
+    let output = Arc::new(Mutex::new(String::new()));
+    let mut threads = Vec::new();
+    if let Some(stdout) = child.stdout.take() {
+        threads.push(spawn_output_collector(stdout, Arc::clone(&output)));
+    }
+    if let Some(stderr) = child.stderr.take() {
+        threads.push(spawn_output_collector(stderr, Arc::clone(&output)));
+    }
+
+    wait_for_output(
+        &mut child,
+        &output,
+        "Starting eval dev server",
+        Duration::from_secs(60),
+    );
+    thread::sleep(Duration::from_millis(500));
+
+    let base_url = format!("http://127.0.0.1:{dev_port}");
+
+    // Send parent as a dict — this is the format the playground actually uses.
+    let eval_body = serde_json::json!({
+        "name": "cli-streaming",
+        "data": {
+            "data": [
+                {"input": "hello", "expected": "hello"},
+                {"input": "world", "expected": "world"}
+            ]
+        },
+        "parent": {
+            "object_type": "playground_logs",
+            "object_id": "00000000-0000-0000-0000-000000000042",
+            "row_ids": {
+                "id": "00000000-0000-0000-0000-000000000001",
+                "span_id": "00000000-0000-0000-0000-000000000002",
+                "root_span_id": "00000000-0000-0000-0000-000000000003"
+            }
+        },
+        "stream": true
+    })
+    .to_string();
+
+    let post_headers = vec![
+        ("x-bt-auth-token", "test-key"),
+        ("x-bt-org-name", "test-org"),
+        ("Content-Type", "application/json"),
+    ];
+    let sse_response = curl_post(&format!("{base_url}/eval"), &post_headers, &eval_body);
+    let events = parse_sse_events(&sse_response);
+    let event_names: Vec<&str> = events.iter().map(|e| e.event.as_str()).collect();
+
+    assert!(
+        !events.iter().any(|e| e.event == "error"),
+        "expected no error events when dict parent is provided, got: {event_names:?}"
+    );
+    assert!(
+        events.iter().any(|e| e.event == "summary"),
+        "expected a summary event, got: {event_names:?}"
+    );
+    assert_eq!(
+        events.last().map(|e| e.event.as_str()),
+        Some("done"),
+        "expected done as last event, got: {event_names:?}"
+    );
+
+    let _ = child.kill();
+    let _ = child.wait();
+    for handle in threads {
+        let _ = handle.join();
+    }
+}

--- a/tests/evals/py/atexit_flush/eval_atexit.py
+++ b/tests/evals/py/atexit_flush/eval_atexit.py
@@ -1,0 +1,42 @@
+import asyncio
+import atexit
+import os
+import time
+
+from braintrust import Eval
+
+MARKER_FILE = os.environ.get("ATEXIT_MARKER_FILE", "")
+
+
+def _write_marker():
+    if MARKER_FILE:
+        time.sleep(1)
+        with open(MARKER_FILE, "w") as f:
+            f.write("exited")
+
+
+atexit.register(_write_marker)
+
+
+def data():
+    return [
+        {"input": "hello", "expected": "hello"},
+        {"input": "world", "expected": "world"},
+    ]
+
+
+async def task(value, hooks):
+    await asyncio.sleep(0.01)
+    return value
+
+
+def exact_match(output, expected):
+    return int(output == expected)
+
+
+Eval(
+    "cli-atexit-flush",
+    data=data,
+    task=task,
+    scores=[exact_match],
+)

--- a/tests/evals/py/atexit_flush/fixture.json
+++ b/tests/evals/py/atexit_flush/fixture.json
@@ -1,0 +1,1 @@
+{ "runtime": "python", "files": ["eval_atexit.py"] }

--- a/tests/evals/py/streaming/eval_streaming.py
+++ b/tests/evals/py/streaming/eval_streaming.py
@@ -1,0 +1,27 @@
+import asyncio
+
+from braintrust import Eval
+
+
+def data():
+    return [
+        {"input": "hello", "expected": "hello"},
+        {"input": "world", "expected": "world"},
+    ]
+
+
+async def task(value, hooks):
+    await asyncio.sleep(0.01)
+    return value
+
+
+def exact_match(output, expected):
+    return int(output == expected)
+
+
+Eval(
+    "cli-streaming",
+    data=data,
+    task=task,
+    scores=[exact_match],
+)

--- a/tests/evals/py/streaming/fixture.json
+++ b/tests/evals/py/streaming/fixture.json
@@ -1,0 +1,1 @@
+{ "runtime": "python", "files": ["eval_streaming.py"] }


### PR DESCRIPTION
## Summary        
  - Streaming eval results: Users watching eval runs in the dev server UI had no visibility into progress until the entire run completed. Now individual task results stream back in real-time.
  - Parent context support: Eval runs triggered from the app need their spans nested under the parent trace, so the dev server now accepts and propagates a parent span identifier.
  - Improved error reporting: When the eval runner crashed, the dev server returned a generic "exited with an error" message, making debugging difficult. Now stderr output is included.
  - Global state flush: The Python SDK sometimes dropped log events on process exit because the background flush hadn't completed. An explicit flush ensures all data reaches the API before the process terminates.
  - Musl build targets: Added x86_64-unknown-linux-musl and aarch64-unknown-linux-musl so the CLI can run on any Linux environment (e.g. Lambda, minimal containers) without glibc version dependencies.
  - SSE field naming: Aligned start event fields with the camelCase convention used by the rest of the API.
