### PR TITLE
Replace bt login references with bt auth

### DIFF
--- a/skills/shared/braintrust-cli-body.md
+++ b/skills/shared/braintrust-cli-body.md
@@ -9,7 +9,7 @@ Use the Braintrust `bt` CLI for projects, traces, prompts, and sync workflows.
 ## How To Use
 
 1. Confirm auth and context:
-   - `bt login status`
+   - `bt status`
    - `bt projects list`
 2. Run the smallest command that answers the question:
    - `bt prompts list --project <name>`
@@ -21,4 +21,4 @@ Use the Braintrust `bt` CLI for projects, traces, prompts, and sync workflows.
 ## Guardrails
 
 - Prefer `bt` commands over direct API calls when both can accomplish the task.
-- Respect existing login/profile settings from `bt login`.
+- Respect existing login/profile settings from `bt auth`.

--- a/src/setup/mod.rs
+++ b/src/setup/mod.rs
@@ -24,7 +24,7 @@ const CURSOR_RULE_FRONTMATTER: &str =
     include_str!("../../skills/shared/cursor_rule_frontmatter.md");
 const BT_README: &str = include_str!("../../README.md");
 const README_AGENT_SECTION_MARKERS: &[&str] = &[
-    "bt eval", "bt sql", "bt view", "bt login", "bt setup", "bt docs",
+    "bt eval", "bt sql", "bt view", "bt auth", "bt setup", "bt docs",
 ];
 const ALL_AGENTS: [Agent; 4] = [Agent::Claude, Agent::Codex, Agent::Cursor, Agent::Opencode];
 const ALL_WORKFLOWS: [WorkflowArg; 5] = [


### PR DESCRIPTION
Summary:
- replace `bt login` references with `bt auth` in setup markers and shared CLI skill docs
- keep auth/context check command as `bt status`

Testing:
- docs/code text changes only