### PR TITLE
Flag restructuring for bt setup

### DIFF
--- a/src/args.rs
+++ b/src/args.rs
@@ -10,9 +10,9 @@ pub struct BaseArgs {
     #[arg(long, global = true)]
     pub json: bool,
 
-    /// Suppress non-essential output
-    #[arg(long, short = 'q', env = "BRAINTRUST_QUIET", global = true, value_parser = clap::builder::BoolishValueParser::new(), default_value_t = false)]
-    pub quiet: bool,
+    /// Verbose mode — set at runtime by subcommands that support it
+    #[arg(skip)]
+    pub verbose: bool,
 
     /// Disable ANSI color output
     #[arg(long, env = "BRAINTRUST_NO_COLOR", global = true, value_parser = clap::builder::BoolishValueParser::new(), default_value_t = false)]
@@ -43,10 +43,6 @@ pub struct BaseArgs {
     /// Prefer profile credentials even if BRAINTRUST_API_KEY/--api-key is set.
     #[arg(long, global = true)]
     pub prefer_profile: bool,
-
-    /// Disable all interactive prompts
-    #[arg(long, global = true)]
-    pub no_input: bool,
 
     /// Override API URL (or via BRAINTRUST_API_URL)
     #[arg(

--- a/src/args.rs
+++ b/src/args.rs
@@ -4,6 +4,12 @@ use clap::Args;
 
 pub use braintrust_sdk_rust::{DEFAULT_API_URL, DEFAULT_APP_URL};
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ArgValueSource {
+    CommandLine,
+    EnvVariable,
+}
+
 #[derive(Debug, Clone, Args)]
 pub struct BaseArgs {
     /// Output as JSON
@@ -39,6 +45,9 @@ pub struct BaseArgs {
     /// Override stored API key (or via BRAINTRUST_API_KEY)
     #[arg(long, env = "BRAINTRUST_API_KEY", global = true, hide = true)]
     pub api_key: Option<String>,
+
+    #[arg(skip)]
+    pub api_key_source: Option<ArgValueSource>,
 
     /// Prefer profile credentials even if BRAINTRUST_API_KEY/--api-key is set.
     #[arg(long, global = true)]

--- a/src/args.rs
+++ b/src/args.rs
@@ -20,8 +20,8 @@ pub struct BaseArgs {
     #[arg(skip)]
     pub verbose: bool,
 
-    /// Deprecated: quiet is now the default; this flag is accepted as a no-op
-    #[arg(long, short = 'q', env = "BRAINTRUST_QUIET", global = true, hide = true, value_parser = clap::builder::BoolishValueParser::new(), default_value_t = false)]
+    /// Reduce interactive UI output
+    #[arg(long, short = 'q', env = "BRAINTRUST_QUIET", global = true, value_parser = clap::builder::BoolishValueParser::new(), default_value_t = false)]
     pub quiet: bool,
 
     /// Disable ANSI color output

--- a/src/args.rs
+++ b/src/args.rs
@@ -24,6 +24,10 @@ pub struct BaseArgs {
     #[arg(long, env = "BRAINTRUST_NO_COLOR", global = true, value_parser = clap::builder::BoolishValueParser::new(), default_value_t = false)]
     pub no_color: bool,
 
+    /// Disable all interactive prompts
+    #[arg(long, env = "BRAINTRUST_NO_INPUT", global = true, value_parser = clap::builder::BoolishValueParser::new(), default_value_t = false)]
+    pub no_input: bool,
+
     /// Use a saved login profile (or via BRAINTRUST_PROFILE)
     #[arg(long, env = "BRAINTRUST_PROFILE", global = true)]
     pub profile: Option<String>,

--- a/src/args.rs
+++ b/src/args.rs
@@ -20,6 +20,10 @@ pub struct BaseArgs {
     #[arg(skip)]
     pub verbose: bool,
 
+    /// Deprecated: quiet is now the default; this flag is accepted as a no-op
+    #[arg(long, short = 'q', env = "BRAINTRUST_QUIET", global = true, hide = true, value_parser = clap::builder::BoolishValueParser::new(), default_value_t = false)]
+    pub quiet: bool,
+
     /// Disable ANSI color output
     #[arg(long, env = "BRAINTRUST_NO_COLOR", global = true, value_parser = clap::builder::BoolishValueParser::new(), default_value_t = false)]
     pub no_color: bool,

--- a/src/auth.rs
+++ b/src/auth.rs
@@ -2642,14 +2642,13 @@ mod tests {
     fn make_base() -> BaseArgs {
         BaseArgs {
             json: false,
-            quiet: false,
+            verbose: false,
             no_color: false,
             profile: None,
             project: None,
             org_name: None,
             api_key: None,
             prefer_profile: false,
-            no_input: false,
             api_url: None,
             app_url: None,
             env_file: None,

--- a/src/auth.rs
+++ b/src/auth.rs
@@ -831,6 +831,7 @@ async fn run_login_oauth(base: &BaseArgs, args: AuthLoginArgs) -> Result<()> {
     Ok(())
 }
 
+#[allow(dead_code)]
 pub async fn login_interactive(base: &mut BaseArgs) -> Result<String> {
     let methods = ["OAuth (browser)", "API key"];
     let selected = ui::fuzzy_select("Select login method", &methods, 0)?;
@@ -842,6 +843,11 @@ pub async fn login_interactive(base: &mut BaseArgs) -> Result<String> {
     }
 }
 
+pub async fn login_setup_oauth(base: &mut BaseArgs) -> Result<String> {
+    login_interactive_oauth(base).await
+}
+
+#[allow(dead_code)]
 async fn login_interactive_api_key(base: &mut BaseArgs) -> Result<String> {
     let api_key = prompt_api_key()?;
 
@@ -2648,6 +2654,7 @@ mod tests {
             project: None,
             org_name: None,
             api_key: None,
+            api_key_source: None,
             prefer_profile: false,
             api_url: None,
             app_url: None,

--- a/src/auth.rs
+++ b/src/auth.rs
@@ -2649,6 +2649,7 @@ mod tests {
         BaseArgs {
             json: false,
             verbose: false,
+            quiet: false,
             no_color: false,
             no_input: false,
             profile: None,

--- a/src/auth.rs
+++ b/src/auth.rs
@@ -2650,6 +2650,7 @@ mod tests {
             json: false,
             verbose: false,
             no_color: false,
+            no_input: false,
             profile: None,
             project: None,
             org_name: None,

--- a/src/auth.rs
+++ b/src/auth.rs
@@ -1,4 +1,5 @@
 use std::collections::BTreeMap;
+use std::error::Error as StdError;
 use std::fs;
 use std::io::{IsTerminal, Write};
 use std::path::{Path, PathBuf};
@@ -65,6 +66,48 @@ pub struct AvailableOrg {
     pub id: String,
     pub name: String,
     pub api_url: Option<String>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum RecoverableAuthErrorKind {
+    OauthProfileSelection,
+    OauthClientId,
+    OauthRefreshToken,
+    StoredCredential,
+}
+
+#[derive(Debug)]
+struct RecoverableAuthError {
+    kind: RecoverableAuthErrorKind,
+    message: String,
+}
+
+impl std::fmt::Display for RecoverableAuthError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(&self.message)
+    }
+}
+
+impl StdError for RecoverableAuthError {}
+
+fn recoverable_auth_error(kind: RecoverableAuthErrorKind, message: String) -> anyhow::Error {
+    anyhow::Error::new(RecoverableAuthError { kind, message })
+}
+
+pub fn is_missing_credential_error(err: &anyhow::Error) -> bool {
+    err.chain().any(|source| {
+        source
+            .downcast_ref::<RecoverableAuthError>()
+            .is_some_and(|err| {
+                matches!(
+                    err.kind,
+                    RecoverableAuthErrorKind::OauthProfileSelection
+                        | RecoverableAuthErrorKind::OauthClientId
+                        | RecoverableAuthErrorKind::OauthRefreshToken
+                        | RecoverableAuthErrorKind::StoredCredential
+                )
+            })
+    })
 }
 
 pub fn list_profiles() -> Result<Vec<ProfileInfo>> {
@@ -494,15 +537,23 @@ pub async fn resolve_auth(base: &BaseArgs) -> Result<ResolvedAuth> {
         .or_else(|| {
             (store.profiles.len() == 1).then(|| store.profiles.keys().next().unwrap().as_str())
         })
-        .ok_or_else(|| anyhow::anyhow!("oauth profile requested but none selected"))?
+        .ok_or_else(|| {
+            recoverable_auth_error(
+                RecoverableAuthErrorKind::OauthProfileSelection,
+                "oauth profile requested but none selected".to_string(),
+            )
+        })?
         .to_string();
     let profile = store
         .profiles
         .get(profile_name.as_str())
         .ok_or_else(|| anyhow::anyhow!("profile '{profile_name}' not found"))?;
     let client_id = profile.oauth_client_id.as_deref().ok_or_else(|| {
-        anyhow::anyhow!(
-            "oauth profile '{profile_name}' is missing client_id; re-run `bt auth login --oauth --profile {profile_name}`"
+        recoverable_auth_error(
+            RecoverableAuthErrorKind::OauthClientId,
+            format!(
+                "oauth profile '{profile_name}' is missing client_id; re-run `bt auth login --oauth --profile {profile_name}`"
+            ),
         )
     })?;
     let cached_expires_at = profile.oauth_access_expires_at;
@@ -519,8 +570,11 @@ pub async fn resolve_auth(base: &BaseArgs) -> Result<ResolvedAuth> {
     }
 
     let refresh_token = load_profile_oauth_refresh_token(&profile_name)?.ok_or_else(|| {
-        anyhow::anyhow!(
-            "oauth refresh token missing for profile '{profile_name}'; re-run `bt auth login --oauth --profile {profile_name}`"
+        recoverable_auth_error(
+            RecoverableAuthErrorKind::OauthRefreshToken,
+            format!(
+                "oauth refresh token missing for profile '{profile_name}'; re-run `bt auth login --oauth --profile {profile_name}`"
+            ),
         )
     })?;
     let refreshed = refresh_oauth_access_token(&api_url, &refresh_token, client_id).await?;
@@ -640,8 +694,11 @@ where
             None
         } else {
             Some(load_secret(profile_name)?.ok_or_else(|| {
-                anyhow::anyhow!(
-                    "no keychain credential found for profile '{profile_name}'; re-run `bt auth login --profile {profile_name}`"
+                recoverable_auth_error(
+                    RecoverableAuthErrorKind::StoredCredential,
+                    format!(
+                        "no keychain credential found for profile '{profile_name}'; re-run `bt auth login --profile {profile_name}`"
+                    ),
                 )
             })?)
         };
@@ -2716,6 +2773,34 @@ mod tests {
 
     fn assert_invalid_api_url<T>(result: Result<T>) {
         assert_err_contains(result, "invalid api_url");
+    }
+
+    #[test]
+    fn missing_credential_error_helper_detects_typed_auth_errors() {
+        let err = recoverable_auth_error(
+            RecoverableAuthErrorKind::OauthRefreshToken,
+            "oauth refresh token missing".to_string(),
+        );
+
+        assert!(is_missing_credential_error(&err));
+    }
+
+    #[test]
+    fn missing_credential_error_helper_ignores_unrelated_errors() {
+        let err = anyhow::anyhow!("some unrelated error");
+
+        assert!(!is_missing_credential_error(&err));
+    }
+
+    #[test]
+    fn missing_credential_error_helper_detects_errors_through_context() {
+        let err = recoverable_auth_error(
+            RecoverableAuthErrorKind::StoredCredential,
+            "missing stored credential".to_string(),
+        )
+        .context("while resolving auth");
+
+        assert!(is_missing_credential_error(&err));
     }
 
     fn restore_env_var(key: &str, previous: Option<OsString>) {

--- a/src/functions/push.rs
+++ b/src/functions/push.rs
@@ -3439,6 +3439,7 @@ mod tests {
             org_name: None,
             project: None,
             api_key: None,
+            api_key_source: None,
             prefer_profile: false,
             api_url: None,
             app_url: None,

--- a/src/functions/push.rs
+++ b/src/functions/push.rs
@@ -3433,14 +3433,13 @@ mod tests {
     fn test_base_args() -> BaseArgs {
         BaseArgs {
             json: false,
-            quiet: false,
+            verbose: false,
             no_color: false,
             profile: None,
             org_name: None,
             project: None,
             api_key: None,
             prefer_profile: false,
-            no_input: false,
             api_url: None,
             app_url: None,
             env_file: None,

--- a/src/functions/push.rs
+++ b/src/functions/push.rs
@@ -3434,6 +3434,7 @@ mod tests {
         BaseArgs {
             json: false,
             verbose: false,
+            quiet: false,
             no_color: false,
             no_input: false,
             profile: None,

--- a/src/functions/push.rs
+++ b/src/functions/push.rs
@@ -3435,6 +3435,7 @@ mod tests {
             json: false,
             verbose: false,
             no_color: false,
+            no_input: false,
             profile: None,
             org_name: None,
             project: None,

--- a/src/main.rs
+++ b/src/main.rs
@@ -446,31 +446,4 @@ mod tests {
 
         assert_eq!(cli.command.base().api_key_source, None);
     }
-
-    #[test]
-    fn deprecated_global_quiet_flag_still_parses_for_other_commands() {
-        let matches = Cli::command()
-            .try_get_matches_from(["bt", "status", "--quiet"])
-            .expect("matches");
-        let cli = Cli::from_arg_matches(&matches).expect("cli");
-
-        assert!(cli.command.base().quiet);
-    }
-
-    #[test]
-    fn deprecated_global_quiet_flag_still_parses_for_setup_subcommands() {
-        let matches = Cli::command()
-            .try_get_matches_from(["bt", "setup", "skills", "--quiet"])
-            .expect("matches");
-        let cli = Cli::from_arg_matches(&matches).expect("cli");
-
-        assert!(cli.command.base().quiet);
-    }
-
-    #[test]
-    fn setup_instrument_quiet_no_longer_aliases_background() {
-        Cli::command()
-            .try_get_matches_from(["bt", "setup", "instrument", "--quiet", "--tui"])
-            .expect("matches");
-    }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -81,6 +81,7 @@ Flags
   -o, --org <ORG>            Override active org [env: BRAINTRUST_ORG_NAME]
       -p, --project <PROJECT>    Override active project [env: BRAINTRUST_DEFAULT_PROJECT]
       --json                 Output as JSON
+  -q, --quiet                Reduce interactive UI output [env: BRAINTRUST_QUIET=]
       --no-color             Disable ANSI color output
       --no-input             Disable all interactive prompts
       --api-url <URL>        Override API URL [env: BRAINTRUST_API_URL]
@@ -295,9 +296,9 @@ fn configure_output(base: &BaseArgs) {
         ui::set_animations_enabled(false);
     }
 
-    ui::set_quiet(true);
+    ui::set_quiet(base.quiet);
     ui::set_no_input(base.no_input);
-    ui::set_animations_enabled(false);
+    ui::set_animations_enabled(!term_is_dumb && !base.quiet);
 
     if disable_color {
         dialoguer::console::set_colors_enabled(false);

--- a/src/main.rs
+++ b/src/main.rs
@@ -260,7 +260,16 @@ async fn try_main() -> Result<()> {
 }
 
 fn apply_base_arg_sources(matches: &ArgMatches, base: &mut BaseArgs) {
-    base.api_key_source = matches.value_source("api_key").and_then(map_value_source);
+    base.api_key_source = find_value_source(matches, "api_key").and_then(map_value_source);
+}
+
+fn find_value_source(matches: &ArgMatches, id: &str) -> Option<ValueSource> {
+    match matches.try_contains_id(id) {
+        Ok(_) => matches.value_source(id),
+        Err(_) => matches
+            .subcommand()
+            .and_then(|(_, sub_matches)| find_value_source(sub_matches, id)),
+    }
 }
 
 fn map_value_source(source: ValueSource) -> Option<ArgValueSource> {
@@ -375,5 +384,37 @@ fn print_error(err: &anyhow::Error, code: ExitCode) {
     eprintln!("error: {err}");
     if code == ExitCode::Error {
         eprintln!("If this seems like a bug, file an issue at https://github.com/braintrustdata/bt/issues/new and include `bt --version`, `bt status --json`, and the command you ran.");
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn apply_base_arg_sources_tracks_cli_api_key() {
+        let matches = Cli::command()
+            .try_get_matches_from(["bt", "status", "--api-key", "secret"])
+            .expect("matches");
+        let mut cli = Cli::from_arg_matches(&matches).expect("cli");
+
+        apply_base_arg_sources(&matches, cli.command.base_mut());
+
+        assert_eq!(
+            cli.command.base().api_key_source,
+            Some(ArgValueSource::CommandLine)
+        );
+    }
+
+    #[test]
+    fn apply_base_arg_sources_leaves_api_key_source_empty_when_unset() {
+        let matches = Cli::command()
+            .try_get_matches_from(["bt", "status"])
+            .expect("matches");
+        let mut cli = Cli::from_arg_matches(&matches).expect("cli");
+
+        apply_base_arg_sources(&matches, cli.command.base_mut());
+
+        assert_eq!(cli.command.base().api_key_source, None);
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,5 @@
 use anyhow::Result;
-use clap::{Parser, Subcommand};
+use clap::{parser::ValueSource, ArgMatches, CommandFactory, FromArgMatches, Parser, Subcommand};
 use std::ffi::{OsStr, OsString};
 
 mod args;
@@ -31,7 +31,7 @@ mod ui;
 mod util_cmd;
 mod utils;
 
-use crate::args::{BaseArgs, CLIArgs};
+use crate::args::{ArgValueSource, BaseArgs, CLIArgs};
 
 const DEFAULT_CANARY_VERSION: &str = concat!(env!("CARGO_PKG_VERSION"), "-canary.dev");
 const CLI_VERSION: &str = match option_env!("BT_VERSION_STRING") {
@@ -176,6 +176,30 @@ impl Commands {
             Commands::Status(cmd) => &cmd.base,
         }
     }
+
+    fn base_mut(&mut self) -> &mut BaseArgs {
+        match self {
+            Commands::Init(cmd) => &mut cmd.base,
+            Commands::Setup(cmd) => &mut cmd.base,
+            Commands::Docs(cmd) => &mut cmd.base,
+            Commands::Sql(cmd) => &mut cmd.base,
+            Commands::Auth(cmd) => &mut cmd.base,
+            Commands::View(cmd) => &mut cmd.base,
+            #[cfg(unix)]
+            Commands::Eval(cmd) => &mut cmd.base,
+            Commands::Projects(cmd) => &mut cmd.base,
+            Commands::Prompts(cmd) => &mut cmd.base,
+            Commands::SelfCommand(cmd) => &mut cmd.base,
+            Commands::Tools(cmd) => &mut cmd.base,
+            Commands::Scorers(cmd) => &mut cmd.base,
+            Commands::Functions(cmd) => &mut cmd.base,
+            Commands::Experiments(cmd) => &mut cmd.base,
+            Commands::Sync(cmd) => &mut cmd.base,
+            Commands::Util(cmd) => &mut cmd.base,
+            Commands::Switch(cmd) => &mut cmd.base,
+            Commands::Status(cmd) => &mut cmd.base,
+        }
+    }
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -205,7 +229,9 @@ async fn try_main() -> Result<()> {
     let argv: Vec<OsString> = std::env::args_os().collect();
     env::bootstrap_from_args(&argv)?;
 
-    let cli = Cli::parse_from(argv);
+    let matches = Cli::command().get_matches_from(&argv);
+    let mut cli = Cli::from_arg_matches(&matches).expect("clap matches should parse");
+    apply_base_arg_sources(&matches, cli.command.base_mut());
     configure_output(cli.command.base());
 
     match cli.command {
@@ -231,6 +257,18 @@ async fn try_main() -> Result<()> {
     }
 
     Ok(())
+}
+
+fn apply_base_arg_sources(matches: &ArgMatches, base: &mut BaseArgs) {
+    base.api_key_source = matches.value_source("api_key").and_then(map_value_source);
+}
+
+fn map_value_source(source: ValueSource) -> Option<ArgValueSource> {
+    match source {
+        ValueSource::CommandLine => Some(ArgValueSource::CommandLine),
+        ValueSource::EnvVariable => Some(ArgValueSource::EnvVariable),
+        _ => None,
+    }
 }
 
 fn configure_output(base: &BaseArgs) {

--- a/src/main.rs
+++ b/src/main.rs
@@ -80,10 +80,8 @@ Flags
       --profile <PROFILE>    Use a saved login profile [env: BRAINTRUST_PROFILE]
   -o, --org <ORG>            Override active org [env: BRAINTRUST_ORG_NAME]
   -p, --project <PROJECT>    Override active project [env: BRAINTRUST_DEFAULT_PROJECT]
-  -q, --quiet                Suppress non-essential output
       --json                 Output as JSON
       --no-color             Disable ANSI color output
-      --no-input             Disable all interactive prompts
       --api-url <URL>        Override API URL [env: BRAINTRUST_API_URL]
       --app-url <URL>        Override app URL [env: BRAINTRUST_APP_URL]
       --env-file <PATH>      Path to a .env file to load
@@ -249,14 +247,8 @@ fn configure_output(base: &BaseArgs) {
         ui::set_animations_enabled(false);
     }
 
-    if base.quiet {
-        ui::set_quiet(true);
-        ui::set_animations_enabled(false);
-    }
-
-    if base.no_input {
-        ui::set_no_input(true);
-    }
+    ui::set_quiet(true);
+    ui::set_animations_enabled(false);
 
     if disable_color {
         dialoguer::console::set_colors_enabled(false);

--- a/src/main.rs
+++ b/src/main.rs
@@ -392,15 +392,36 @@ fn print_error(err: &anyhow::Error, code: ExitCode) {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::env;
+    use std::ffi::OsString;
+    use std::sync::{Mutex, OnceLock};
+
+    fn env_test_lock() -> &'static Mutex<()> {
+        static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+        LOCK.get_or_init(|| Mutex::new(()))
+    }
+
+    fn restore_env_var(key: &str, previous: Option<OsString>) {
+        match previous {
+            Some(value) => env::set_var(key, value),
+            None => env::remove_var(key),
+        }
+    }
 
     #[test]
     fn apply_base_arg_sources_tracks_cli_api_key() {
+        let _guard = env_test_lock().lock().expect("env test lock");
+        let previous_api_key = env::var_os("BRAINTRUST_API_KEY");
+        env::remove_var("BRAINTRUST_API_KEY");
+
         let matches = Cli::command()
             .try_get_matches_from(["bt", "status", "--api-key", "secret"])
             .expect("matches");
         let mut cli = Cli::from_arg_matches(&matches).expect("cli");
 
         apply_base_arg_sources(&matches, cli.command.base_mut());
+
+        restore_env_var("BRAINTRUST_API_KEY", previous_api_key);
 
         assert_eq!(
             cli.command.base().api_key_source,
@@ -410,6 +431,10 @@ mod tests {
 
     #[test]
     fn apply_base_arg_sources_leaves_api_key_source_empty_when_unset() {
+        let _guard = env_test_lock().lock().expect("env test lock");
+        let previous_api_key = env::var_os("BRAINTRUST_API_KEY");
+        env::remove_var("BRAINTRUST_API_KEY");
+
         let matches = Cli::command()
             .try_get_matches_from(["bt", "status"])
             .expect("matches");
@@ -417,6 +442,35 @@ mod tests {
 
         apply_base_arg_sources(&matches, cli.command.base_mut());
 
+        restore_env_var("BRAINTRUST_API_KEY", previous_api_key);
+
         assert_eq!(cli.command.base().api_key_source, None);
+    }
+
+    #[test]
+    fn deprecated_global_quiet_flag_still_parses_for_other_commands() {
+        let matches = Cli::command()
+            .try_get_matches_from(["bt", "status", "--quiet"])
+            .expect("matches");
+        let cli = Cli::from_arg_matches(&matches).expect("cli");
+
+        assert!(cli.command.base().quiet);
+    }
+
+    #[test]
+    fn deprecated_global_quiet_flag_still_parses_for_setup_subcommands() {
+        let matches = Cli::command()
+            .try_get_matches_from(["bt", "setup", "skills", "--quiet"])
+            .expect("matches");
+        let cli = Cli::from_arg_matches(&matches).expect("cli");
+
+        assert!(cli.command.base().quiet);
+    }
+
+    #[test]
+    fn setup_instrument_quiet_no_longer_aliases_background() {
+        Cli::command()
+            .try_get_matches_from(["bt", "setup", "instrument", "--quiet", "--tui"])
+            .expect("matches");
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -79,9 +79,10 @@ Additional
 Flags
       --profile <PROFILE>    Use a saved login profile [env: BRAINTRUST_PROFILE]
   -o, --org <ORG>            Override active org [env: BRAINTRUST_ORG_NAME]
-  -p, --project <PROJECT>    Override active project [env: BRAINTRUST_DEFAULT_PROJECT]
+      -p, --project <PROJECT>    Override active project [env: BRAINTRUST_DEFAULT_PROJECT]
       --json                 Output as JSON
       --no-color             Disable ANSI color output
+      --no-input             Disable all interactive prompts
       --api-url <URL>        Override API URL [env: BRAINTRUST_API_URL]
       --app-url <URL>        Override app URL [env: BRAINTRUST_APP_URL]
       --env-file <PATH>      Path to a .env file to load
@@ -295,6 +296,7 @@ fn configure_output(base: &BaseArgs) {
     }
 
     ui::set_quiet(true);
+    ui::set_no_input(base.no_input);
     ui::set_animations_enabled(false);
 
     if disable_color {

--- a/src/setup/mod.rs
+++ b/src/setup/mod.rs
@@ -53,21 +53,58 @@ pub struct SetupArgs {
     #[command(subcommand)]
     command: Option<SetupSubcommand>,
 
-    /// Set up coding-agent skills (skips interactive selection in wizard)
-    #[arg(long)]
+    /// Set up coding-agent skills [default]
+    #[arg(long, conflicts_with = "no_skills")]
     skills: bool,
 
-    /// Set up MCP server (skips interactive selection in wizard)
-    #[arg(long)]
+    /// Do not set up coding-agent skills
+    #[arg(long, conflicts_with = "skills")]
+    no_skills: bool,
+
+    /// Set up MCP server
+    #[arg(long, conflicts_with = "no_mcp")]
     mcp: bool,
 
-    /// Run instrumentation agent (skips interactive prompt in wizard)
+    /// Do not set up MCP server [default]
+    #[arg(long, conflicts_with = "mcp")]
+    no_mcp: bool,
+
+    /// Run instrumentation agent [default]
     #[arg(long)]
     instrument: bool,
 
-    /// Skip skills and MCP setup (skips interactive selection in wizard)
-    #[arg(long, conflicts_with_all = ["skills", "mcp"])]
-    no_mcp_skill: bool,
+    /// Do not run instrumentation agent (skills and MCP are still configured)
+    #[arg(
+        long,
+        conflicts_with = "instrument",
+        conflicts_with = "tui",
+        conflicts_with = "background",
+        conflicts_with = "yolo"
+    )]
+    no_instrument: bool,
+
+    /// Run the agent in interactive TUI mode [default]
+    #[arg(long, conflicts_with = "background", conflicts_with = "no_instrument")]
+    tui: bool,
+
+    /// Run the agent in background (non-interactive) mode
+    #[arg(long, conflicts_with = "tui", conflicts_with = "no_instrument")]
+    background: bool,
+
+    /// Language(s) to instrument (repeatable; case-insensitive).
+    /// When provided, the agent skips language auto-detection and instruments
+    /// the specified language(s) directly.
+    #[arg(long = "language", value_enum, ignore_case = true)]
+    languages: Vec<LanguageArg>,
+
+    /// Run the interactive setup wizard, prompting for every choice not already
+    /// specified as a flag.
+    #[arg(long, short = 'i')]
+    interactive: bool,
+
+    /// Show additional setup output
+    #[arg(long, short = 'v')]
+    verbose: bool,
 
     #[command(flatten)]
     agents: AgentsSetupArgs,
@@ -87,24 +124,27 @@ enum SetupSubcommand {
 
 #[derive(Debug, Clone, Args)]
 struct AgentsSetupArgs {
-    /// Agent(s) to configure (repeatable)
-    #[arg(long = "agent", value_enum)]
-    agents: Vec<AgentArg>,
+    /// Agent to configure
+    #[arg(long, value_enum)]
+    agent: Option<AgentArg>,
 
     /// Configure the current git repo root
     #[arg(long, conflicts_with = "global")]
     local: bool,
 
-    /// Configure user-wide state
+    /// Configure user-wide state [default]
     #[arg(long)]
     global: bool,
 
-    /// Workflow docs to prefetch (repeatable)
+    /// Workflow docs to prefetch (repeatable) [default: all]
     #[arg(long = "workflow", value_enum)]
     workflows: Vec<WorkflowArg>,
 
-    /// Skip confirmation prompts and use defaults
-    #[arg(long, short = 'y')]
+    /// Do not fetch workflow docs during setup
+    #[arg(long, conflicts_with = "workflows")]
+    no_workflow: bool,
+
+    #[arg(skip)]
     yes: bool,
 
     /// Do not auto-fetch workflow docs during setup
@@ -119,28 +159,26 @@ struct AgentsSetupArgs {
     #[arg(long, default_value_t = crate::sync::default_workers())]
     workers: usize,
 
-    /// Grant the agent full permissions and run it in the background without prompting.
-    /// Equivalent to choosing "Background" with all tool restrictions lifted.
-    #[arg(long)]
+    /// Grant the agent full permissions (bypass permission prompts)
+    #[arg(long, conflicts_with = "no_instrument")]
     yolo: bool,
 }
 
 #[derive(Debug, Clone, Args)]
 struct AgentsMcpSetupArgs {
-    /// Agent(s) to configure MCP for (repeatable)
-    #[arg(long = "agent", value_enum)]
-    agents: Vec<AgentArg>,
+    /// Agent to configure MCP for
+    #[arg(long, value_enum)]
+    agent: Option<AgentArg>,
 
     /// Configure MCP in the current git repo root
     #[arg(long, conflicts_with = "global")]
     local: bool,
 
-    /// Configure MCP in user-wide state
+    /// Configure MCP in user-wide state [default]
     #[arg(long)]
     global: bool,
 
-    /// Skip confirmation prompts and use defaults
-    #[arg(long, short = 'y')]
+    #[arg(skip)]
     yes: bool,
 }
 
@@ -154,12 +192,11 @@ struct InstrumentSetupArgs {
     #[arg(long)]
     agent_cmd: Option<String>,
 
-    /// Workflow docs to prefetch alongside instrument (repeatable; always includes instrument)
+    /// Workflow docs to prefetch alongside instrument (repeatable; always includes instrument) [default: all]
     #[arg(long = "workflow", value_enum)]
     workflows: Vec<WorkflowArg>,
 
-    /// Skip confirmation prompts and use defaults
-    #[arg(long, short = 'y')]
+    #[arg(skip)]
     yes: bool,
 
     /// Refresh prefetched docs by clearing existing output before download
@@ -170,10 +207,6 @@ struct InstrumentSetupArgs {
     #[arg(long, default_value_t = crate::sync::default_workers())]
     workers: usize,
 
-    /// Suppress streaming agent output; show a spinner and print results at the end
-    #[arg(long, short = 'q')]
-    quiet: bool,
-
     /// Language(s) to instrument (repeatable; case-insensitive).
     /// When provided, the agent skips language auto-detection and instruments
     /// the specified language(s) directly.
@@ -181,15 +214,22 @@ struct InstrumentSetupArgs {
     #[arg(long = "language", value_enum, ignore_case = true)]
     languages: Vec<LanguageArg>,
 
-    /// Run the agent in interactive mode: inherits the terminal so the user can
-    /// approve/deny tool uses directly. Conflicts with --quiet and --yolo.
-    #[arg(long, short = 'i', conflicts_with_all = ["quiet", "yolo"])]
-    interactive: bool,
+    /// Run the agent in interactive TUI mode [default]
+    #[arg(long, conflicts_with = "background")]
+    tui: bool,
 
-    /// Grant the agent full permissions and run it in the background without prompting.
-    /// Skips the run-mode selection question. Conflicts with --interactive.
-    #[arg(long, conflicts_with = "interactive")]
+    /// Run the agent in background (non-interactive) mode
+    #[arg(long, conflicts_with = "tui")]
+    background: bool,
+
+    /// Grant the agent full permissions (bypass permission prompts)
+    #[arg(long)]
     yolo: bool,
+
+    /// Set up skills and write the task file but do not launch the agent.
+    #[arg(skip)]
+    #[allow(dead_code)]
+    skip_launch: bool,
 }
 
 #[derive(Debug, Clone, Args)]
@@ -210,7 +250,6 @@ enum AgentArg {
     Codex,
     Cursor,
     Opencode,
-    All,
 }
 
 #[derive(Debug, Clone, Copy, Eq, PartialEq, Hash, Ord, PartialOrd, Serialize)]
@@ -374,7 +413,18 @@ struct SkillsAliasResult {
     path: PathBuf,
 }
 
-pub async fn run_setup_top(base: BaseArgs, args: SetupArgs) -> Result<()> {
+pub async fn run_setup_top(mut base: BaseArgs, mut args: SetupArgs) -> Result<()> {
+    if args.verbose {
+        base.verbose = true;
+        crate::ui::set_quiet(false);
+        crate::ui::set_animations_enabled(true);
+    }
+    if base.json && args.instrument {
+        bail!("--json conflicts with --instrument: JSON mode implies --no-instrument");
+    }
+    if base.json {
+        args.no_instrument = true;
+    }
     match args.command {
         Some(SetupSubcommand::Skills(setup)) => run_setup(base, setup).await,
         Some(SetupSubcommand::Instrument(instrument)) => {
@@ -385,15 +435,22 @@ pub async fn run_setup_top(base: BaseArgs, args: SetupArgs) -> Result<()> {
         None => {
             if should_prompt_setup_action(&base, &args.agents) {
                 let wizard_flags = WizardFlags {
+                    interactive: args.interactive,
                     yolo: args.agents.yolo,
                     skills: args.skills,
+                    no_skills: args.no_skills,
                     mcp: args.mcp,
+                    no_mcp: args.no_mcp,
                     local: args.agents.local,
                     global: args.agents.global,
                     instrument: args.instrument,
-                    agents: args.agents.agents,
-                    no_mcp_skill: args.no_mcp_skill,
+                    no_instrument: args.no_instrument,
+                    tui: args.tui,
+                    background: args.background,
+                    agent: args.agents.agent,
                     workflows: args.agents.workflows,
+                    no_workflow: args.agents.no_workflow,
+                    languages: args.languages,
                 };
                 run_setup_wizard(base, wizard_flags).await
             } else {
@@ -405,51 +462,66 @@ pub async fn run_setup_top(base: BaseArgs, args: SetupArgs) -> Result<()> {
 
 pub use docs::run_docs_top;
 
+#[allow(dead_code)]
 struct WizardFlags {
+    interactive: bool,
     yolo: bool,
     skills: bool,
+    no_skills: bool,
     mcp: bool,
+    no_mcp: bool,
     local: bool,
     global: bool,
     instrument: bool,
-    agents: Vec<AgentArg>,
-    no_mcp_skill: bool,
+    no_instrument: bool,
+    tui: bool,
+    background: bool,
+    agent: Option<AgentArg>,
     workflows: Vec<WorkflowArg>,
+    no_workflow: bool,
+    languages: Vec<LanguageArg>,
 }
 
 async fn run_setup_wizard(mut base: BaseArgs, flags: WizardFlags) -> Result<()> {
     let WizardFlags {
+        interactive: _,
         yolo,
         skills: flag_skills,
+        no_skills: flag_no_skills,
         mcp: flag_mcp,
+        no_mcp: flag_no_mcp,
         local: flag_local,
         global: flag_global,
         instrument: flag_instrument,
-        agents: flag_agents,
-        no_mcp_skill: flag_no_mcp_skill,
+        no_instrument: flag_no_instrument,
+        tui: flag_tui,
+        background: flag_background,
+        agent: flag_agent,
         workflows: flag_workflows,
+        no_workflow: _,
+        languages: flag_languages,
     } = flags;
     let mut had_failures = false;
-    let quiet = base.quiet;
+    let verbose = base.verbose;
 
     // ── Step 1: Auth ──
-    if !quiet {
+    if verbose {
         print_wizard_step(1, "Auth");
     }
     let project_flag = base.project.clone();
     let login_ctx = ensure_auth(&mut base).await?;
     let client = ApiClient::new(&login_ctx)?;
     let org = client.org_name().to_string();
-    if !quiet {
+    if verbose {
         eprintln!("   {} Using org '{}'", style("✓").green(), org);
     }
 
     // ── Step 2: Project ──
-    if !quiet {
+    if verbose {
         print_wizard_step(2, "Project");
     }
-    let project = select_project_with_skip(&client, project_flag.as_deref(), quiet).await?;
-    if !quiet {
+    let project = select_project_with_skip(&client, project_flag.as_deref(), !verbose).await?;
+    if verbose {
         if let Some(ref project) = project {
             if find_git_root().is_some() && maybe_init(&org, project)? {
                 eprintln!(
@@ -469,12 +541,12 @@ async fn run_setup_wizard(mut base: BaseArgs, flags: WizardFlags) -> Result<()> 
     }
 
     // ── Step 3: Agent tools (skills + MCP) ──
-    if !quiet {
+    if verbose {
         print_wizard_step(3, "Agents");
     }
     let mut multiselect_hint_shown = false;
-    let (wants_skills, wants_mcp) = if flag_no_mcp_skill {
-        if !quiet {
+    let (wants_skills, wants_mcp) = if flag_no_skills && flag_no_mcp {
+        if verbose {
             eprintln!(
                 "{} What would you like to set up? · {}",
                 style("✔").green(),
@@ -482,8 +554,12 @@ async fn run_setup_wizard(mut base: BaseArgs, flags: WizardFlags) -> Result<()> 
             );
         }
         (false, false)
+    } else if flag_no_skills {
+        (false, flag_mcp || !flag_no_mcp)
+    } else if flag_no_mcp {
+        (flag_skills || !flag_no_skills, false)
     } else if flag_skills || flag_mcp {
-        if !quiet {
+        if verbose {
             let chosen: Vec<&str> = [("Skills", flag_skills), ("MCP", flag_mcp)]
                 .iter()
                 .filter(|(_, v)| *v)
@@ -501,7 +577,7 @@ async fn run_setup_wizard(mut base: BaseArgs, flags: WizardFlags) -> Result<()> 
         }
         (flag_skills, flag_mcp)
     } else {
-        if !quiet {
+        if verbose {
             eprintln!(
                 "   {}",
                 style("(Un)select option with Space, confirm selection with Enter.").dim()
@@ -520,7 +596,7 @@ async fn run_setup_wizard(mut base: BaseArgs, flags: WizardFlags) -> Result<()> 
 
     let setup_context = if wants_skills || wants_mcp {
         let scope = if flag_local {
-            if !quiet {
+            if verbose {
                 eprintln!(
                     "{} Select install scope · {}",
                     style("✔").green(),
@@ -529,7 +605,7 @@ async fn run_setup_wizard(mut base: BaseArgs, flags: WizardFlags) -> Result<()> 
             }
             InstallScope::Local
         } else if flag_global {
-            if !quiet {
+            if verbose {
                 eprintln!(
                     "{} Select install scope · {}",
                     style("✔").green(),
@@ -544,8 +620,8 @@ async fn run_setup_wizard(mut base: BaseArgs, flags: WizardFlags) -> Result<()> 
         let home = home_dir().ok_or_else(|| anyhow!("failed to resolve HOME/USERPROFILE"))?;
         let local_root = resolve_local_root_for_scope(scope)?;
         let detected = detect_agents(local_root.as_deref(), &home);
-        let agents = resolve_selected_agents(&flag_agents, &detected);
-        if !quiet && !flag_agents.is_empty() {
+        let agents = resolve_selected_agents(flag_agent, &detected);
+        if verbose && flag_agent.is_some() {
             let agent_names: Vec<String> = agents
                 .iter()
                 .map(|a| style(a.as_str()).green().to_string())
@@ -562,18 +638,17 @@ async fn run_setup_wizard(mut base: BaseArgs, flags: WizardFlags) -> Result<()> 
     };
 
     if wants_skills {
-        if !quiet {
+        if verbose {
             eprintln!("   {}", style("Skills:").bold());
         }
-        if let Some((scope, ref agents, _)) = setup_context {
-            let agent_args: Vec<AgentArg> =
-                agents.iter().map(|a| map_agent_to_agent_arg(*a)).collect();
+        if let Some((scope, _, _)) = setup_context {
             let args = AgentsSetupArgs {
-                agents: agent_args,
+                agent: flag_agent,
                 local: matches!(scope, InstallScope::Local),
                 global: matches!(scope, InstallScope::Global),
                 workflows: Vec::new(),
-                yes: false,
+                no_workflow: false,
+                yes: true,
                 no_fetch_docs: true,
                 refresh_docs: false,
                 workers: crate::sync::default_workers(),
@@ -581,7 +656,7 @@ async fn run_setup_wizard(mut base: BaseArgs, flags: WizardFlags) -> Result<()> 
             };
             let outcome = execute_skills_setup(&base, &args, true).await?;
             for r in &outcome.results {
-                if !quiet {
+                if verbose {
                     print_wizard_agent_result(r);
                 }
                 if matches!(r.status, InstallStatus::Failed) {
@@ -592,14 +667,14 @@ async fn run_setup_wizard(mut base: BaseArgs, flags: WizardFlags) -> Result<()> 
     }
 
     if wants_mcp {
-        if !quiet {
+        if verbose {
             eprintln!("   {}", style("MCP:").bold());
         }
         if let Some((scope, ref agents, ref home)) = setup_context {
             let local_root = resolve_local_root_for_scope(scope)?;
             let outcome = execute_mcp_install(scope, local_root.as_deref(), home, agents);
             for r in &outcome.results {
-                if !quiet {
+                if verbose {
                     print_wizard_agent_result(r);
                 }
                 if matches!(r.status, InstallStatus::Failed) {
@@ -612,17 +687,25 @@ async fn run_setup_wizard(mut base: BaseArgs, flags: WizardFlags) -> Result<()> 
         }
     }
 
-    if !wants_skills && !wants_mcp && !quiet {
+    if !wants_skills && !wants_mcp && verbose {
         eprintln!("   {}", style("Skipped").dim());
     }
 
     // ── Step 4: Instrument ──
-    if !quiet {
+    if verbose {
         print_wizard_step(4, "Instrument");
     }
     if find_git_root().is_some() {
-        let instrument = if flag_instrument {
-            if !quiet {
+        let instrument = if flag_no_instrument {
+            if verbose {
+                eprintln!(
+                    "Run instrumentation agent to set up tracing in this repo? {}",
+                    style("no").dim()
+                );
+            }
+            false
+        } else if flag_instrument {
+            if verbose {
                 eprintln!(
                     "Run instrumentation agent to set up tracing in this repo? {}",
                     style("yes").green()
@@ -636,16 +719,12 @@ async fn run_setup_wizard(mut base: BaseArgs, flags: WizardFlags) -> Result<()> 
                 .interact()?
         };
         if instrument {
-            let instrument_agent = match flag_agents.as_slice() {
-                [single] => match single {
-                    AgentArg::Claude => Some(InstrumentAgentArg::Claude),
-                    AgentArg::Codex => Some(InstrumentAgentArg::Codex),
-                    AgentArg::Cursor => Some(InstrumentAgentArg::Cursor),
-                    AgentArg::Opencode => Some(InstrumentAgentArg::Opencode),
-                    AgentArg::All => None,
-                },
-                _ => None,
-            };
+            let instrument_agent = flag_agent.map(|a| match a {
+                AgentArg::Claude => InstrumentAgentArg::Claude,
+                AgentArg::Codex => InstrumentAgentArg::Codex,
+                AgentArg::Cursor => InstrumentAgentArg::Cursor,
+                AgentArg::Opencode => InstrumentAgentArg::Opencode,
+            });
             run_instrument_setup(
                 base,
                 InstrumentSetupArgs {
@@ -655,23 +734,24 @@ async fn run_setup_wizard(mut base: BaseArgs, flags: WizardFlags) -> Result<()> 
                     yes: false,
                     refresh_docs: false,
                     workers: crate::sync::default_workers(),
-                    quiet: false,
-                    languages: Vec::new(),
-                    interactive: false,
+                    languages: flag_languages,
+                    tui: flag_tui,
+                    background: flag_background,
                     yolo,
+                    skip_launch: false,
                 },
                 !multiselect_hint_shown,
             )
             .await?;
-        } else if !quiet {
+        } else if verbose {
             eprintln!("   {}", style("Skipped").dim());
         }
-    } else if !quiet {
+    } else if verbose {
         eprintln!("   {}", style("Skipped").dim());
     }
 
     // ── Done ──
-    if !quiet {
+    if verbose {
         print_wizard_done(had_failures);
     }
     if had_failures {
@@ -840,7 +920,7 @@ async fn execute_skills_setup(
     let mut warnings = Vec::new();
     let mut notes = Vec::new();
     let mut results = Vec::new();
-    let show_progress = !base.json && !quiet && !base.quiet;
+    let show_progress = !base.json && !quiet;
 
     if show_progress {
         println!("Configuring coding agents for Braintrust");
@@ -976,13 +1056,13 @@ async fn run_instrument_setup(
     let mut selected = if let Some(agent_arg) = args.agent {
         map_instrument_agent_arg(agent_arg)
     } else {
-        pick_agent_mode_target(&resolve_selected_agents(&[], &detected))
+        pick_agent_mode_target(&resolve_selected_agents(None, &detected))
             .ok_or_else(|| anyhow!("no detected agents available for instrumentation"))?
     };
 
     if args.agent.is_none() && ui::is_interactive() && !args.yes {
         selected = prompt_instrument_agent(selected)?;
-    } else if args.agent.is_some() && !base.quiet {
+    } else if args.agent.is_some() && base.verbose {
         eprintln!(
             "{} Select agent to instrument this repo · {}",
             style("✔").green(),
@@ -990,7 +1070,7 @@ async fn run_instrument_setup(
         );
     }
 
-    let mut hint_pending = print_hint && !base.quiet;
+    let mut hint_pending = print_hint && base.verbose;
     let selected_workflows = resolve_instrument_workflow_selection(&args, &mut hint_pending)?;
 
     let selected_languages: Vec<LanguageArg> = if !args.languages.is_empty() {
@@ -1039,10 +1119,11 @@ async fn run_instrument_setup(
         .await?;
     } else {
         let setup_args = AgentsSetupArgs {
-            agents: vec![map_agent_to_agent_arg(selected)],
+            agent: Some(map_agent_to_agent_arg(selected)),
             local: true,
             global: false,
             workflows: selected_workflows.clone(),
+            no_workflow: false,
             yes: true,
             no_fetch_docs: false,
             refresh_docs: args.refresh_docs,
@@ -1060,15 +1141,16 @@ async fn run_instrument_setup(
     }
 
     // Determine run mode: interactive TUI vs background (autonomous).
-    // --yolo:        background, full bypassPermissions (no restrictions)
-    // --interactive: interactive TUI
+    // --yolo:       background, full bypassPermissions (no restrictions)
+    // --tui:        interactive TUI
+    // --background: background, restricted to language package managers
     // --yes or non-interactive terminal: background, restricted to language package managers
     // Otherwise: ask the user.
-    let (run_interactive, bypass_permissions) = if args.interactive {
+    let (run_interactive, bypass_permissions) = if args.tui {
         (true, false)
     } else if args.yolo {
         (false, true)
-    } else if args.yes || !ui::is_interactive() {
+    } else if args.background || args.yes || !ui::is_interactive() {
         (false, false)
     } else {
         let pkg_mgrs = package_manager_cmds_for_languages(&selected_languages).join(", ");
@@ -1132,8 +1214,8 @@ async fn run_instrument_setup(
         eprintln!();
     }
 
-    let show_output = !base.json && !args.quiet;
-    let status = if args.quiet && !base.json {
+    let show_output = !base.json && !args.background;
+    let status = if args.background && !base.json {
         with_spinner(
             "Running agent instrumentation…",
             run_agent_invocation(&root, &invocation, false),
@@ -1869,7 +1951,7 @@ fn resolve_setup_selection(args: &AgentsSetupArgs, home: &Path) -> Result<SetupS
     );
     let interactive = ui::is_interactive() && !args.yes;
     let mut prompted_agents: Option<Vec<Agent>> = None;
-    let mut prompted_workflows: Option<Vec<WorkflowArg>> = if args.no_fetch_docs {
+    let mut prompted_workflows: Option<Vec<WorkflowArg>> = if args.no_fetch_docs || args.no_workflow {
         Some(Vec::new())
     } else {
         None
@@ -1887,7 +1969,7 @@ fn resolve_setup_selection(args: &AgentsSetupArgs, home: &Path) -> Result<SetupS
         if scope.is_none() {
             steps.push(SetupWizardStep::Scope);
         }
-        if args.agents.is_empty() {
+        if args.agent.is_none() {
             steps.push(SetupWizardStep::Agents);
         }
         if !args.no_fetch_docs && args.workflows.is_empty() {
@@ -1913,7 +1995,7 @@ fn resolve_setup_selection(args: &AgentsSetupArgs, home: &Path) -> Result<SetupS
                     let current_scope = scope.ok_or_else(|| anyhow!("scope not selected"))?;
                     let local_root = resolve_local_root_for_scope(current_scope)?;
                     let detected = detect_agents(local_root.as_deref(), home);
-                    let defaults = resolve_selected_agents(&[], &detected);
+                    let defaults = resolve_selected_agents(None, &detected);
                     match prompt_agents_selection(&defaults)? {
                         Some(selected) => {
                             prompted_agents = Some(selected);
@@ -1960,7 +2042,7 @@ fn resolve_setup_selection(args: &AgentsSetupArgs, home: &Path) -> Result<SetupS
     let detected = detect_agents(local_root.as_deref(), home);
     let selected_agents = match prompted_agents {
         Some(value) => value,
-        None => resolve_selected_agents(&args.agents, &detected),
+        None => resolve_selected_agents(args.agent, &detected),
     };
     if selected_agents.is_empty() {
         bail!("no agents selected for installation");
@@ -1999,7 +2081,7 @@ fn resolve_mcp_selection(args: &AgentsMcpSetupArgs, home: &Path) -> Result<McpSe
         if scope.is_none() {
             steps.push(McpWizardStep::Scope);
         }
-        if args.agents.is_empty() {
+        if args.agent.is_none() {
             steps.push(McpWizardStep::Agents);
         }
 
@@ -2022,7 +2104,7 @@ fn resolve_mcp_selection(args: &AgentsMcpSetupArgs, home: &Path) -> Result<McpSe
                     let current_scope = scope.ok_or_else(|| anyhow!("scope not selected"))?;
                     let local_root = resolve_local_root_for_scope(current_scope)?;
                     let detected = detect_agents(local_root.as_deref(), home);
-                    let defaults = resolve_selected_agents(&[], &detected);
+                    let defaults = resolve_selected_agents(None, &detected);
                     match prompt_agents_selection(&defaults)? {
                         Some(selected) => {
                             prompted_agents = Some(selected);
@@ -2054,7 +2136,7 @@ fn resolve_mcp_selection(args: &AgentsMcpSetupArgs, home: &Path) -> Result<McpSe
     let detected = detect_agents(local_root.as_deref(), home);
     let selected_agents = match prompted_agents {
         Some(value) => value,
-        None => resolve_selected_agents(&args.agents, &detected),
+        None => resolve_selected_agents(args.agent, &detected),
     };
     if selected_agents.is_empty() {
         bail!("no agents selected for MCP setup");
@@ -2354,8 +2436,8 @@ fn resolve_scope_from_flags(
     })
 }
 
-fn resolve_selected_agents(requested: &[AgentArg], detected: &[DetectionSignal]) -> Vec<Agent> {
-    if requested.is_empty() {
+fn resolve_selected_agents(requested: Option<AgentArg>, detected: &[DetectionSignal]) -> Vec<Agent> {
+    let Some(arg) = requested else {
         let mut inferred = BTreeSet::new();
         for signal in detected {
             inferred.insert(signal.agent);
@@ -2364,26 +2446,15 @@ fn resolve_selected_agents(requested: &[AgentArg], detected: &[DetectionSignal])
             return ALL_AGENTS.to_vec();
         }
         return inferred.into_iter().collect();
-    }
+    };
 
-    if requested.contains(&AgentArg::All) {
-        return ALL_AGENTS.to_vec();
-    }
-
-    let mut out = BTreeSet::new();
-    for value in requested {
-        let mapped = match value {
-            AgentArg::Claude => Some(Agent::Claude),
-            AgentArg::Codex => Some(Agent::Codex),
-            AgentArg::Cursor => Some(Agent::Cursor),
-            AgentArg::Opencode => Some(Agent::Opencode),
-            AgentArg::All => None,
-        };
-        if let Some(agent) = mapped {
-            out.insert(agent);
-        }
-    }
-    out.into_iter().collect()
+    let agent = match arg {
+        AgentArg::Claude => Agent::Claude,
+        AgentArg::Codex => Agent::Codex,
+        AgentArg::Cursor => Agent::Cursor,
+        AgentArg::Opencode => Agent::Opencode,
+    };
+    vec![agent]
 }
 
 fn map_instrument_agent_arg(agent: InstrumentAgentArg) -> Agent {
@@ -3137,9 +3208,9 @@ mod tests {
     use std::time::{SystemTime, UNIX_EPOCH};
 
     #[test]
-    fn all_agent_arg_expands_to_all_agents() {
+    fn no_agent_arg_defaults_to_all_agents() {
         let detected = vec![];
-        let resolved = resolve_selected_agents(&[AgentArg::All], &detected);
+        let resolved = resolve_selected_agents(None, &detected);
         assert_eq!(
             resolved,
             vec![Agent::Claude, Agent::Codex, Agent::Cursor, Agent::Opencode]
@@ -3152,7 +3223,7 @@ mod tests {
             agent: Agent::Codex,
             reason: "hint".to_string(),
         }];
-        let resolved = resolve_selected_agents(&[], &detected);
+        let resolved = resolve_selected_agents(None, &detected);
         assert_eq!(resolved, vec![Agent::Codex]);
     }
 
@@ -3254,10 +3325,11 @@ mod tests {
     #[test]
     fn resolve_setup_selection_honors_no_fetch_docs() {
         let args = AgentsSetupArgs {
-            agents: vec![AgentArg::Codex],
+            agent: Some(AgentArg::Codex),
             local: false,
             global: true,
             workflows: vec![WorkflowArg::Evaluate],
+            no_workflow: false,
             yes: true,
             no_fetch_docs: true,
             refresh_docs: false,
@@ -3288,10 +3360,11 @@ mod tests {
             yes: true,
             refresh_docs: false,
             workers: crate::sync::default_workers(),
-            quiet: false,
             languages: Vec::new(),
-            interactive: false,
+            tui: false,
+            background: false,
             yolo: false,
+            skip_launch: false,
         };
 
         let selected = resolve_instrument_workflow_selection(&args, &mut false)
@@ -3311,10 +3384,11 @@ mod tests {
             yes: true,
             refresh_docs: false,
             workers: crate::sync::default_workers(),
-            quiet: false,
             languages: Vec::new(),
-            interactive: false,
+            tui: false,
+            background: false,
             yolo: false,
+            skip_launch: false,
         };
 
         let selected = resolve_instrument_workflow_selection(&args, &mut false)

--- a/src/setup/mod.rs
+++ b/src/setup/mod.rs
@@ -11,7 +11,7 @@ use serde::Serialize;
 use serde_json::{Map, Value};
 use tokio::process::Command;
 
-use crate::args::BaseArgs;
+use crate::args::{ArgValueSource, BaseArgs};
 use crate::auth;
 use crate::auth::LoginContext;
 use crate::config;
@@ -94,7 +94,12 @@ pub struct SetupArgs {
     /// Language(s) to instrument (repeatable; case-insensitive).
     /// When provided, the agent skips language auto-detection and instruments
     /// the specified language(s) directly.
-    #[arg(long = "language", value_enum, ignore_case = true)]
+    #[arg(
+        long = "language",
+        value_enum,
+        ignore_case = true,
+        conflicts_with = "no_instrument"
+    )]
     languages: Vec<LanguageArg>,
 
     /// Run the interactive setup wizard, prompting for every choice not already
@@ -129,7 +134,7 @@ enum SetupSubcommand {
 #[derive(Debug, Clone, Args)]
 struct AgentsSetupArgs {
     /// Agent to configure
-    #[arg(long, value_enum)]
+    #[arg(long, alias = "agents", value_enum)]
     agent: Option<AgentArg>,
 
     /// Configure the current git repo root
@@ -164,14 +169,14 @@ struct AgentsSetupArgs {
     workers: usize,
 
     /// Grant the agent full permissions (bypass permission prompts)
-    #[arg(long, conflicts_with = "no_instrument")]
+    #[arg(long)]
     yolo: bool,
 }
 
 #[derive(Debug, Clone, Args)]
 struct AgentsMcpSetupArgs {
     /// Agent to configure MCP for
-    #[arg(long, value_enum)]
+    #[arg(long, alias = "agents", value_enum)]
     agent: Option<AgentArg>,
 
     /// Configure MCP in the current git repo root
@@ -447,28 +452,28 @@ pub async fn run_setup_top(mut base: BaseArgs, mut args: SetupArgs) -> Result<()
         Some(SetupSubcommand::Mcp(mcp)) => run_mcp_setup(base, mcp),
         Some(SetupSubcommand::Doctor(doctor)) => run_doctor(base, doctor),
         None => {
-            if should_prompt_setup_action(&base, &args.agents) {
-                let wizard_flags = WizardFlags {
-                    interactive: args.interactive,
-                    yolo: args.agents.yolo,
-                    skills: args.skills,
-                    no_skills: args.no_skills,
-                    mcp: args.mcp,
-                    no_mcp: args.no_mcp,
-                    local: args.agents.local,
-                    global: args.agents.global,
-                    instrument: args.instrument,
-                    no_instrument: args.no_instrument,
-                    tui: args.tui,
-                    background: args.background,
-                    agent: args.agents.agent,
-                    workflows: args.agents.workflows,
-                    no_workflow: args.agents.no_workflow,
-                    languages: args.languages,
-                };
+            let wizard_flags = WizardFlags {
+                interactive: args.interactive,
+                yolo: args.agents.yolo,
+                skills: args.skills,
+                no_skills: args.no_skills,
+                mcp: args.mcp,
+                no_mcp: args.no_mcp,
+                local: args.agents.local,
+                global: args.agents.global,
+                instrument: args.instrument,
+                no_instrument: args.no_instrument,
+                tui: args.tui,
+                background: args.background,
+                agent: args.agents.agent,
+                workflows: args.agents.workflows.clone(),
+                no_workflow: args.agents.no_workflow,
+                languages: args.languages.clone(),
+            };
+            if args.interactive {
                 run_setup_wizard(base, wizard_flags).await
             } else {
-                run_setup(base, args.agents).await
+                run_default_setup(base, args).await
             }
         }
     }
@@ -599,7 +604,7 @@ async fn run_setup_wizard(mut base: BaseArgs, flags: WizardFlags) -> Result<()> 
             multiselect_hint_shown = true;
         }
         let choices = ["Skills", "MCP"];
-        let defaults = [true, true];
+        let defaults = [true, false];
         let selected = MultiSelect::with_theme(&ColorfulTheme::default())
             .with_prompt("What would you like to set up?")
             .items(&choices)
@@ -634,7 +639,12 @@ async fn run_setup_wizard(mut base: BaseArgs, flags: WizardFlags) -> Result<()> 
         let home = home_dir().ok_or_else(|| anyhow!("failed to resolve HOME/USERPROFILE"))?;
         let local_root = resolve_local_root_for_scope(scope)?;
         let detected = detect_agents(local_root.as_deref(), &home);
-        let agents = resolve_selected_agents(flag_agent, &detected);
+        let agents = vec![resolve_default_agent_selection(
+            flag_agent,
+            &detected,
+            "Select coding agent",
+            true,
+        )?];
         if verbose && flag_agent.is_some() {
             let agent_names: Vec<String> = agents
                 .iter()
@@ -729,7 +739,7 @@ async fn run_setup_wizard(mut base: BaseArgs, flags: WizardFlags) -> Result<()> 
         } else {
             Confirm::with_theme(&ColorfulTheme::default())
                 .with_prompt("Run instrumentation agent to set up tracing in this repo?")
-                .default(false)
+                .default(true)
                 .interact()?
         };
         if instrument {
@@ -774,37 +784,153 @@ async fn run_setup_wizard(mut base: BaseArgs, flags: WizardFlags) -> Result<()> 
     Ok(())
 }
 
+async fn run_default_setup(mut base: BaseArgs, args: SetupArgs) -> Result<()> {
+    let login_ctx = ensure_auth(&mut base).await?;
+    let client = ApiClient::new(&login_ctx)?;
+    let org = client.org_name().to_string();
+    let project = select_project_for_setup(&client, base.project.as_deref()).await?;
+
+    if find_git_root().is_some() {
+        let _ = maybe_init(&org, &project)?;
+    }
+
+    let scope = default_setup_scope(&args.agents);
+    let home = home_dir().ok_or_else(|| anyhow!("failed to resolve HOME/USERPROFILE"))?;
+    let local_root = resolve_local_root_for_scope(scope)?;
+    let detected = detect_agents(local_root.as_deref(), &home);
+    let selected_agent = resolve_default_agent_selection(
+        args.agents.agent,
+        &detected,
+        "Select coding agent",
+        ui::is_interactive(),
+    )?;
+
+    if args.skills || !args.no_skills {
+        run_setup(
+            base.clone(),
+            AgentsSetupArgs {
+                agent: Some(map_agent_to_agent_arg(selected_agent)),
+                local: matches!(scope, InstallScope::Local),
+                global: matches!(scope, InstallScope::Global),
+                workflows: args.agents.workflows.clone(),
+                no_workflow: args.agents.no_workflow,
+                yes: true,
+                no_fetch_docs: args.agents.no_fetch_docs,
+                refresh_docs: args.agents.refresh_docs,
+                workers: args.agents.workers,
+                yolo: args.agents.yolo,
+            },
+        )
+        .await?;
+    }
+
+    if args.mcp && !args.no_mcp {
+        run_mcp_setup(
+            base.clone(),
+            AgentsMcpSetupArgs {
+                agent: Some(map_agent_to_agent_arg(selected_agent)),
+                local: matches!(scope, InstallScope::Local),
+                global: matches!(scope, InstallScope::Global),
+                yes: true,
+            },
+        )?;
+    }
+
+    if !args.no_instrument {
+        if find_git_root().is_some() {
+            run_instrument_setup(
+                base,
+                InstrumentSetupArgs {
+                    agent: Some(map_agent_to_instrument_agent_arg(selected_agent)),
+                    agent_cmd: None,
+                    workflows: args.agents.workflows,
+                    yes: true,
+                    refresh_docs: args.agents.refresh_docs,
+                    workers: args.agents.workers,
+                    languages: args.languages,
+                    tui: args.tui,
+                    background: args.background,
+                    yolo: args.agents.yolo,
+                    skip_launch: false,
+                },
+                false,
+            )
+            .await?;
+        } else if !base.json {
+            eprintln!("Skipping instrumentation: not inside a git repository.");
+        }
+    }
+
+    Ok(())
+}
+
 async fn ensure_auth(base: &mut BaseArgs) -> Result<LoginContext> {
-    if base.api_key.is_some() {
+    if matches!(base.api_key_source, Some(ArgValueSource::CommandLine)) {
         return auth::login(base).await;
     }
 
     let profiles = auth::list_profiles()?;
-    match profiles.len() {
-        0 => {
-            eprintln!("No auth profiles found. Let's set one up.\n");
-            auth::login_interactive(base).await?;
+    if base.prefer_profile {
+        return login_with_existing_or_oauth(base, &profiles).await;
+    }
+
+    if matches!(base.api_key_source, Some(ArgValueSource::EnvVariable)) {
+        return auth::login(base).await;
+    }
+
+    login_with_existing_or_oauth(base, &profiles).await
+}
+
+async fn login_with_existing_or_oauth(
+    base: &mut BaseArgs,
+    profiles: &[auth::ProfileInfo],
+) -> Result<LoginContext> {
+    if profiles.is_empty() {
+        eprintln!("No auth profiles found. Let's set one up.\n");
+        auth::login_setup_oauth(base).await?;
+        return auth::login(base).await;
+    }
+
+    let profile_name = choose_setup_profile(base, profiles)?;
+    base.profile = Some(profile_name);
+    match auth::login(base).await {
+        Ok(ctx) => Ok(ctx),
+        Err(err) if should_force_reauth(&err) => {
+            auth::login_setup_oauth(base).await?;
             auth::login(base).await
         }
-        1 => {
-            let p = &profiles[0];
-            base.profile = Some(p.name.clone());
-            auth::login(base).await
-        }
-        _ => {
-            let name = auth::select_profile_interactive(None)?
-                .ok_or_else(|| anyhow!("no profile selected"))?;
-            base.profile = Some(name);
-            auth::login(base).await
-        }
+        Err(err) => Err(err),
     }
 }
 
-async fn select_project_with_skip(
+fn choose_setup_profile(base: &BaseArgs, profiles: &[auth::ProfileInfo]) -> Result<String> {
+    if let Some(profile_name) = base.profile.as_ref().map(|value| value.trim()) {
+        if !profile_name.is_empty() {
+            return Ok(profile_name.to_string());
+        }
+    }
+
+    if let Some(org) = base.org_name.as_deref() {
+        return auth::resolve_org_to_profile(org, profiles);
+    }
+
+    profiles
+        .first()
+        .map(|profile| profile.name.clone())
+        .ok_or_else(|| anyhow!("no auth profiles found"))
+}
+
+fn should_force_reauth(err: &anyhow::Error) -> bool {
+    let msg = err.to_string();
+    msg.contains("oauth refresh token missing")
+        || msg.contains("oauth profile requested but none selected")
+        || msg.contains("re-run `bt auth login --oauth")
+}
+
+async fn select_project_for_setup(
     client: &ApiClient,
     project_name: Option<&str>,
-    quiet: bool,
-) -> Result<Option<crate::projects::api::Project>> {
+) -> Result<crate::projects::api::Project> {
     if let Some(name) = project_name {
         let project = with_spinner(
             "Loading project...",
@@ -812,12 +938,7 @@ async fn select_project_with_skip(
         )
         .await?;
         match project {
-            Some(p) => {
-                if !quiet {
-                    eprintln!("{} Select project · {}", style("✔").green(), p.name);
-                }
-                return Ok(Some(p));
-            }
+            Some(p) => return Ok(p),
             None => bail!(
                 "project '{}' not found in org '{}'",
                 name,
@@ -832,21 +953,74 @@ async fn select_project_with_skip(
     )
     .await?;
 
-    if projects.is_empty() {
-        bail!("no projects found in org '{}'", client.org_name());
+    if projects.len() == 1 && projects[0].name == "My Project" {
+        return create_or_fetch_project(client, &default_setup_project_name()).await;
     }
 
     projects.sort_by(|a, b| a.name.cmp(&b.name));
-    let mut labels: Vec<String> = projects.iter().map(|p| p.name.clone()).collect();
-    labels.push("Skip (not recommended)".to_string());
+    if !ui::is_interactive() {
+        bail!(
+            "multiple project choices available; pass --project <NAME> or run `bt setup` in an interactive terminal"
+        );
+    }
 
+    let mut labels: Vec<String> = projects.iter().map(|p| p.name.clone()).collect();
+    labels.push("Create new project".to_string());
     let selection = ui::fuzzy_select("Select project", &labels, 0)?;
 
     if selection == labels.len() - 1 {
-        Ok(None)
-    } else {
-        Ok(Some(projects[selection].clone()))
+        let default_name = default_setup_project_name();
+        let name: String = dialoguer::Input::with_theme(&ColorfulTheme::default())
+            .with_prompt("Project name")
+            .default(default_name)
+            .interact_text()?;
+        let trimmed = name.trim();
+        if trimmed.is_empty() {
+            bail!("project name cannot be empty");
+        }
+        return create_or_fetch_project(client, trimmed).await;
     }
+
+    Ok(projects[selection].clone())
+}
+
+async fn select_project_with_skip(
+    client: &ApiClient,
+    project_name: Option<&str>,
+    quiet: bool,
+) -> Result<Option<crate::projects::api::Project>> {
+    let project = select_project_for_setup(client, project_name).await?;
+    if !quiet {
+        eprintln!("{} Select project · {}", style("✔").green(), project.name);
+    }
+    Ok(Some(project))
+}
+
+async fn create_or_fetch_project(
+    client: &ApiClient,
+    name: &str,
+) -> Result<crate::projects::api::Project> {
+    if let Some(project) = crate::projects::api::get_project_by_name(client, name).await? {
+        return Ok(project);
+    }
+    match crate::projects::api::create_project(client, name).await {
+        Ok(project) => Ok(project),
+        Err(_) => crate::projects::api::get_project_by_name(client, name)
+            .await?
+            .ok_or_else(|| anyhow!("failed to create project '{name}'")),
+    }
+}
+
+fn default_setup_project_name() -> String {
+    let output = std::process::Command::new("whoami").output();
+    let user = output
+        .ok()
+        .filter(|result| result.status.success())
+        .and_then(|result| String::from_utf8(result.stdout).ok())
+        .map(|stdout| stdout.trim().to_string())
+        .filter(|name| !name.is_empty())
+        .unwrap_or_else(|| "braintrust".to_string());
+    format!("{user}-test")
 }
 
 /// Returns `true` if config was written or already matched, `false` if user declined.
@@ -884,6 +1058,14 @@ fn maybe_init(org: &str, project: &crate::projects::api::Project) -> Result<bool
     };
     config::save_local(&cfg, true)?;
     Ok(true)
+}
+
+fn default_setup_scope(args: &AgentsSetupArgs) -> InstallScope {
+    if args.local {
+        InstallScope::Local
+    } else {
+        InstallScope::Global
+    }
 }
 
 async fn run_setup(base: BaseArgs, args: AgentsSetupArgs) -> Result<()> {
@@ -1044,16 +1226,6 @@ impl LanguageArg {
     }
 }
 
-fn should_prompt_setup_action(base: &BaseArgs, args: &AgentsSetupArgs) -> bool {
-    if base.json || !ui::is_interactive() {
-        return false;
-    }
-    !args.yes
-        && !args.no_fetch_docs
-        && !args.refresh_docs
-        && args.workers == crate::sync::default_workers()
-}
-
 async fn run_instrument_setup(
     base: BaseArgs,
     args: InstrumentSetupArgs,
@@ -1067,16 +1239,14 @@ async fn run_instrument_setup(
     })?;
     let mut detected = detect_agents(Some(&root), &home);
 
-    let mut selected = if let Some(agent_arg) = args.agent {
-        map_instrument_agent_arg(agent_arg)
-    } else {
-        pick_agent_mode_target(&resolve_selected_agents(None, &detected))
-            .ok_or_else(|| anyhow!("no detected agents available for instrumentation"))?
-    };
+    let selected = resolve_default_agent_selection(
+        args.agent.map(map_instrument_agent_arg_to_agent_arg),
+        &detected,
+        "Select agent to instrument this repo",
+        ui::is_interactive() && !args.yes,
+    )?;
 
-    if args.agent.is_none() && ui::is_interactive() && !args.yes {
-        selected = prompt_instrument_agent(selected)?;
-    } else if args.agent.is_some() && base.verbose {
+    if args.agent.is_some() && base.verbose {
         eprintln!(
             "{} Select agent to instrument this repo · {}",
             style("✔").green(),
@@ -1087,23 +1257,7 @@ async fn run_instrument_setup(
     let mut hint_pending = print_hint && base.verbose;
     let selected_workflows = resolve_instrument_workflow_selection(&args, &mut hint_pending)?;
 
-    let selected_languages: Vec<LanguageArg> = if !args.languages.is_empty() {
-        args.languages.clone()
-    } else if ui::is_interactive() && !args.yes {
-        if hint_pending {
-            eprintln!(
-                "   {}",
-                style("(Un)select option with Space, confirm selection with Enter.").dim()
-            );
-        }
-        let detected_langs = detect_languages_from_dir(&std::env::current_dir()?);
-        let Some(langs) = prompt_instrument_language_selection(&detected_langs)? else {
-            bail!("instrument setup cancelled by user");
-        };
-        langs
-    } else {
-        Vec::new()
-    };
+    let selected_languages: Vec<LanguageArg> = args.languages.clone();
 
     let show_progress = !base.json;
     let mut warnings = Vec::new();
@@ -1167,26 +1321,7 @@ async fn run_instrument_setup(
     } else if args.background || args.yes || !ui::is_interactive() {
         (false, false)
     } else {
-        let pkg_mgrs = package_manager_cmds_for_languages(&selected_languages).join(", ");
-        let background_label = format!(
-            "Background (automatic) — runs autonomously; \
-             allowed package managers: {pkg_mgrs}"
-        );
-        let choices = [
-            background_label.as_str(),
-            "Interactive TUI — agent opens in its terminal UI; \
-             you review and approve each tool use",
-        ];
-        let selection = Select::with_theme(&ColorfulTheme::default())
-            .with_prompt("How do you want to run the agent?")
-            .items(&choices)
-            .default(0)
-            .interact_opt()?;
-        let Some(index) = selection else {
-            bail!("instrument setup cancelled by user");
-        };
-        let interactive = index == 1;
-        (interactive, false)
+        (true, false)
     };
 
     let docs_output_dir = root.join(".bt").join("skills").join("docs");
@@ -1287,7 +1422,7 @@ async fn run_instrument_setup(
 
 fn resolve_instrument_workflow_selection(
     args: &InstrumentSetupArgs,
-    hint_pending: &mut bool,
+    _hint_pending: &mut bool,
 ) -> Result<Vec<WorkflowArg>> {
     if !args.workflows.is_empty() {
         let mut selected = resolve_workflow_selection(&args.workflows);
@@ -1299,23 +1434,10 @@ fn resolve_instrument_workflow_selection(
         return Ok(selected);
     }
 
-    if ui::is_interactive() && !args.yes {
-        if *hint_pending {
-            eprintln!(
-                "   {}",
-                style("(Un)select option with Space, confirm selection with Enter.").dim()
-            );
-            *hint_pending = false;
-        }
-        let Some(selected) = prompt_instrument_workflow_selection()? else {
-            bail!("instrument setup cancelled by user");
-        };
-        return Ok(selected);
-    }
-
-    Ok(vec![WorkflowArg::Instrument])
+    Ok(resolve_workflow_selection(&[]))
 }
 
+#[allow(dead_code)]
 fn prompt_instrument_workflow_selection() -> Result<Option<Vec<WorkflowArg>>> {
     let choices = ["observe", "annotate", "evaluate", "deploy"];
     let defaults = [true, false, true, false];
@@ -1339,6 +1461,7 @@ fn prompt_instrument_workflow_selection() -> Result<Option<Vec<WorkflowArg>>> {
     }))
 }
 
+#[allow(dead_code)]
 fn detect_languages_from_dir(dir: &std::path::Path) -> Vec<LanguageArg> {
     // (indicator filename suffix, language)
     let indicators: &[(&str, LanguageArg)] = &[
@@ -1404,6 +1527,7 @@ fn detect_languages_from_dir(dir: &std::path::Path) -> Vec<LanguageArg> {
     found.into_iter().collect()
 }
 
+#[allow(dead_code)]
 fn prompt_instrument_language_selection(
     detected: &[LanguageArg],
 ) -> Result<Option<Vec<LanguageArg>>> {
@@ -1464,6 +1588,15 @@ fn map_agent_to_agent_arg(agent: Agent) -> AgentArg {
         Agent::Codex => AgentArg::Codex,
         Agent::Cursor => AgentArg::Cursor,
         Agent::Opencode => AgentArg::Opencode,
+    }
+}
+
+fn map_agent_to_instrument_agent_arg(agent: Agent) -> InstrumentAgentArg {
+    match agent {
+        Agent::Claude => InstrumentAgentArg::Claude,
+        Agent::Codex => InstrumentAgentArg::Codex,
+        Agent::Cursor => InstrumentAgentArg::Cursor,
+        Agent::Opencode => InstrumentAgentArg::Opencode,
     }
 }
 
@@ -1542,6 +1675,7 @@ async fn prefetch_workflow_docs(
     Ok(())
 }
 
+#[allow(dead_code)]
 fn prompt_instrument_agent(default_agent: Agent) -> Result<Agent> {
     let choices = ALL_AGENTS
         .iter()
@@ -1957,14 +2091,8 @@ fn run_mcp_setup(base: BaseArgs, args: AgentsMcpSetupArgs) -> Result<()> {
 }
 
 fn resolve_setup_selection(args: &AgentsSetupArgs, home: &Path) -> Result<SetupSelection> {
-    let mut scope = initial_scope(
-        args.local,
-        args.global,
-        args.yes,
-        YesScopeDefault::LocalIfGit,
-    );
+    let mut scope = initial_scope(args.local, args.global, args.yes, YesScopeDefault::Global);
     let interactive = ui::is_interactive() && !args.yes;
-    let mut prompted_agents: Option<Vec<Agent>> = None;
     let mut prompted_workflows: Option<Vec<WorkflowArg>> = if args.no_fetch_docs || args.no_workflow
     {
         Some(Vec::new())
@@ -1976,16 +2104,12 @@ fn resolve_setup_selection(args: &AgentsSetupArgs, home: &Path) -> Result<SetupS
         #[derive(Clone, Copy)]
         enum SetupWizardStep {
             Scope,
-            Agents,
             Workflows,
         }
 
         let mut steps = Vec::new();
         if scope.is_none() {
             steps.push(SetupWizardStep::Scope);
-        }
-        if args.agent.is_none() {
-            steps.push(SetupWizardStep::Agents);
         }
         if !args.no_fetch_docs && args.workflows.is_empty() {
             steps.push(SetupWizardStep::Workflows);
@@ -2006,24 +2130,6 @@ fn resolve_setup_selection(args: &AgentsSetupArgs, home: &Path) -> Result<SetupS
                         idx -= 1;
                     }
                 },
-                SetupWizardStep::Agents => {
-                    let current_scope = scope.ok_or_else(|| anyhow!("scope not selected"))?;
-                    let local_root = resolve_local_root_for_scope(current_scope)?;
-                    let detected = detect_agents(local_root.as_deref(), home);
-                    let defaults = resolve_selected_agents(None, &detected);
-                    match prompt_agents_selection(&defaults)? {
-                        Some(selected) => {
-                            prompted_agents = Some(selected);
-                            idx += 1;
-                        }
-                        None => {
-                            if idx == 0 {
-                                bail!("setup cancelled by user");
-                            }
-                            idx -= 1;
-                        }
-                    }
-                }
                 SetupWizardStep::Workflows => {
                     let defaults = resolve_workflow_selection(&[]);
                     match prompt_workflows_selection(&defaults)? {
@@ -2055,13 +2161,13 @@ fn resolve_setup_selection(args: &AgentsSetupArgs, home: &Path) -> Result<SetupS
     };
     let local_root = resolve_local_root_for_scope(scope)?;
     let detected = detect_agents(local_root.as_deref(), home);
-    let selected_agents = match prompted_agents {
-        Some(value) => value,
-        None => resolve_selected_agents(args.agent, &detected),
-    };
-    if selected_agents.is_empty() {
-        bail!("no agents selected for installation");
-    }
+    let selected_agent = resolve_default_agent_selection(
+        args.agent,
+        &detected,
+        "Select agent to configure",
+        interactive,
+    )?;
+    let selected_agents = vec![selected_agent];
 
     let selected_workflows = if args.no_fetch_docs {
         Vec::new()
@@ -2083,23 +2189,17 @@ fn resolve_setup_selection(args: &AgentsSetupArgs, home: &Path) -> Result<SetupS
 fn resolve_mcp_selection(args: &AgentsMcpSetupArgs, home: &Path) -> Result<McpSelection> {
     let mut scope = initial_scope(args.local, args.global, args.yes, YesScopeDefault::Global);
     let interactive = ui::is_interactive() && !args.yes;
-    let mut prompted_agents: Option<Vec<Agent>> = None;
 
     if interactive {
         #[derive(Clone, Copy)]
         enum McpWizardStep {
             Scope,
-            Agents,
         }
 
         let mut steps = Vec::new();
         if scope.is_none() {
             steps.push(McpWizardStep::Scope);
         }
-        if args.agent.is_none() {
-            steps.push(McpWizardStep::Agents);
-        }
-
         let mut idx = 0usize;
         while idx < steps.len() {
             match steps[idx] {
@@ -2115,24 +2215,6 @@ fn resolve_mcp_selection(args: &AgentsMcpSetupArgs, home: &Path) -> Result<McpSe
                         idx -= 1;
                     }
                 },
-                McpWizardStep::Agents => {
-                    let current_scope = scope.ok_or_else(|| anyhow!("scope not selected"))?;
-                    let local_root = resolve_local_root_for_scope(current_scope)?;
-                    let detected = detect_agents(local_root.as_deref(), home);
-                    let defaults = resolve_selected_agents(None, &detected);
-                    match prompt_agents_selection(&defaults)? {
-                        Some(selected) => {
-                            prompted_agents = Some(selected);
-                            idx += 1;
-                        }
-                        None => {
-                            if idx == 0 {
-                                bail!("MCP setup cancelled by user");
-                            }
-                            idx -= 1;
-                        }
-                    }
-                }
             }
         }
     }
@@ -2149,13 +2231,13 @@ fn resolve_mcp_selection(args: &AgentsMcpSetupArgs, home: &Path) -> Result<McpSe
     };
     let local_root = resolve_local_root_for_scope(scope)?;
     let detected = detect_agents(local_root.as_deref(), home);
-    let selected_agents = match prompted_agents {
-        Some(value) => value,
-        None => resolve_selected_agents(args.agent, &detected),
-    };
-    if selected_agents.is_empty() {
-        bail!("no agents selected for MCP setup");
-    }
+    let selected_agent = resolve_default_agent_selection(
+        args.agent,
+        &detected,
+        "Select agent to configure MCP for",
+        interactive,
+    )?;
+    let selected_agents = vec![selected_agent];
 
     Ok(McpSelection {
         scope,
@@ -2358,7 +2440,7 @@ fn prompt_scope_selection(prompt: &str) -> Result<Option<InstallScope>> {
     let idx = Select::with_theme(&ColorfulTheme::default())
         .with_prompt(prompt)
         .items(&choices)
-        .default(0)
+        .default(1)
         .interact_opt()?;
     Ok(idx.map(|i| {
         if i == 0 {
@@ -2369,29 +2451,21 @@ fn prompt_scope_selection(prompt: &str) -> Result<Option<InstallScope>> {
     }))
 }
 
-fn prompt_agents_selection(defaults: &[Agent]) -> Result<Option<Vec<Agent>>> {
-    let default_set: BTreeSet<Agent> = defaults.iter().copied().collect();
+fn prompt_agent_selection(prompt: &str, default: Agent) -> Result<Option<Agent>> {
     let labels = ALL_AGENTS
         .iter()
         .map(|agent| agent.as_str())
         .collect::<Vec<_>>();
-    let default_flags = ALL_AGENTS
+    let default_index = ALL_AGENTS
         .iter()
-        .map(|agent| default_set.contains(agent))
-        .collect::<Vec<_>>();
-
-    let selected = MultiSelect::with_theme(&ColorfulTheme::default())
-        .with_prompt("Select agents to configure (Esc: back)")
+        .position(|agent| *agent == default)
+        .unwrap_or(0);
+    let selected = FuzzySelect::with_theme(&ColorfulTheme::default())
+        .with_prompt(prompt)
         .items(&labels)
-        .defaults(&default_flags)
+        .default(default_index)
         .interact_opt()?;
-
-    Ok(selected.map(|indexes| {
-        indexes
-            .into_iter()
-            .map(|index| ALL_AGENTS[index])
-            .collect::<Vec<_>>()
-    }))
+    Ok(selected.map(|index| ALL_AGENTS[index]))
 }
 
 fn prompt_workflows_selection(defaults: &[WorkflowArg]) -> Result<Option<Vec<WorkflowArg>>> {
@@ -2451,36 +2525,55 @@ fn resolve_scope_from_flags(
     })
 }
 
-fn resolve_selected_agents(
+fn resolve_default_agent_selection(
     requested: Option<AgentArg>,
     detected: &[DetectionSignal],
-) -> Vec<Agent> {
-    let Some(arg) = requested else {
-        let mut inferred = BTreeSet::new();
-        for signal in detected {
-            inferred.insert(signal.agent);
-        }
-        if inferred.is_empty() {
-            return ALL_AGENTS.to_vec();
-        }
-        return inferred.into_iter().collect();
-    };
+    prompt: &str,
+    allow_prompt: bool,
+) -> Result<Agent> {
+    if let Some(arg) = requested {
+        return Ok(map_agent_arg(arg));
+    }
 
-    let agent = match arg {
-        AgentArg::Claude => Agent::Claude,
-        AgentArg::Codex => Agent::Codex,
-        AgentArg::Cursor => Agent::Cursor,
-        AgentArg::Opencode => Agent::Opencode,
-    };
-    vec![agent]
+    let path_agents = detected_agents_on_path(detected);
+    if path_agents.len() == 1 {
+        return Ok(path_agents[0]);
+    }
+
+    if allow_prompt {
+        let default = pick_agent_mode_target(&path_agents).unwrap_or(Agent::Codex);
+        return prompt_agent_selection(prompt, default)?
+            .ok_or_else(|| anyhow!("setup cancelled by user"));
+    }
+
+    bail!("multiple coding agents available; pass --agent <AGENT> or re-run in an interactive terminal");
 }
 
+#[allow(dead_code)]
 fn map_instrument_agent_arg(agent: InstrumentAgentArg) -> Agent {
     match agent {
         InstrumentAgentArg::Claude => Agent::Claude,
         InstrumentAgentArg::Codex => Agent::Codex,
         InstrumentAgentArg::Cursor => Agent::Cursor,
         InstrumentAgentArg::Opencode => Agent::Opencode,
+    }
+}
+
+fn map_instrument_agent_arg_to_agent_arg(agent: InstrumentAgentArg) -> AgentArg {
+    match agent {
+        InstrumentAgentArg::Claude => AgentArg::Claude,
+        InstrumentAgentArg::Codex => AgentArg::Codex,
+        InstrumentAgentArg::Cursor => AgentArg::Cursor,
+        InstrumentAgentArg::Opencode => AgentArg::Opencode,
+    }
+}
+
+fn map_agent_arg(agent: AgentArg) -> Agent {
+    match agent {
+        AgentArg::Claude => Agent::Claude,
+        AgentArg::Codex => Agent::Codex,
+        AgentArg::Cursor => Agent::Cursor,
+        AgentArg::Opencode => Agent::Opencode,
     }
 }
 
@@ -2496,6 +2589,16 @@ fn pick_agent_mode_target(candidates: &[Agent]) -> Option<Agent> {
         }
     }
     candidates.first().copied()
+}
+
+fn detected_agents_on_path(detected: &[DetectionSignal]) -> Vec<Agent> {
+    let mut agents = BTreeSet::new();
+    for signal in detected {
+        if signal.reason.contains("binary found in PATH") {
+            agents.insert(signal.agent);
+        }
+    }
+    agents.into_iter().collect()
 }
 
 fn resolve_workflow_selection(requested: &[WorkflowArg]) -> Vec<WorkflowArg> {
@@ -3226,23 +3329,32 @@ mod tests {
     use std::time::{SystemTime, UNIX_EPOCH};
 
     #[test]
-    fn no_agent_arg_defaults_to_all_agents() {
-        let detected = vec![];
-        let resolved = resolve_selected_agents(None, &detected);
-        assert_eq!(
-            resolved,
-            vec![Agent::Claude, Agent::Codex, Agent::Cursor, Agent::Opencode]
-        );
+    fn single_path_agent_is_selected_by_default() {
+        let detected = vec![DetectionSignal {
+            agent: Agent::Codex,
+            reason: "`codex` binary found in PATH".to_string(),
+        }];
+        let resolved =
+            resolve_default_agent_selection(None, &detected, "Select coding agent", false)
+                .expect("resolve default agent");
+        assert_eq!(resolved, Agent::Codex);
     }
 
     #[test]
-    fn detection_drives_default_selection() {
-        let detected = vec![DetectionSignal {
-            agent: Agent::Codex,
-            reason: "hint".to_string(),
-        }];
-        let resolved = resolve_selected_agents(None, &detected);
-        assert_eq!(resolved, vec![Agent::Codex]);
+    fn default_agent_selection_requires_prompt_when_path_is_ambiguous() {
+        let detected = vec![
+            DetectionSignal {
+                agent: Agent::Codex,
+                reason: "`codex` binary found in PATH".to_string(),
+            },
+            DetectionSignal {
+                agent: Agent::Claude,
+                reason: "`claude` binary found in PATH".to_string(),
+            },
+        ];
+        let err = resolve_default_agent_selection(None, &detected, "Select coding agent", false)
+            .expect_err("ambiguous path detection should fail");
+        assert!(err.to_string().contains("pass --agent"));
     }
 
     #[test]
@@ -3394,7 +3506,7 @@ mod tests {
     }
 
     #[test]
-    fn resolve_instrument_workflows_default_to_instrument() {
+    fn resolve_instrument_workflows_default_to_all() {
         let args = InstrumentSetupArgs {
             agent: Some(InstrumentAgentArg::Codex),
             agent_cmd: None,
@@ -3411,7 +3523,7 @@ mod tests {
 
         let selected = resolve_instrument_workflow_selection(&args, &mut false)
             .expect("resolve instrument workflows");
-        assert_eq!(selected, vec![WorkflowArg::Instrument]);
+        assert_eq!(selected, resolve_workflow_selection(&[]));
     }
 
     #[test]

--- a/src/setup/mod.rs
+++ b/src/setup/mod.rs
@@ -792,16 +792,7 @@ async fn run_setup_wizard(mut base: BaseArgs, flags: WizardFlags) -> Result<()> 
     Ok(())
 }
 
-async fn run_default_setup(mut base: BaseArgs, args: SetupArgs) -> Result<()> {
-    let login_ctx = ensure_auth(&mut base).await?;
-    let client = ApiClient::new(&login_ctx)?;
-    let org = client.org_name().to_string();
-    let project = select_project_for_setup(&client, base.project.as_deref()).await?;
-
-    if find_git_root().is_some() {
-        let _ = maybe_init(&org, &project)?;
-    }
-
+async fn run_default_setup(base: BaseArgs, args: SetupArgs) -> Result<()> {
     let scope = default_setup_scope(&args.agents);
     let home = home_dir().ok_or_else(|| anyhow!("failed to resolve HOME/USERPROFILE"))?;
     let local_root = resolve_local_root_for_scope(scope)?;
@@ -1622,8 +1613,9 @@ fn skill_config_path(
     let root = scope_root(scope, local_root, home)?;
     let path = match agent {
         Agent::Claude => root.join(".claude/skills/braintrust/SKILL.md"),
-        Agent::Codex | Agent::Opencode => root.join(".agents/skills/braintrust/SKILL.md"),
-        Agent::Cursor => root.join(".cursor/rules/braintrust.mdc"),
+        Agent::Codex | Agent::Opencode | Agent::Cursor => {
+            root.join(".agents/skills/braintrust/SKILL.md")
+        }
     };
     Ok(path)
 }
@@ -2365,32 +2357,9 @@ fn doctor_agent_status(
         .collect::<Vec<_>>();
     let detected_any = !detected_signals.is_empty();
 
-    let config_path = match (agent, scope) {
-        (Agent::Claude, InstallScope::Local) => local_root
-            .map(|root| root.join(".claude/skills/braintrust/SKILL.md"))
-            .map(|p| p.display().to_string()),
-        (Agent::Claude, InstallScope::Global) => Some(
-            home.join(".claude/skills/braintrust/SKILL.md")
-                .display()
-                .to_string(),
-        ),
-        (Agent::Codex, InstallScope::Local) | (Agent::Opencode, InstallScope::Local) => local_root
-            .map(|root| root.join(".agents/skills/braintrust/SKILL.md"))
-            .map(|p| p.display().to_string()),
-        (Agent::Codex, InstallScope::Global) | (Agent::Opencode, InstallScope::Global) => Some(
-            home.join(".agents/skills/braintrust/SKILL.md")
-                .display()
-                .to_string(),
-        ),
-        (Agent::Cursor, InstallScope::Local) => local_root
-            .map(|root| root.join(".cursor/skills/braintrust/SKILL.md"))
-            .map(|p| p.display().to_string()),
-        (Agent::Cursor, InstallScope::Global) => Some(
-            home.join(".cursor/skills/braintrust/SKILL.md")
-                .display()
-                .to_string(),
-        ),
-    };
+    let config_path = skill_config_path(agent, scope, local_root, home)
+        .ok()
+        .map(|path| path.display().to_string());
 
     let configured = config_path
         .as_deref()
@@ -3866,7 +3835,14 @@ mod tests {
         let home = std::env::temp_dir();
         let status = doctor_agent_status(Agent::Cursor, InstallScope::Global, None, &home, &[]);
         assert!(!status.configured);
-        assert!(status.config_path.is_some());
+        assert_eq!(
+            status.config_path,
+            Some(
+                home.join(".agents/skills/braintrust/SKILL.md")
+                    .display()
+                    .to_string()
+            )
+        );
         assert!(status.notes.is_empty());
     }
 

--- a/src/setup/mod.rs
+++ b/src/setup/mod.rs
@@ -784,13 +784,14 @@ async fn run_setup_wizard(mut base: BaseArgs, flags: WizardFlags) -> Result<()> 
 }
 
 async fn run_default_setup(mut base: BaseArgs, args: SetupArgs) -> Result<()> {
-    let project_flag = base.project.clone();
-    let login_ctx = ensure_auth(&mut base).await?;
-    let client = ApiClient::new(&login_ctx)?;
-    let org = client.org_name().to_string();
-    let project = select_project_with_skip(&client, project_flag.as_deref(), true).await?;
-    if let Some(ref project) = project {
-        if find_git_root().is_some() {
+    let should_prepare_project = should_prepare_project_context(args.no_instrument);
+    if should_prepare_project {
+        let project_flag = base.project.clone();
+        let login_ctx = ensure_auth(&mut base).await?;
+        let client = ApiClient::new(&login_ctx)?;
+        let org = client.org_name().to_string();
+        let project = select_project_with_skip(&client, project_flag.as_deref(), true).await?;
+        if let Some(ref project) = project {
             let _ = maybe_init(&org, project)?;
         }
     }
@@ -865,6 +866,10 @@ async fn run_default_setup(mut base: BaseArgs, args: SetupArgs) -> Result<()> {
     Ok(())
 }
 
+fn should_prepare_project_context(no_instrument: bool) -> bool {
+    !no_instrument && find_git_root().is_some()
+}
+
 async fn ensure_auth(base: &mut BaseArgs) -> Result<LoginContext> {
     if matches!(base.api_key_source, Some(ArgValueSource::CommandLine)) {
         return auth::login(base).await;
@@ -892,8 +897,9 @@ async fn login_with_existing_or_oauth(
         return auth::login(base).await;
     }
 
-    let profile_name = choose_setup_profile(base, profiles)?;
-    base.profile = Some(profile_name);
+    if let Some(profile_name) = choose_setup_profile(base, profiles)? {
+        base.profile = Some(profile_name);
+    }
     match auth::login(base).await {
         Ok(ctx) => Ok(ctx),
         Err(err) if auth::is_missing_credential_error(&err) => {
@@ -904,21 +910,26 @@ async fn login_with_existing_or_oauth(
     }
 }
 
-fn choose_setup_profile(base: &BaseArgs, profiles: &[auth::ProfileInfo]) -> Result<String> {
+fn choose_setup_profile(base: &BaseArgs, profiles: &[auth::ProfileInfo]) -> Result<Option<String>> {
     if let Some(profile_name) = base.profile.as_ref().map(|value| value.trim()) {
         if !profile_name.is_empty() {
-            return Ok(profile_name.to_string());
+            return Ok(Some(profile_name.to_string()));
         }
     }
 
     if let Some(org) = base.org_name.as_deref() {
-        return auth::resolve_org_to_profile(org, profiles);
+        return auth::resolve_org_to_profile(org, profiles).map(Some);
     }
 
-    profiles
-        .first()
-        .map(|profile| profile.name.clone())
-        .ok_or_else(|| anyhow!("no auth profiles found"))
+    if profiles.len() == 1 {
+        return Ok(profiles.first().map(|profile| profile.name.clone()));
+    }
+
+    if ui::is_interactive() {
+        return auth::select_profile_interactive(None);
+    }
+
+    bail!("multiple auth profiles found; pass --profile <NAME> or --org <ORG>, or re-run in an interactive terminal")
 }
 
 async fn select_project_for_setup(
@@ -2726,6 +2737,30 @@ fn detect_agents(local_root: Option<&Path>, home: &Path) -> Vec<DetectionSignal>
             Agent::Claude,
             true,
             "`claude` binary found in PATH",
+        );
+    }
+    if command_exists("codex") {
+        add_signal(
+            &mut by_agent,
+            Agent::Codex,
+            true,
+            "`codex` binary found in PATH",
+        );
+    }
+    if command_exists("cursor-agent") {
+        add_signal(
+            &mut by_agent,
+            Agent::Cursor,
+            true,
+            "`cursor-agent` binary found in PATH",
+        );
+    }
+    if command_exists("opencode") {
+        add_signal(
+            &mut by_agent,
+            Agent::Opencode,
+            true,
+            "`opencode` binary found in PATH",
         );
     }
 

--- a/src/setup/mod.rs
+++ b/src/setup/mod.rs
@@ -108,7 +108,7 @@ pub struct SetupArgs {
     interactive: bool,
 
     /// Show additional setup output
-    #[arg(long, short = 'v')]
+    #[arg(long, short = 'v', global = true)]
     verbose: bool,
 
     /// Deprecated: use --no-skills --no-mcp instead
@@ -190,7 +190,7 @@ struct AgentsMcpSetupArgs {
 #[derive(Debug, Clone, Args)]
 struct InstrumentSetupArgs {
     /// Agent to run for instrumentation
-    #[arg(long = "agent", value_enum)]
+    #[arg(long = "agent", alias = "agents", value_enum)]
     agent: Option<InstrumentAgentArg>,
 
     /// Command to run the selected agent (overrides built-in defaults)
@@ -201,8 +201,8 @@ struct InstrumentSetupArgs {
     #[arg(long = "workflow", value_enum)]
     workflows: Vec<WorkflowArg>,
 
-    #[arg(skip)]
-    skip_workflow_docs: bool,
+    #[arg(long = "no-workflow", conflicts_with = "workflows")]
+    no_workflow: bool,
 
     #[arg(skip)]
     yes: bool,
@@ -424,11 +424,9 @@ struct SkillsAliasResult {
 }
 
 pub async fn run_setup_top(mut base: BaseArgs, mut args: SetupArgs) -> Result<()> {
-    if args.verbose {
-        base.verbose = true;
-        crate::ui::set_quiet(false);
-        crate::ui::set_animations_enabled(true);
-    }
+    base.verbose = args.verbose;
+    crate::ui::set_quiet(!args.verbose);
+    crate::ui::set_animations_enabled(args.verbose);
     // Deprecated flag: --no-mcp-skill is equivalent to --no-skills --no-mcp
     if args.no_mcp_skill {
         args.no_skills = true;
@@ -753,7 +751,7 @@ async fn run_setup_wizard(mut base: BaseArgs, flags: WizardFlags) -> Result<()> 
                     agent: instrument_agent,
                     agent_cmd: None,
                     workflows: flag_workflows,
-                    skip_workflow_docs: flag_no_workflow,
+                    no_workflow: flag_no_workflow,
                     yes: false,
                     refresh_docs: false,
                     workers: crate::sync::default_workers(),
@@ -845,7 +843,7 @@ async fn run_default_setup(mut base: BaseArgs, args: SetupArgs) -> Result<()> {
                     agent: Some(map_agent_to_instrument_agent_arg(selected_agent)),
                     agent_cmd: None,
                     workflows: args.agents.workflows,
-                    skip_workflow_docs: args.agents.no_workflow,
+                    no_workflow: args.agents.no_workflow,
                     yes: false,
                     refresh_docs: args.agents.refresh_docs,
                     workers: args.agents.workers,
@@ -1304,7 +1302,7 @@ async fn run_instrument_setup(
             local: true,
             global: false,
             workflows: selected_workflows.clone(),
-            no_workflow: args.skip_workflow_docs,
+            no_workflow: args.no_workflow,
             yes: true,
             refresh_docs: args.refresh_docs,
             workers: args.workers,
@@ -1436,7 +1434,7 @@ fn resolve_instrument_workflow_selection(
     args: &InstrumentSetupArgs,
     _hint_pending: &mut bool,
 ) -> Result<Vec<WorkflowArg>> {
-    if args.skip_workflow_docs {
+    if args.no_workflow {
         return Ok(Vec::new());
     }
 
@@ -3593,7 +3591,7 @@ mod tests {
             agent: Some(InstrumentAgentArg::Codex),
             agent_cmd: None,
             workflows: vec![WorkflowArg::Evaluate],
-            skip_workflow_docs: false,
+            no_workflow: false,
             yes: true,
             refresh_docs: false,
             workers: crate::sync::default_workers(),
@@ -3618,7 +3616,7 @@ mod tests {
             agent: Some(InstrumentAgentArg::Codex),
             agent_cmd: None,
             workflows: Vec::new(),
-            skip_workflow_docs: false,
+            no_workflow: false,
             yes: true,
             refresh_docs: false,
             workers: crate::sync::default_workers(),
@@ -3635,12 +3633,12 @@ mod tests {
     }
 
     #[test]
-    fn resolve_instrument_workflows_honors_skip_workflow_docs() {
+    fn resolve_instrument_workflows_honors_no_workflow() {
         let args = InstrumentSetupArgs {
             agent: Some(InstrumentAgentArg::Codex),
             agent_cmd: None,
             workflows: vec![WorkflowArg::Evaluate],
-            skip_workflow_docs: true,
+            no_workflow: true,
             yes: true,
             refresh_docs: false,
             workers: crate::sync::default_workers(),

--- a/src/setup/mod.rs
+++ b/src/setup/mod.rs
@@ -111,10 +111,6 @@ pub struct SetupArgs {
     #[arg(long, short = 'v')]
     verbose: bool,
 
-    /// Deprecated: quiet is now the default; this flag is accepted as a no-op
-    #[arg(long, hide = true)]
-    quiet: bool,
-
     /// Deprecated: use --no-skills --no-mcp instead
     #[arg(long, hide = true, conflicts_with = "skills", conflicts_with = "mcp")]
     no_mcp_skill: bool,
@@ -235,7 +231,7 @@ struct InstrumentSetupArgs {
     tui: bool,
 
     /// Run the agent in background (non-interactive) mode
-    #[arg(long, conflicts_with = "tui", alias = "quiet")]
+    #[arg(long, conflicts_with = "tui")]
     background: bool,
 
     /// Grant the agent full permissions (bypass permission prompts)
@@ -3660,13 +3656,6 @@ mod tests {
         let selected = resolve_instrument_workflow_selection(&args, &mut false)
             .expect("resolve instrument workflows");
         assert!(selected.is_empty());
-    }
-
-    #[test]
-    fn setup_accepts_deprecated_quiet_flag() {
-        let parsed = SetupArgsHarness::try_parse_from(["bt", "--quiet"]).expect("parse");
-        assert!(parsed.setup.quiet);
-        assert!(!parsed.setup.verbose);
     }
 
     #[test]

--- a/src/setup/mod.rs
+++ b/src/setup/mod.rs
@@ -362,6 +362,8 @@ struct AgentInstallResult {
 #[derive(Debug, Clone, Serialize)]
 struct DetectionSignal {
     agent: Agent,
+    #[serde(default)]
+    on_path: bool,
     reason: String,
 }
 
@@ -646,24 +648,16 @@ async fn run_setup_wizard(mut base: BaseArgs, flags: WizardFlags) -> Result<()> 
         let home = home_dir().ok_or_else(|| anyhow!("failed to resolve HOME/USERPROFILE"))?;
         let local_root = resolve_local_root_for_scope(scope)?;
         let detected = detect_agents(local_root.as_deref(), &home);
-        let agents = vec![resolve_default_agent_selection(
-            flag_agent,
-            &detected,
-            "Select coding agent",
-            true,
-        )?];
+        let selected_agent =
+            resolve_default_agent_selection(flag_agent, &detected, "Select coding agent", true)?;
         if verbose && flag_agent.is_some() {
-            let agent_names: Vec<String> = agents
-                .iter()
-                .map(|a| style(a.as_str()).green().to_string())
-                .collect();
             eprintln!(
-                "{} Select agents to configure · {}",
+                "{} Select agent to configure · {}",
                 style("✔").green(),
-                agent_names.join(", ")
+                style(selected_agent.as_str()).green()
             );
         }
-        Some((scope, agents, home))
+        Some((scope, selected_agent, home))
     } else {
         None
     };
@@ -672,11 +666,11 @@ async fn run_setup_wizard(mut base: BaseArgs, flags: WizardFlags) -> Result<()> 
         if verbose {
             eprintln!("   {}", style("Skills:").bold());
         }
-        if let Some((scope, _, _)) = setup_context {
+        if let Some((scope, selected_agent, _)) = setup_context.as_ref() {
             let args = AgentsSetupArgs {
-                agent: flag_agent,
-                local: matches!(scope, InstallScope::Local),
-                global: matches!(scope, InstallScope::Global),
+                agent: Some(map_agent_to_agent_arg(*selected_agent)),
+                local: matches!(*scope, InstallScope::Local),
+                global: matches!(*scope, InstallScope::Global),
                 workflows: Vec::new(),
                 no_workflow: flag_no_workflow,
                 yes: true,
@@ -701,9 +695,10 @@ async fn run_setup_wizard(mut base: BaseArgs, flags: WizardFlags) -> Result<()> 
         if verbose {
             eprintln!("   {}", style("MCP:").bold());
         }
-        if let Some((scope, ref agents, ref home)) = setup_context {
-            let local_root = resolve_local_root_for_scope(scope)?;
-            let outcome = execute_mcp_install(scope, local_root.as_deref(), home, agents);
+        if let Some((scope, selected_agent, home)) = setup_context.as_ref() {
+            let local_root = resolve_local_root_for_scope(*scope)?;
+            let outcome =
+                execute_mcp_install(*scope, local_root.as_deref(), home, &[*selected_agent]);
             for r in &outcome.results {
                 if verbose {
                     print_wizard_agent_result(r);
@@ -712,7 +707,7 @@ async fn run_setup_wizard(mut base: BaseArgs, flags: WizardFlags) -> Result<()> 
                     had_failures = true;
                 }
             }
-            if outcome.installed_count == 0 && !agents.is_empty() {
+            if outcome.installed_count == 0 {
                 had_failures = true;
             }
         }
@@ -750,12 +745,17 @@ async fn run_setup_wizard(mut base: BaseArgs, flags: WizardFlags) -> Result<()> 
                 .interact()?
         };
         if instrument {
-            let instrument_agent = flag_agent.map(|a| match a {
-                AgentArg::Claude => InstrumentAgentArg::Claude,
-                AgentArg::Codex => InstrumentAgentArg::Codex,
-                AgentArg::Cursor => InstrumentAgentArg::Cursor,
-                AgentArg::Opencode => InstrumentAgentArg::Opencode,
-            });
+            let instrument_agent = setup_context
+                .as_ref()
+                .map(|(_, agent, _)| map_agent_to_instrument_agent_arg(*agent))
+                .or_else(|| {
+                    flag_agent.map(|a| match a {
+                        AgentArg::Claude => InstrumentAgentArg::Claude,
+                        AgentArg::Codex => InstrumentAgentArg::Codex,
+                        AgentArg::Cursor => InstrumentAgentArg::Cursor,
+                        AgentArg::Opencode => InstrumentAgentArg::Opencode,
+                    })
+                });
             run_instrument_setup(
                 base,
                 InstrumentSetupArgs {
@@ -792,7 +792,18 @@ async fn run_setup_wizard(mut base: BaseArgs, flags: WizardFlags) -> Result<()> 
     Ok(())
 }
 
-async fn run_default_setup(base: BaseArgs, args: SetupArgs) -> Result<()> {
+async fn run_default_setup(mut base: BaseArgs, args: SetupArgs) -> Result<()> {
+    let project_flag = base.project.clone();
+    let login_ctx = ensure_auth(&mut base).await?;
+    let client = ApiClient::new(&login_ctx)?;
+    let org = client.org_name().to_string();
+    let project = select_project_with_skip(&client, project_flag.as_deref(), true).await?;
+    if let Some(ref project) = project {
+        if find_git_root().is_some() {
+            let _ = maybe_init(&org, project)?;
+        }
+    }
+
     let scope = default_setup_scope(&args.agents);
     let home = home_dir().ok_or_else(|| anyhow!("failed to resolve HOME/USERPROFILE"))?;
     let local_root = resolve_local_root_for_scope(scope)?;
@@ -844,7 +855,7 @@ async fn run_default_setup(base: BaseArgs, args: SetupArgs) -> Result<()> {
                     agent_cmd: None,
                     workflows: args.agents.workflows,
                     skip_workflow_docs: args.agents.no_workflow,
-                    yes: true,
+                    yes: false,
                     refresh_docs: args.agents.refresh_docs,
                     workers: args.agents.workers,
                     languages: args.languages,
@@ -953,6 +964,10 @@ async fn select_project_for_setup(
     )
     .await?;
 
+    if projects.is_empty() {
+        bail!("no projects found in org '{}'", client.org_name());
+    }
+
     if projects.len() == 1 && projects[0].name == "My Project" {
         return create_or_fetch_project(client, &default_setup_project_name()).await;
     }
@@ -1005,9 +1020,15 @@ async fn create_or_fetch_project(
     }
     match crate::projects::api::create_project(client, name).await {
         Ok(project) => Ok(project),
-        Err(_) => crate::projects::api::get_project_by_name(client, name)
-            .await?
-            .ok_or_else(|| anyhow!("failed to create project '{name}'")),
+        Err(err) => match crate::projects::api::get_project_by_name(client, name).await {
+            Ok(Some(project)) => Ok(project),
+            Ok(None) => Err(err).context(format!(
+                "failed to create project '{name}' and project was not found afterwards"
+            )),
+            Err(fetch_err) => Err(fetch_err).context(format!(
+                "failed to create project '{name}' after initial create error: {err}"
+            )),
+        },
     }
 }
 
@@ -1313,7 +1334,7 @@ async fn run_instrument_setup(
     // --tui:        interactive TUI
     // --background: background, restricted to language package managers
     // --yes or non-interactive terminal: background, restricted to language package managers
-    // Otherwise: ask the user.
+    // Otherwise: default to interactive TUI.
     let (run_interactive, bypass_permissions) = if args.tui {
         (true, false)
     } else if args.yolo {
@@ -1357,14 +1378,14 @@ async fn run_instrument_setup(
 
     if run_interactive {
         eprintln!();
-        eprintln!("Claude Code is opening in interactive mode.");
+        eprintln!("{} is opening in interactive mode.", selected.as_str());
         eprintln!("The instrumentation task is pre-loaded. Press Enter to begin.");
         eprintln!("Task file: {}", task_path.display());
         eprintln!();
     }
 
-    let show_output = !base.json && !args.background;
-    let status = if args.background && !base.json {
+    let show_output = !base.json && run_interactive;
+    let status = if !run_interactive && !base.json {
         with_spinner(
             "Running agent instrumentation…",
             run_agent_invocation(&root, &invocation, false),
@@ -1771,39 +1792,56 @@ fn resolve_instrument_invocation(
     }
 
     let invocation = match agent {
-        Agent::Codex => InstrumentInvocation::Program {
-            program: "codex".to_string(),
-            args: vec!["exec".to_string(), "-".to_string()],
-            stdin_file: Some(task_path.to_path_buf()),
-            prompt_file_arg: None,
-            initial_prompt: None,
-            stream_json: false,
-            interactive,
-        },
+        Agent::Codex => {
+            let mut codex_args = vec![];
+            if bypass_permissions {
+                codex_args.push("--dangerously-bypass-approvals-and-sandbox".to_string());
+            }
+            if interactive {
+                InstrumentInvocation::Program {
+                    program: "codex".to_string(),
+                    args: codex_args,
+                    stdin_file: None,
+                    prompt_file_arg: Some(task_path.to_path_buf()),
+                    initial_prompt: None,
+                    stream_json: false,
+                    interactive: true,
+                }
+            } else {
+                codex_args.extend(["exec".to_string(), "-".to_string()]);
+                InstrumentInvocation::Program {
+                    program: "codex".to_string(),
+                    args: codex_args,
+                    stdin_file: Some(task_path.to_path_buf()),
+                    prompt_file_arg: None,
+                    initial_prompt: None,
+                    stream_json: false,
+                    interactive: false,
+                }
+            }
+        }
         Agent::Claude => {
             if interactive {
-                // In interactive mode the full task goes into --append-system-prompt so
-                // Claude already knows what to do.  A short initial user message is passed
-                // as the positional arg so Claude immediately starts working — the user only
-                // needs to press Enter once on a short, clear prompt rather than a wall of
-                // raw task markdown.
-                let task_content = std::fs::read_to_string(task_path)
-                    .with_context(|| format!("failed to read task file {}", task_path.display()))?;
+                let permission_mode = if bypass_permissions {
+                    "bypassPermissions"
+                } else {
+                    "acceptEdits"
+                };
                 InstrumentInvocation::Program {
                     program: "claude".to_string(),
                     args: vec![
-                        "--append-system-prompt".to_string(),
-                        task_content,
+                        "--permission-mode".to_string(),
+                        permission_mode.to_string(),
+                        "--settings".to_string(),
+                        format!(r#"{{"defaultMode": "{permission_mode}"}}"#),
                         "--disallowedTools".to_string(),
-                        "EnterPlanMode".to_string(),
+                        "ExitPlanMode,EnterPlanMode".to_string(),
                         "--name".to_string(),
                         "Braintrust: Instrument".to_string(),
                     ],
                     stdin_file: None,
-                    prompt_file_arg: None,
-                    initial_prompt: Some(
-                        "Please begin the Braintrust instrumentation task.".to_string(),
-                    ),
+                    prompt_file_arg: Some(task_path.to_path_buf()),
+                    initial_prompt: None,
                     stream_json: false,
                     interactive: true,
                 }
@@ -1848,21 +1886,39 @@ fn resolve_instrument_invocation(
             stream_json: false,
             interactive,
         },
-        Agent::Cursor => InstrumentInvocation::Program {
-            program: "cursor-agent".to_string(),
-            args: vec![
-                "-p".to_string(),
-                "-f".to_string(),
-                "--output-format".to_string(),
-                "stream-json".to_string(),
-                "--stream-partial-output".to_string(),
-            ],
-            stdin_file: None,
-            prompt_file_arg: Some(task_path.to_path_buf()),
-            initial_prompt: None,
-            stream_json: true,
-            interactive,
-        },
+        Agent::Cursor => {
+            let mut cursor_args = vec![];
+            if bypass_permissions {
+                cursor_args.push("--yolo".to_string());
+            }
+            if interactive {
+                InstrumentInvocation::Program {
+                    program: "cursor-agent".to_string(),
+                    args: cursor_args,
+                    stdin_file: None,
+                    prompt_file_arg: Some(task_path.to_path_buf()),
+                    initial_prompt: None,
+                    stream_json: false,
+                    interactive: true,
+                }
+            } else {
+                cursor_args.extend([
+                    "-p".to_string(),
+                    "--output-format".to_string(),
+                    "stream-json".to_string(),
+                    "--stream-partial-output".to_string(),
+                ]);
+                InstrumentInvocation::Program {
+                    program: "cursor-agent".to_string(),
+                    args: cursor_args,
+                    stdin_file: None,
+                    prompt_file_arg: Some(task_path.to_path_buf()),
+                    initial_prompt: None,
+                    stream_json: true,
+                    interactive: false,
+                }
+            }
+        }
     };
     Ok(invocation)
 }
@@ -2518,14 +2574,18 @@ fn resolve_default_agent_selection(
     }
 
     let path_agents = detected_agents_on_path(detected);
-    if path_agents.len() == 1 {
-        return Ok(path_agents[0]);
-    }
-
     if allow_prompt {
         let default = pick_agent_mode_target(&path_agents).unwrap_or(Agent::Codex);
         return prompt_agent_selection(prompt, default)?
             .ok_or_else(|| anyhow!("setup cancelled by user"));
+    }
+
+    if path_agents.len() == 1 {
+        return Ok(path_agents[0]);
+    }
+
+    if path_agents.is_empty() {
+        bail!("no coding agents detected on PATH; pass --agent <AGENT> to try anyway");
     }
 
     bail!("multiple coding agents available; pass --agent <AGENT> or re-run in an interactive terminal");
@@ -2576,7 +2636,7 @@ fn pick_agent_mode_target(candidates: &[Agent]) -> Option<Agent> {
 fn detected_agents_on_path(detected: &[DetectionSignal]) -> Vec<Agent> {
     let mut agents = BTreeSet::new();
     for signal in detected {
-        if signal.reason.contains("binary found in PATH") {
+        if signal.on_path {
             agents.insert(signal.agent);
         }
     }
@@ -2598,19 +2658,30 @@ fn resolve_workflow_selection(requested: &[WorkflowArg]) -> Vec<WorkflowArg> {
 }
 
 fn detect_agents(local_root: Option<&Path>, home: &Path) -> Vec<DetectionSignal> {
-    let mut by_agent: BTreeMap<Agent, BTreeSet<String>> = BTreeMap::new();
+    let mut by_agent: BTreeMap<Agent, BTreeSet<(bool, String)>> = BTreeMap::new();
 
     if let Some(root) = local_root {
         if root.join(".claude").exists() {
-            add_signal(&mut by_agent, Agent::Claude, ".claude exists in repo root");
+            add_signal(
+                &mut by_agent,
+                Agent::Claude,
+                false,
+                ".claude exists in repo root",
+            );
         }
         if root.join(".cursor").exists() {
-            add_signal(&mut by_agent, Agent::Cursor, ".cursor exists in repo root");
+            add_signal(
+                &mut by_agent,
+                Agent::Cursor,
+                false,
+                ".cursor exists in repo root",
+            );
         }
         if root.join(".opencode").exists() {
             add_signal(
                 &mut by_agent,
                 Agent::Opencode,
+                false,
                 ".opencode exists in repo root",
             );
         }
@@ -2618,36 +2689,54 @@ fn detect_agents(local_root: Option<&Path>, home: &Path) -> Vec<DetectionSignal>
             add_signal(
                 &mut by_agent,
                 Agent::Codex,
+                false,
                 ".agents/skills exists in repo root",
             );
             add_signal(
                 &mut by_agent,
                 Agent::Opencode,
+                false,
                 ".agents/skills exists in repo root",
             );
         }
         if root.join("AGENTS.md").exists() {
-            add_signal(&mut by_agent, Agent::Codex, "AGENTS.md exists in repo root");
+            add_signal(
+                &mut by_agent,
+                Agent::Codex,
+                false,
+                "AGENTS.md exists in repo root",
+            );
         }
     }
 
     if home.join(".claude").exists() {
-        add_signal(&mut by_agent, Agent::Claude, "~/.claude exists");
+        add_signal(&mut by_agent, Agent::Claude, false, "~/.claude exists");
     }
     if home.join(".cursor").exists() {
-        add_signal(&mut by_agent, Agent::Cursor, "~/.cursor exists");
+        add_signal(&mut by_agent, Agent::Cursor, false, "~/.cursor exists");
     }
     if home.join(".codex").exists() {
-        add_signal(&mut by_agent, Agent::Codex, "~/.codex exists");
+        add_signal(&mut by_agent, Agent::Codex, false, "~/.codex exists");
     }
     if home.join(".agents/skills").exists() {
-        add_signal(&mut by_agent, Agent::Codex, "~/.agents/skills exists");
-        add_signal(&mut by_agent, Agent::Opencode, "~/.agents/skills exists");
+        add_signal(
+            &mut by_agent,
+            Agent::Codex,
+            false,
+            "~/.agents/skills exists",
+        );
+        add_signal(
+            &mut by_agent,
+            Agent::Opencode,
+            false,
+            "~/.agents/skills exists",
+        );
     }
     if home.join(".opencode").exists() || home.join(".config/opencode").exists() {
         add_signal(
             &mut by_agent,
             Agent::Opencode,
+            false,
             "opencode config directory exists",
         );
     }
@@ -2656,21 +2745,33 @@ fn detect_agents(local_root: Option<&Path>, home: &Path) -> Vec<DetectionSignal>
         add_signal(
             &mut by_agent,
             Agent::Claude,
+            true,
             "`claude` binary found in PATH",
         );
     }
 
     let mut out = Vec::new();
-    for (agent, reasons) in by_agent {
-        for reason in reasons {
-            out.push(DetectionSignal { agent, reason });
+    for (agent, signals) in by_agent {
+        for (on_path, reason) in signals {
+            out.push(DetectionSignal {
+                agent,
+                on_path,
+                reason,
+            });
         }
     }
     out
 }
 
-fn add_signal(map: &mut BTreeMap<Agent, BTreeSet<String>>, agent: Agent, reason: &str) {
-    map.entry(agent).or_default().insert(reason.to_string());
+fn add_signal(
+    map: &mut BTreeMap<Agent, BTreeSet<(bool, String)>>,
+    agent: Agent,
+    on_path: bool,
+    reason: &str,
+) {
+    map.entry(agent)
+        .or_default()
+        .insert((on_path, reason.to_string()));
 }
 
 fn install_claude(
@@ -3321,6 +3422,7 @@ mod tests {
     fn single_path_agent_is_selected_by_default() {
         let detected = vec![DetectionSignal {
             agent: Agent::Codex,
+            on_path: true,
             reason: "`codex` binary found in PATH".to_string(),
         }];
         let resolved =
@@ -3334,10 +3436,12 @@ mod tests {
         let detected = vec![
             DetectionSignal {
                 agent: Agent::Codex,
+                on_path: true,
                 reason: "`codex` binary found in PATH".to_string(),
             },
             DetectionSignal {
                 agent: Agent::Claude,
+                on_path: true,
                 reason: "`claude` binary found in PATH".to_string(),
             },
         ];
@@ -3612,6 +3716,34 @@ mod tests {
     }
 
     #[test]
+    fn codex_interactive_instrument_invocation_uses_tui_prompt_arg() {
+        let task_path = PathBuf::from("/tmp/AGENT_TASK.instrument.md");
+        let invocation =
+            resolve_instrument_invocation(Agent::Codex, None, &task_path, true, false, &[])
+                .expect("resolve instrument invocation");
+
+        match invocation {
+            InstrumentInvocation::Program {
+                program,
+                args,
+                stdin_file,
+                prompt_file_arg,
+                stream_json,
+                interactive,
+                ..
+            } => {
+                assert_eq!(program, "codex");
+                assert!(args.is_empty());
+                assert_eq!(stdin_file, None);
+                assert_eq!(prompt_file_arg, Some(task_path));
+                assert!(!stream_json);
+                assert!(interactive);
+            }
+            InstrumentInvocation::Shell(_) => panic!("expected program invocation"),
+        }
+    }
+
+    #[test]
     fn claude_instrument_invocation_uses_print_with_bypass_permissions() {
         let task_path = PathBuf::from("/tmp/AGENT_TASK.instrument.md");
         let invocation =
@@ -3712,11 +3844,8 @@ mod tests {
     }
 
     #[test]
-    fn claude_interactive_instrument_invocation_uses_system_prompt_no_print_flag() {
-        let dir = tempfile::tempdir().expect("tempdir");
-        let task_path = dir.path().join("AGENT_TASK.instrument.md");
-        std::fs::write(&task_path, "## Task\nInstrument this repo.").expect("write task");
-
+    fn claude_interactive_instrument_invocation_uses_prompt_arg_no_print_flag() {
+        let task_path = PathBuf::from("/tmp/AGENT_TASK.instrument.md");
         let invocation =
             resolve_instrument_invocation(Agent::Claude, None, &task_path, true, false, &[])
                 .expect("resolve instrument invocation");
@@ -3727,30 +3856,21 @@ mod tests {
                 args,
                 stdin_file,
                 prompt_file_arg,
-                initial_prompt,
                 stream_json,
                 interactive,
+                ..
             } => {
                 assert_eq!(program, "claude");
                 assert!(
                     !args.contains(&"-p".to_string()),
                     "interactive mode must not pass -p"
                 );
-                assert!(
-                    args.contains(&"--append-system-prompt".to_string()),
-                    "task should be in system prompt"
-                );
+                assert!(args.contains(&"--permission-mode".to_string()));
+                assert!(args.contains(&"--settings".to_string()));
                 assert!(args.contains(&"--disallowedTools".to_string()));
                 assert!(args.contains(&"--name".to_string()));
                 assert_eq!(stdin_file, None);
-                assert_eq!(
-                    prompt_file_arg, None,
-                    "task is in system prompt, not prompt_file_arg"
-                );
-                assert!(
-                    initial_prompt.is_some(),
-                    "short initial message must be set to trigger Claude"
-                );
+                assert_eq!(prompt_file_arg, Some(task_path));
                 assert!(!stream_json);
                 assert!(interactive);
             }
@@ -3805,7 +3925,6 @@ mod tests {
                     args,
                     vec![
                         "-p".to_string(),
-                        "-f".to_string(),
                         "--output-format".to_string(),
                         "stream-json".to_string(),
                         "--stream-partial-output".to_string(),
@@ -3814,6 +3933,34 @@ mod tests {
                 assert_eq!(stdin_file, None);
                 assert_eq!(prompt_file_arg, Some(task_path));
                 assert!(stream_json);
+            }
+            InstrumentInvocation::Shell(_) => panic!("expected program invocation"),
+        }
+    }
+
+    #[test]
+    fn cursor_interactive_instrument_invocation_uses_tui_prompt_arg() {
+        let task_path = PathBuf::from("/tmp/AGENT_TASK.instrument.md");
+        let invocation =
+            resolve_instrument_invocation(Agent::Cursor, None, &task_path, true, false, &[])
+                .expect("resolve instrument invocation");
+
+        match invocation {
+            InstrumentInvocation::Program {
+                program,
+                args,
+                stdin_file,
+                prompt_file_arg,
+                stream_json,
+                interactive,
+                ..
+            } => {
+                assert_eq!(program, "cursor-agent");
+                assert!(args.is_empty());
+                assert_eq!(stdin_file, None);
+                assert_eq!(prompt_file_arg, Some(task_path));
+                assert!(!stream_json);
+                assert!(interactive);
             }
             InstrumentInvocation::Shell(_) => panic!("expected program invocation"),
         }

--- a/src/setup/mod.rs
+++ b/src/setup/mod.rs
@@ -106,6 +106,10 @@ pub struct SetupArgs {
     #[arg(long, short = 'v')]
     verbose: bool,
 
+    /// Deprecated: use --no-skills --no-mcp instead
+    #[arg(long, hide = true, conflicts_with = "skills", conflicts_with = "mcp")]
+    no_mcp_skill: bool,
+
     #[command(flatten)]
     agents: AgentsSetupArgs,
 }
@@ -215,11 +219,11 @@ struct InstrumentSetupArgs {
     languages: Vec<LanguageArg>,
 
     /// Run the agent in interactive TUI mode [default]
-    #[arg(long, conflicts_with = "background")]
+    #[arg(long, conflicts_with = "background", alias = "interactive")]
     tui: bool,
 
     /// Run the agent in background (non-interactive) mode
-    #[arg(long, conflicts_with = "tui")]
+    #[arg(long, conflicts_with = "tui", alias = "quiet")]
     background: bool,
 
     /// Grant the agent full permissions (bypass permission prompts)
@@ -419,8 +423,18 @@ pub async fn run_setup_top(mut base: BaseArgs, mut args: SetupArgs) -> Result<()
         crate::ui::set_quiet(false);
         crate::ui::set_animations_enabled(true);
     }
+    // Deprecated flag: --no-mcp-skill is equivalent to --no-skills --no-mcp
+    if args.no_mcp_skill {
+        args.no_skills = true;
+        args.no_mcp = true;
+    }
     if base.json && args.instrument {
         bail!("--json conflicts with --instrument: JSON mode implies --no-instrument");
+    }
+    if base.json && args.tui {
+        bail!(
+            "--json conflicts with --tui: JSON output is not compatible with interactive TUI mode"
+        );
     }
     if base.json {
         args.no_instrument = true;
@@ -1951,7 +1965,8 @@ fn resolve_setup_selection(args: &AgentsSetupArgs, home: &Path) -> Result<SetupS
     );
     let interactive = ui::is_interactive() && !args.yes;
     let mut prompted_agents: Option<Vec<Agent>> = None;
-    let mut prompted_workflows: Option<Vec<WorkflowArg>> = if args.no_fetch_docs || args.no_workflow {
+    let mut prompted_workflows: Option<Vec<WorkflowArg>> = if args.no_fetch_docs || args.no_workflow
+    {
         Some(Vec::new())
     } else {
         None
@@ -2436,7 +2451,10 @@ fn resolve_scope_from_flags(
     })
 }
 
-fn resolve_selected_agents(requested: Option<AgentArg>, detected: &[DetectionSignal]) -> Vec<Agent> {
+fn resolve_selected_agents(
+    requested: Option<AgentArg>,
+    detected: &[DetectionSignal],
+) -> Vec<Agent> {
     let Some(arg) = requested else {
         let mut inferred = BTreeSet::new();
         for signal in detected {

--- a/src/setup/mod.rs
+++ b/src/setup/mod.rs
@@ -156,12 +156,8 @@ struct AgentsSetupArgs {
     #[arg(skip)]
     yes: bool,
 
-    /// Do not auto-fetch workflow docs during setup
-    #[arg(long)]
-    no_fetch_docs: bool,
-
     /// Refresh prefetched docs by clearing existing output before download
-    #[arg(long, conflicts_with = "no_fetch_docs")]
+    #[arg(long, conflicts_with = "no_workflow")]
     refresh_docs: bool,
 
     /// Number of concurrent workers for docs prefetch/download.
@@ -668,9 +664,8 @@ async fn run_setup_wizard(mut base: BaseArgs, flags: WizardFlags) -> Result<()> 
                 local: matches!(*scope, InstallScope::Local),
                 global: matches!(*scope, InstallScope::Global),
                 workflows: Vec::new(),
-                no_workflow: flag_no_workflow,
+                no_workflow: true,
                 yes: true,
-                no_fetch_docs: true,
                 refresh_docs: false,
                 workers: crate::sync::default_workers(),
                 yolo: false,
@@ -821,7 +816,6 @@ async fn run_default_setup(mut base: BaseArgs, args: SetupArgs) -> Result<()> {
                 workflows: args.agents.workflows.clone(),
                 no_workflow: args.agents.no_workflow,
                 yes: true,
-                no_fetch_docs: args.agents.no_fetch_docs,
                 refresh_docs: args.agents.refresh_docs,
                 workers: args.agents.workers,
                 yolo: args.agents.yolo,
@@ -1169,8 +1163,6 @@ async fn execute_skills_setup(
         notes.push(
             "Skipped workflow docs prefetch (no agents configured successfully).".to_string(),
         );
-    } else if args.no_fetch_docs {
-        notes.push("Skipped workflow docs prefetch (`--no-fetch-docs`).".to_string());
     } else if selected_workflows.is_empty() {
         notes.push("Skipped workflow docs prefetch (no workflows selected).".to_string());
     } else {
@@ -1303,7 +1295,6 @@ async fn run_instrument_setup(
             workflows: selected_workflows.clone(),
             no_workflow: args.skip_workflow_docs,
             yes: true,
-            no_fetch_docs: args.skip_workflow_docs,
             refresh_docs: args.refresh_docs,
             workers: args.workers,
             yolo: false,
@@ -2143,8 +2134,7 @@ fn run_mcp_setup(base: BaseArgs, args: AgentsMcpSetupArgs) -> Result<()> {
 fn resolve_setup_selection(args: &AgentsSetupArgs, home: &Path) -> Result<SetupSelection> {
     let mut scope = initial_scope(args.local, args.global, args.yes, YesScopeDefault::Global);
     let interactive = ui::is_interactive() && !args.yes;
-    let mut prompted_workflows: Option<Vec<WorkflowArg>> = if args.no_fetch_docs || args.no_workflow
-    {
+    let mut prompted_workflows: Option<Vec<WorkflowArg>> = if args.no_workflow {
         Some(Vec::new())
     } else {
         None
@@ -2161,7 +2151,7 @@ fn resolve_setup_selection(args: &AgentsSetupArgs, home: &Path) -> Result<SetupS
         if scope.is_none() {
             steps.push(SetupWizardStep::Scope);
         }
-        if !args.no_fetch_docs && args.workflows.is_empty() {
+        if !args.no_workflow && args.workflows.is_empty() {
             steps.push(SetupWizardStep::Workflows);
         }
 
@@ -2219,7 +2209,7 @@ fn resolve_setup_selection(args: &AgentsSetupArgs, home: &Path) -> Result<SetupS
     )?;
     let selected_agents = vec![selected_agent];
 
-    let selected_workflows = if args.no_fetch_docs {
+    let selected_workflows = if args.no_workflow {
         Vec::new()
     } else if let Some(value) = prompted_workflows {
         value
@@ -3535,25 +3525,6 @@ mod tests {
     }
 
     #[test]
-    fn resolve_setup_selection_honors_no_fetch_docs() {
-        let args = AgentsSetupArgs {
-            agent: Some(AgentArg::Codex),
-            local: false,
-            global: true,
-            workflows: vec![WorkflowArg::Evaluate],
-            no_workflow: false,
-            yes: true,
-            no_fetch_docs: true,
-            refresh_docs: false,
-            workers: crate::sync::default_workers(),
-            yolo: false,
-        };
-        let home = std::env::temp_dir();
-        let selection = resolve_setup_selection(&args, &home).expect("resolve setup selection");
-        assert!(selection.selected_workflows.is_empty());
-    }
-
-    #[test]
     fn resolve_setup_selection_honors_no_workflow() {
         let args = AgentsSetupArgs {
             agent: Some(AgentArg::Codex),
@@ -3562,7 +3533,6 @@ mod tests {
             workflows: vec![WorkflowArg::Evaluate],
             no_workflow: true,
             yes: true,
-            no_fetch_docs: false,
             refresh_docs: false,
             workers: crate::sync::default_workers(),
             yolo: false,

--- a/src/setup/mod.rs
+++ b/src/setup/mod.rs
@@ -837,6 +837,9 @@ async fn run_default_setup(mut base: BaseArgs, args: SetupArgs) -> Result<()> {
 
     if !args.no_instrument {
         if find_git_root().is_some() {
+            let home = home_dir().ok_or_else(|| anyhow!("failed to resolve HOME/USERPROFILE"))?;
+            let root = find_git_root().expect("git root already checked");
+            ensure_instrumentation_skill_prereq(selected_agent, &root, &home, args.no_skills)?;
             run_instrument_setup(
                 base,
                 InstrumentSetupArgs {
@@ -895,7 +898,8 @@ async fn login_with_existing_or_oauth(
         return auth::login(base).await;
     }
 
-    if let Some(profile_name) = choose_setup_profile(base, profiles)? {
+    let cfg_org = config::load().ok().and_then(|cfg| cfg.org);
+    if let Some(profile_name) = choose_setup_profile(base, profiles, cfg_org.as_deref())? {
         base.profile = Some(profile_name);
     }
     match auth::login(base).await {
@@ -908,7 +912,11 @@ async fn login_with_existing_or_oauth(
     }
 }
 
-fn choose_setup_profile(base: &BaseArgs, profiles: &[auth::ProfileInfo]) -> Result<Option<String>> {
+fn choose_setup_profile(
+    base: &BaseArgs,
+    profiles: &[auth::ProfileInfo],
+    cfg_org: Option<&str>,
+) -> Result<Option<String>> {
     if let Some(profile_name) = base.profile.as_ref().map(|value| value.trim()) {
         if !profile_name.is_empty() {
             return Ok(Some(profile_name.to_string()));
@@ -916,6 +924,10 @@ fn choose_setup_profile(base: &BaseArgs, profiles: &[auth::ProfileInfo]) -> Resu
     }
 
     if let Some(org) = base.org_name.as_deref() {
+        return auth::resolve_org_to_profile(org, profiles).map(Some);
+    }
+
+    if let Some(org) = cfg_org {
         return auth::resolve_org_to_profile(org, profiles).map(Some);
     }
 
@@ -928,6 +940,29 @@ fn choose_setup_profile(base: &BaseArgs, profiles: &[auth::ProfileInfo]) -> Resu
     }
 
     bail!("multiple auth profiles found; pass --profile <NAME> or --org <ORG>, or re-run in an interactive terminal")
+}
+
+fn ensure_instrumentation_skill_prereq(
+    agent: Agent,
+    root: &Path,
+    home: &Path,
+    no_skills: bool,
+) -> Result<()> {
+    if !no_skills {
+        return Ok(());
+    }
+
+    let skill_path = skill_config_path(agent, InstallScope::Local, Some(root), home)?;
+    if skill_path.exists() {
+        return Ok(());
+    }
+
+    bail!(
+        "--no-skills prevents automatic skill installation, but instrumentation requires a local {} skill at {}. Re-run without --no-skills, run `bt setup skills --local --agent {}` first, or add --no-instrument.",
+        agent.as_str(),
+        skill_path.display(),
+        agent.as_str(),
+    )
 }
 
 async fn select_project_for_setup(
@@ -3422,6 +3457,7 @@ fn print_mcp_human_report(
 mod tests {
     use super::*;
     use clap::Parser;
+    use std::fs;
     use std::time::{SystemTime, UNIX_EPOCH};
 
     #[derive(Parser)]
@@ -3460,6 +3496,75 @@ mod tests {
         let err = resolve_default_agent_selection(None, &detected, "Select coding agent", false)
             .expect_err("ambiguous path detection should fail");
         assert!(err.to_string().contains("pass --agent"));
+    }
+
+    #[test]
+    fn choose_setup_profile_uses_configured_org_when_multiple_profiles_exist() {
+        let base = BaseArgs {
+            json: false,
+            verbose: false,
+            quiet: false,
+            no_color: false,
+            no_input: true,
+            profile: None,
+            org_name: None,
+            project: None,
+            api_key: None,
+            api_key_source: None,
+            prefer_profile: false,
+            api_url: None,
+            app_url: None,
+            env_file: None,
+        };
+        let profiles = vec![
+            auth::ProfileInfo {
+                name: "alpha".to_string(),
+                org_name: Some("alpha-org".to_string()),
+                user_name: None,
+                email: None,
+                api_key_hint: None,
+            },
+            auth::ProfileInfo {
+                name: "beta".to_string(),
+                org_name: Some("beta-org".to_string()),
+                user_name: None,
+                email: None,
+                api_key_hint: None,
+            },
+        ];
+
+        let selected = choose_setup_profile(&base, &profiles, Some("alpha-org"))
+            .expect("resolve profile from config org");
+
+        assert_eq!(selected, Some("alpha".to_string()));
+    }
+
+    #[test]
+    fn no_skills_blocks_instrumentation_when_local_skill_is_missing() {
+        let root = tempfile::tempdir().expect("tempdir");
+        let home = tempfile::tempdir().expect("home tempdir");
+
+        let err = ensure_instrumentation_skill_prereq(Agent::Codex, root.path(), home.path(), true)
+            .expect_err("missing local skill should fail when --no-skills is set");
+
+        assert!(err
+            .to_string()
+            .contains("--no-skills prevents automatic skill installation"));
+        assert!(err
+            .to_string()
+            .contains("bt setup skills --local --agent codex"));
+    }
+
+    #[test]
+    fn no_skills_allows_instrumentation_when_local_skill_exists() {
+        let root = tempfile::tempdir().expect("tempdir");
+        let home = tempfile::tempdir().expect("home tempdir");
+        let skill_path = root.path().join(".agents/skills/braintrust/SKILL.md");
+        fs::create_dir_all(skill_path.parent().expect("skill dir")).expect("create skill dir");
+        fs::write(&skill_path, "skill").expect("write skill");
+
+        ensure_instrumentation_skill_prereq(Agent::Codex, root.path(), home.path(), true)
+            .expect("existing local skill should satisfy --no-skills instrumentation prereq");
     }
 
     #[test]

--- a/src/setup/mod.rs
+++ b/src/setup/mod.rs
@@ -902,7 +902,7 @@ async fn login_with_existing_or_oauth(
     base.profile = Some(profile_name);
     match auth::login(base).await {
         Ok(ctx) => Ok(ctx),
-        Err(err) if should_force_reauth(&err) => {
+        Err(err) if auth::is_missing_credential_error(&err) => {
             auth::login_setup_oauth(base).await?;
             auth::login(base).await
         }
@@ -925,13 +925,6 @@ fn choose_setup_profile(base: &BaseArgs, profiles: &[auth::ProfileInfo]) -> Resu
         .first()
         .map(|profile| profile.name.clone())
         .ok_or_else(|| anyhow!("no auth profiles found"))
-}
-
-fn should_force_reauth(err: &anyhow::Error) -> bool {
-    let msg = err.to_string();
-    msg.contains("oauth refresh token missing")
-        || msg.contains("oauth profile requested but none selected")
-        || msg.contains("re-run `bt auth login --oauth")
 }
 
 async fn select_project_for_setup(

--- a/src/setup/mod.rs
+++ b/src/setup/mod.rs
@@ -111,6 +111,10 @@ pub struct SetupArgs {
     #[arg(long, short = 'v')]
     verbose: bool,
 
+    /// Deprecated: quiet is now the default; this flag is accepted as a no-op
+    #[arg(long, hide = true)]
+    quiet: bool,
+
     /// Deprecated: use --no-skills --no-mcp instead
     #[arg(long, hide = true, conflicts_with = "skills", conflicts_with = "mcp")]
     no_mcp_skill: bool,
@@ -204,6 +208,9 @@ struct InstrumentSetupArgs {
     /// Workflow docs to prefetch alongside instrument (repeatable; always includes instrument) [default: all]
     #[arg(long = "workflow", value_enum)]
     workflows: Vec<WorkflowArg>,
+
+    #[arg(skip)]
+    skip_workflow_docs: bool,
 
     #[arg(skip)]
     yes: bool,
@@ -517,7 +524,7 @@ async fn run_setup_wizard(mut base: BaseArgs, flags: WizardFlags) -> Result<()> 
         background: flag_background,
         agent: flag_agent,
         workflows: flag_workflows,
-        no_workflow: _,
+        no_workflow: flag_no_workflow,
         languages: flag_languages,
     } = flags;
     let mut had_failures = false;
@@ -671,7 +678,7 @@ async fn run_setup_wizard(mut base: BaseArgs, flags: WizardFlags) -> Result<()> 
                 local: matches!(scope, InstallScope::Local),
                 global: matches!(scope, InstallScope::Global),
                 workflows: Vec::new(),
-                no_workflow: false,
+                no_workflow: flag_no_workflow,
                 yes: true,
                 no_fetch_docs: true,
                 refresh_docs: false,
@@ -755,6 +762,7 @@ async fn run_setup_wizard(mut base: BaseArgs, flags: WizardFlags) -> Result<()> 
                     agent: instrument_agent,
                     agent_cmd: None,
                     workflows: flag_workflows,
+                    skip_workflow_docs: flag_no_workflow,
                     yes: false,
                     refresh_docs: false,
                     workers: crate::sync::default_workers(),
@@ -844,6 +852,7 @@ async fn run_default_setup(mut base: BaseArgs, args: SetupArgs) -> Result<()> {
                     agent: Some(map_agent_to_instrument_agent_arg(selected_agent)),
                     agent_cmd: None,
                     workflows: args.agents.workflows,
+                    skip_workflow_docs: args.agents.no_workflow,
                     yes: true,
                     refresh_docs: args.agents.refresh_docs,
                     workers: args.agents.workers,
@@ -1291,9 +1300,9 @@ async fn run_instrument_setup(
             local: true,
             global: false,
             workflows: selected_workflows.clone(),
-            no_workflow: false,
+            no_workflow: args.skip_workflow_docs,
             yes: true,
-            no_fetch_docs: false,
+            no_fetch_docs: args.skip_workflow_docs,
             refresh_docs: args.refresh_docs,
             workers: args.workers,
             yolo: false,
@@ -1424,6 +1433,10 @@ fn resolve_instrument_workflow_selection(
     args: &InstrumentSetupArgs,
     _hint_pending: &mut bool,
 ) -> Result<Vec<WorkflowArg>> {
+    if args.skip_workflow_docs {
+        return Ok(Vec::new());
+    }
+
     if !args.workflows.is_empty() {
         let mut selected = resolve_workflow_selection(&args.workflows);
         if !selected.contains(&WorkflowArg::Instrument) {
@@ -3326,7 +3339,14 @@ fn print_mcp_human_report(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use clap::Parser;
     use std::time::{SystemTime, UNIX_EPOCH};
+
+    #[derive(Parser)]
+    struct SetupArgsHarness {
+        #[command(flatten)]
+        setup: SetupArgs,
+    }
 
     #[test]
     fn single_path_agent_is_selected_by_default() {
@@ -3472,6 +3492,25 @@ mod tests {
     }
 
     #[test]
+    fn resolve_setup_selection_honors_no_workflow() {
+        let args = AgentsSetupArgs {
+            agent: Some(AgentArg::Codex),
+            local: false,
+            global: true,
+            workflows: vec![WorkflowArg::Evaluate],
+            no_workflow: true,
+            yes: true,
+            no_fetch_docs: false,
+            refresh_docs: false,
+            workers: crate::sync::default_workers(),
+            yolo: false,
+        };
+        let home = std::env::temp_dir();
+        let selection = resolve_setup_selection(&args, &home).expect("resolve setup selection");
+        assert!(selection.selected_workflows.is_empty());
+    }
+
+    #[test]
     fn resolve_workflow_selection_resolves_explicit_values() {
         let selected =
             resolve_workflow_selection(&[WorkflowArg::Evaluate, WorkflowArg::Instrument]);
@@ -3487,6 +3526,7 @@ mod tests {
             agent: Some(InstrumentAgentArg::Codex),
             agent_cmd: None,
             workflows: vec![WorkflowArg::Evaluate],
+            skip_workflow_docs: false,
             yes: true,
             refresh_docs: false,
             workers: crate::sync::default_workers(),
@@ -3511,6 +3551,7 @@ mod tests {
             agent: Some(InstrumentAgentArg::Codex),
             agent_cmd: None,
             workflows: Vec::new(),
+            skip_workflow_docs: false,
             yes: true,
             refresh_docs: false,
             workers: crate::sync::default_workers(),
@@ -3524,6 +3565,35 @@ mod tests {
         let selected = resolve_instrument_workflow_selection(&args, &mut false)
             .expect("resolve instrument workflows");
         assert_eq!(selected, resolve_workflow_selection(&[]));
+    }
+
+    #[test]
+    fn resolve_instrument_workflows_honors_skip_workflow_docs() {
+        let args = InstrumentSetupArgs {
+            agent: Some(InstrumentAgentArg::Codex),
+            agent_cmd: None,
+            workflows: vec![WorkflowArg::Evaluate],
+            skip_workflow_docs: true,
+            yes: true,
+            refresh_docs: false,
+            workers: crate::sync::default_workers(),
+            languages: Vec::new(),
+            tui: false,
+            background: false,
+            yolo: false,
+            skip_launch: false,
+        };
+
+        let selected = resolve_instrument_workflow_selection(&args, &mut false)
+            .expect("resolve instrument workflows");
+        assert!(selected.is_empty());
+    }
+
+    #[test]
+    fn setup_accepts_deprecated_quiet_flag() {
+        let parsed = SetupArgsHarness::try_parse_from(["bt", "--quiet"]).expect("parse");
+        assert!(parsed.setup.quiet);
+        assert!(!parsed.setup.verbose);
     }
 
     #[test]

--- a/src/switch.rs
+++ b/src/switch.rs
@@ -259,6 +259,7 @@ mod tests {
             org_name: org.map(String::from),
             project: project.map(String::from),
             api_key: None,
+            api_key_source: None,
             prefer_profile: false,
             api_url: None,
             app_url: None,

--- a/src/switch.rs
+++ b/src/switch.rs
@@ -254,6 +254,7 @@ mod tests {
         BaseArgs {
             json: false,
             verbose: false,
+            quiet: false,
             no_color: false,
             no_input: false,
             profile: None,

--- a/src/switch.rs
+++ b/src/switch.rs
@@ -253,14 +253,13 @@ mod tests {
     fn base_args(org: Option<&str>, project: Option<&str>) -> BaseArgs {
         BaseArgs {
             json: false,
-            quiet: false,
+            verbose: false,
             no_color: false,
             profile: None,
             org_name: org.map(String::from),
             project: project.map(String::from),
             api_key: None,
             prefer_profile: false,
-            no_input: false,
             api_url: None,
             app_url: None,
             env_file: None,

--- a/src/switch.rs
+++ b/src/switch.rs
@@ -255,6 +255,7 @@ mod tests {
             json: false,
             verbose: false,
             no_color: false,
+            no_input: false,
             profile: None,
             org_name: org.map(String::from),
             project: project.map(String::from),

--- a/src/traces.rs
+++ b/src/traces.rs
@@ -6059,6 +6059,7 @@ mod tests {
         BaseArgs {
             json: false,
             verbose: false,
+            quiet: false,
             no_color: false,
             no_input: false,
             profile: None,

--- a/src/traces.rs
+++ b/src/traces.rs
@@ -6064,6 +6064,7 @@ mod tests {
             org_name: None,
             project: None,
             api_key: None,
+            api_key_source: None,
             prefer_profile: false,
             api_url: None,
             app_url: None,

--- a/src/traces.rs
+++ b/src/traces.rs
@@ -6060,6 +6060,7 @@ mod tests {
             json: false,
             verbose: false,
             no_color: false,
+            no_input: false,
             profile: None,
             org_name: None,
             project: None,

--- a/src/traces.rs
+++ b/src/traces.rs
@@ -6058,14 +6058,13 @@ mod tests {
     fn base_args() -> BaseArgs {
         BaseArgs {
             json: false,
-            quiet: false,
+            verbose: false,
             no_color: false,
             profile: None,
             org_name: None,
             project: None,
             api_key: None,
             prefer_profile: false,
-            no_input: false,
             api_url: None,
             app_url: None,
             env_file: None,

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -12,7 +12,6 @@ static NO_INPUT: AtomicBool = AtomicBool::new(false);
 static QUIET: AtomicBool = AtomicBool::new(false);
 static ANIMATIONS_ENABLED: AtomicBool = AtomicBool::new(true);
 
-#[allow(dead_code)]
 pub fn set_no_input(val: bool) {
     NO_INPUT.store(val, Ordering::Relaxed);
 }

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -12,6 +12,7 @@ static NO_INPUT: AtomicBool = AtomicBool::new(false);
 static QUIET: AtomicBool = AtomicBool::new(false);
 static ANIMATIONS_ENABLED: AtomicBool = AtomicBool::new(true);
 
+#[allow(dead_code)]
 pub fn set_no_input(val: bool) {
     NO_INPUT.store(val, Ordering::Relaxed);
 }

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -40,12 +40,12 @@ fn write_auth_store(config_home: &Path, profiles: &[(&str, &str)]) {
 }
 
 #[test]
-fn deprecated_global_quiet_flag_still_parses_for_other_commands() {
+fn global_quiet_flag_still_parses_for_other_commands() {
     bt_command().args(["status", "--quiet"]).assert().success();
 }
 
 #[test]
-fn deprecated_global_quiet_flag_still_parses_for_setup_subcommands() {
+fn quiet_flag_still_parses_for_setup_subcommands() {
     bt_command()
         .args(["setup", "skills", "--quiet", "--help"])
         .assert()
@@ -56,6 +56,30 @@ fn deprecated_global_quiet_flag_still_parses_for_setup_subcommands() {
 fn setup_instrument_quiet_no_longer_aliases_background() {
     bt_command()
         .args(["setup", "instrument", "--quiet", "--tui", "--help"])
+        .assert()
+        .success();
+}
+
+#[test]
+fn setup_verbose_is_accepted_after_subcommand() {
+    bt_command()
+        .args(["setup", "skills", "--verbose", "--help"])
+        .assert()
+        .success();
+}
+
+#[test]
+fn setup_instrument_accepts_no_workflow_flag() {
+    bt_command()
+        .args(["setup", "instrument", "--no-workflow", "--help"])
+        .assert()
+        .success();
+}
+
+#[test]
+fn setup_instrument_accepts_deprecated_agents_alias() {
+    bt_command()
+        .args(["setup", "instrument", "--agents", "codex", "--help"])
         .assert()
         .success();
 }

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -1,0 +1,141 @@
+use assert_cmd::Command;
+use predicates::prelude::*;
+use std::fs;
+use std::path::Path;
+
+fn bt_command() -> Command {
+    Command::cargo_bin("bt").expect("bt binary")
+}
+
+fn write_executable(path: &Path) {
+    fs::write(path, "#!/bin/sh\nexit 0\n").expect("write executable");
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let mut perms = fs::metadata(path).expect("metadata").permissions();
+        perms.set_mode(0o755);
+        fs::set_permissions(path, perms).expect("chmod");
+    }
+}
+
+fn make_git_repo() -> tempfile::TempDir {
+    let dir = tempfile::tempdir().expect("tempdir");
+    fs::write(dir.path().join(".git"), "gitdir: /tmp/fake").expect("write .git");
+    dir
+}
+
+fn write_auth_store(config_home: &Path, profiles: &[(&str, &str)]) {
+    let auth_dir = config_home.join("bt");
+    fs::create_dir_all(&auth_dir).expect("create auth dir");
+
+    let mut entries = Vec::new();
+    for (profile, org) in profiles {
+        entries.push(format!(
+            "\"{profile}\":{{\"auth_kind\":\"api_key\",\"org_name\":\"{org}\"}}"
+        ));
+    }
+
+    let body = format!("{{\"profiles\":{{{}}}}}", entries.join(","));
+    fs::write(auth_dir.join("auth.json"), body).expect("write auth store");
+}
+
+#[test]
+fn deprecated_global_quiet_flag_still_parses_for_other_commands() {
+    bt_command().args(["status", "--quiet"]).assert().success();
+}
+
+#[test]
+fn deprecated_global_quiet_flag_still_parses_for_setup_subcommands() {
+    bt_command()
+        .args(["setup", "skills", "--quiet", "--help"])
+        .assert()
+        .success();
+}
+
+#[test]
+fn setup_instrument_quiet_no_longer_aliases_background() {
+    bt_command()
+        .args(["setup", "instrument", "--quiet", "--tui", "--help"])
+        .assert()
+        .success();
+}
+
+#[test]
+fn setup_uses_codex_detected_on_path_without_explicit_agent() {
+    let repo = make_git_repo();
+    let home = tempfile::tempdir().expect("home tempdir");
+    let config_home = tempfile::tempdir().expect("config tempdir");
+    let bin_dir = tempfile::tempdir().expect("bin tempdir");
+    write_executable(&bin_dir.path().join("codex"));
+
+    bt_command()
+        .current_dir(repo.path())
+        .env("HOME", home.path())
+        .env("XDG_CONFIG_HOME", config_home.path())
+        .env("PATH", bin_dir.path())
+        .args([
+            "setup",
+            "--global",
+            "--no-instrument",
+            "--no-workflow",
+            "--no-input",
+        ])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Selected agents: codex"));
+
+    assert!(home
+        .path()
+        .join(".agents/skills/braintrust/SKILL.md")
+        .exists());
+}
+
+#[test]
+fn setup_no_instrument_does_not_require_auth_in_git_repo() {
+    let repo = make_git_repo();
+    let nested = repo.path().join("nested");
+    fs::create_dir_all(&nested).expect("create nested");
+
+    let home = tempfile::tempdir().expect("home tempdir");
+    let config_home = tempfile::tempdir().expect("config tempdir");
+    let bin_dir = tempfile::tempdir().expect("bin tempdir");
+    write_executable(&bin_dir.path().join("codex"));
+
+    bt_command()
+        .current_dir(&nested)
+        .env("HOME", home.path())
+        .env("XDG_CONFIG_HOME", config_home.path())
+        .env("PATH", bin_dir.path())
+        .args([
+            "setup",
+            "--global",
+            "--no-instrument",
+            "--no-workflow",
+            "--no-input",
+        ])
+        .assert()
+        .success();
+}
+
+#[test]
+fn setup_requires_profile_disambiguation_when_multiple_profiles_exist() {
+    let repo = make_git_repo();
+    let home = tempfile::tempdir().expect("home tempdir");
+    let config_home = tempfile::tempdir().expect("config tempdir");
+    let bin_dir = tempfile::tempdir().expect("bin tempdir");
+    write_auth_store(
+        config_home.path(),
+        &[("alpha", "alpha-org"), ("beta", "beta-org")],
+    );
+
+    bt_command()
+        .current_dir(repo.path())
+        .env("HOME", home.path())
+        .env("XDG_CONFIG_HOME", config_home.path())
+        .env("PATH", bin_dir.path())
+        .args(["setup", "--global", "--no-input"])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("multiple auth profiles found"))
+        .stderr(predicate::str::contains("pass --profile"));
+}

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -7,6 +7,16 @@ fn bt_command() -> Command {
     Command::cargo_bin("bt").expect("bt binary")
 }
 
+fn clear_braintrust_auth_env(cmd: &mut Command) {
+    for key in [
+        "BRAINTRUST_API_KEY",
+        "BRAINTRUST_PROFILE",
+        "BRAINTRUST_ORG_NAME",
+    ] {
+        cmd.env_remove(key);
+    }
+}
+
 fn write_executable(path: &Path) {
     fs::write(path, "#!/bin/sh\nexit 0\n").expect("write executable");
     #[cfg(unix)]
@@ -92,8 +102,9 @@ fn setup_uses_codex_detected_on_path_without_explicit_agent() {
     let bin_dir = tempfile::tempdir().expect("bin tempdir");
     write_executable(&bin_dir.path().join("codex"));
 
-    bt_command()
-        .current_dir(repo.path())
+    let mut cmd = bt_command();
+    clear_braintrust_auth_env(&mut cmd);
+    cmd.current_dir(repo.path())
         .env("HOME", home.path())
         .env("XDG_CONFIG_HOME", config_home.path())
         .env("PATH", bin_dir.path())
@@ -125,8 +136,9 @@ fn setup_no_instrument_does_not_require_auth_in_git_repo() {
     let bin_dir = tempfile::tempdir().expect("bin tempdir");
     write_executable(&bin_dir.path().join("codex"));
 
-    bt_command()
-        .current_dir(&nested)
+    let mut cmd = bt_command();
+    clear_braintrust_auth_env(&mut cmd);
+    cmd.current_dir(&nested)
         .env("HOME", home.path())
         .env("XDG_CONFIG_HOME", config_home.path())
         .env("PATH", bin_dir.path())
@@ -152,8 +164,9 @@ fn setup_requires_profile_disambiguation_when_multiple_profiles_exist() {
         &[("alpha", "alpha-org"), ("beta", "beta-org")],
     );
 
-    bt_command()
-        .current_dir(repo.path())
+    let mut cmd = bt_command();
+    clear_braintrust_auth_env(&mut cmd);
+    cmd.current_dir(repo.path())
         .env("HOME", home.path())
         .env("XDG_CONFIG_HOME", config_home.path())
         .env("PATH", bin_dir.path())

--- a/tests/eval_dev_server.rs
+++ b/tests/eval_dev_server.rs
@@ -123,10 +123,10 @@ fn parse_sse_events(body: &str) -> Vec<SseEvent> {
     let mut current_data = Vec::<String>::new();
 
     for line in body.lines() {
-        if line.starts_with("event: ") {
-            current_event = line["event: ".len()..].to_string();
-        } else if line.starts_with("data: ") {
-            current_data.push(line["data: ".len()..].to_string());
+        if let Some(stripped) = line.strip_prefix("event: ") {
+            current_event = stripped.to_string();
+        } else if let Some(stripped) = line.strip_prefix("data: ") {
+            current_data.push(stripped.to_string());
         } else if line.is_empty() && !current_event.is_empty() {
             events.push(SseEvent {
                 event: std::mem::take(&mut current_event),
@@ -518,10 +518,10 @@ fn streaming_eval_post(
             Ok(l) => l,
             Err(_) => break,
         };
-        if line.starts_with("event: ") {
-            current_event = line["event: ".len()..].to_string();
-        } else if line.starts_with("data: ") {
-            current_data.push(line["data: ".len()..].to_string());
+        if let Some(stripped) = line.strip_prefix("event: ") {
+            current_event = stripped.to_string();
+        } else if let Some(stripped) = line.strip_prefix("data: ") {
+            current_data.push(stripped.to_string());
         } else if line.is_empty() && !current_event.is_empty() {
             let event = SseEvent {
                 event: std::mem::take(&mut current_event),


### PR DESCRIPTION
Mechanical rename/removal of CLI flags:
- `--quiet` → `--verbose` (invert default)
- `--agents` (repeatable) → `--agent` (single), remove `AgentArg::All`
- `--no-mcp-skill` → `--no-skills` + `--no-mcp`
- Add `--no-instrument`, `--tui`/`--background`, `--no-workflow`
- Move `--yes` to `#[arg(skip)]`
- ```--interactive/-i``` flag, that more or less preserves the previous behavior of asking all questions

Part 1 of https://github.com/braintrustdata/bt/pull/94