### PR TITLE
Fix link to CLI docs

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -92,7 +92,7 @@ Flags
 
 LEARN MORE
 Use `bt <command> <subcommand> --help` for more information about a command.
-Read the manual at https://braintrust.dev/docs/cli
+Read the manual at https://braintrust.dev/docs/reference/cli
 
 ";
 


### PR DESCRIPTION
The link at the end of the `bt --help` output is broken. Added a redirect on the docs side, but we should fix it at the source as well. 

```
bt --help

  ███  ███
███      ███
  ███  ███
███      ███
  ███  ███


bt is the CLI for interacting with your Braintrust projects - bt <COMMAND>

Core
  init         Initialize .bt config directory and files
  auth         Authenticate bt with Braintrust
  switch       Switch org and project context
  view         View logs, traces, and spans

Projects & resources
  projects     Manage projects
  prompts      Manage prompts
  functions    Manage functions (tools, scorers, and more)
  tools        Manage tools
  scorers      Manage scorers
  experiments  Manage experiments

Data & evaluation
  eval         Run eval files
  sql          Run SQL queries against Braintrust
  sync         Synchronize project logs between Braintrust and local NDJSON files

Additional
  docs         Manage workflow docs for coding agents
  self         Self-management commands
  setup        Configure Braintrust setup flows
  status       Show current org and project context

Flags
      --profile <PROFILE>    Use a saved login profile [env: BRAINTRUST_PROFILE]
  -o, --org <ORG>            Override active org [env: BRAINTRUST_ORG_NAME]
  -p, --project <PROJECT>    Override active project [env: BRAINTRUST_DEFAULT_PROJECT]
  -q, --quiet                Suppress non-essential output
      --json                 Output as JSON
      --no-color             Disable ANSI color output
      --no-input             Disable all interactive prompts
      --api-url <URL>        Override API URL [env: BRAINTRUST_API_URL]
      --app-url <URL>        Override app URL [env: BRAINTRUST_APP_URL]
      --env-file <PATH>      Path to a .env file to load
  -h, --help                 Print help
  -V, --version              Print version

LEARN MORE
Use `bt <command> <subcommand> --help` for more information about a command.
Read the manual at https://braintrust.dev/docs/cli
```