### PR TITLE
fix(setup): align braintrust skill name with install path

### DIFF
--- a/skills/shared/skill_frontmatter.md
+++ b/skills/shared/skill_frontmatter.md
@@ -1,5 +1,5 @@
 ---
-name: braintrust-cli
+name: braintrust
 version: 1.0.0
 description: Use the Braintrust `bt` CLI for projects, traces, prompts, and key Braintrust workflows.
 ---

--- a/src/setup/mod.rs
+++ b/src/setup/mod.rs
@@ -3710,6 +3710,12 @@ mod tests {
     }
 
     #[test]
+    fn rendered_skill_frontmatter_name_matches_braintrust_directory() {
+        let content = render_braintrust_skill();
+        assert!(content.starts_with("---\nname: braintrust\n"));
+    }
+
+    #[test]
     fn docs_cache_has_required_files_checks_workflows_and_sql_reference() {
         let unique = SystemTime::now()
             .duration_since(UNIX_EPOCH)


### PR DESCRIPTION
Rename the generated skill frontmatter from braintrust-cli to braintrust so installed skills match the parent directory name used by agent integrations.

Add a setup regression test to ensure future skill renders keep the expected frontmatter name and avoid skill conflict warnings.

pi was giving a warning for this:

```
[Skill conflicts]
   auto (user) ~/.agents/skills/braintrust/SKILL.md
     name "braintrust-cli" does not match parent directory "braintrust"
```