### PR TITLE
Bump version to 0.3.0 and document eval file selection

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -437,7 +437,7 @@ dependencies = [
 
 [[package]]
 name = "bt"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "actix-web",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bt"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2021"
 rust-version = "1.86.0"
 authors = ["Braintrust engineering <eng@braintrust.dev>"]

--- a/README.md
+++ b/README.md
@@ -122,15 +122,34 @@ Remove-Item -Recurse -Force (Join-Path $env:APPDATA "bt") -ErrorAction SilentlyC
 | `bt sync`        | Synchronize project logs between Braintrust and local NDJSON files |
 | `bt self update` | Update bt in-place                                                 |
 
-## `bt eval` runners
+## `bt eval`
+
+**File selection:**
+
+- `bt eval` — discover and run all eval files in the current directory (recursive)
+- `bt eval tests/` — discover eval files under a specific directory
+- `bt eval "tests/**/*.eval.ts"` — glob pattern
+- `bt eval a.eval.ts b.eval.ts` — one or more explicit files
+
+Files inside `node_modules`, `.venv`, `venv`, `site-packages`, `dist-packages`, and `__pycache__` are excluded from automatic discovery. Explicit paths and globs bypass these exclusions.
+
+**Runners:**
 
 - By default, `bt eval` auto-detects a JavaScript runner from your project (`tsx`, `vite-node`, `ts-node`, then `ts-node-esm`).
-- You can also set a runner explicitly with `--runner`:
+- Set a runner explicitly with `--runner` / `BT_EVAL_RUNNER`:
   - `bt eval --runner vite-node tutorial.eval.ts`
   - `bt eval --runner tsx tutorial.eval.ts`
-- You do not need to pass a full path for common runners; `bt` resolves local `node_modules/.bin` entries automatically.
+- `bt` resolves local `node_modules/.bin` entries automatically — no need for a full path.
 - If eval execution fails with ESM/top-level-await related errors, retry with:
   - `bt eval --runner vite-node tutorial.eval.ts`
+
+**Passing arguments to the eval file:**
+
+Use `--` to forward extra arguments to the eval file via `process.argv`:
+
+```bash
+bt eval foo.eval.ts -- --description "Prod" --shard=1/4
+```
 
 ## `bt sql`
 

--- a/src/eval.rs
+++ b/src/eval.rs
@@ -226,8 +226,9 @@ Examples:
   bt eval --language python my_eval.py
 ")]
 pub struct EvalArgs {
-    /// One or more eval files to execute (e.g. foo.eval.ts)
-    #[arg(required = true, value_name = "FILE")]
+    /// Eval files, directories, or glob patterns to execute (e.g. foo.eval.ts, tests/, "**/*.eval.ts").
+    /// Defaults to the current directory.
+    #[arg(value_name = "FILE")]
     pub files: Vec<String>,
 
     /// Eval runner binary (e.g. tsx, bun, ts-node, deno, python). Defaults to tsx for JS files.


### PR DESCRIPTION
Add documentation for file selection patterns, glob support, and argument forwarding in `bt eval`. Update the help text to clarify that files are optional and default to the current directory.