### PR TITLE
Auth + API key creation when using bt setup

### DIFF
--- a/src/args.rs
+++ b/src/args.rs
@@ -10,9 +10,9 @@ pub struct BaseArgs {
     #[arg(long, global = true)]
     pub json: bool,
 
-    /// Suppress non-essential output
-    #[arg(long, short = 'q', env = "BRAINTRUST_QUIET", global = true, value_parser = clap::builder::BoolishValueParser::new(), default_value_t = false)]
-    pub quiet: bool,
+    /// Verbose mode — set at runtime by subcommands that support it
+    #[arg(skip)]
+    pub verbose: bool,
 
     /// Disable ANSI color output
     #[arg(long, env = "BRAINTRUST_NO_COLOR", global = true, value_parser = clap::builder::BoolishValueParser::new(), default_value_t = false)]
@@ -43,10 +43,6 @@ pub struct BaseArgs {
     /// Prefer profile credentials even if BRAINTRUST_API_KEY/--api-key is set.
     #[arg(long, global = true)]
     pub prefer_profile: bool,
-
-    /// Disable all interactive prompts
-    #[arg(long, global = true)]
-    pub no_input: bool,
 
     /// Override API URL (or via BRAINTRUST_API_URL)
     #[arg(

--- a/src/args.rs
+++ b/src/args.rs
@@ -4,6 +4,12 @@ use clap::Args;
 
 pub use braintrust_sdk_rust::{DEFAULT_API_URL, DEFAULT_APP_URL};
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ArgValueSource {
+    CommandLine,
+    EnvVariable,
+}
+
 #[derive(Debug, Clone, Args)]
 pub struct BaseArgs {
     /// Output as JSON
@@ -39,6 +45,9 @@ pub struct BaseArgs {
     /// Override stored API key (or via BRAINTRUST_API_KEY)
     #[arg(long, env = "BRAINTRUST_API_KEY", global = true, hide = true)]
     pub api_key: Option<String>,
+
+    #[arg(skip)]
+    pub api_key_source: Option<ArgValueSource>,
 
     /// Prefer profile credentials even if BRAINTRUST_API_KEY/--api-key is set.
     #[arg(long, global = true)]

--- a/src/args.rs
+++ b/src/args.rs
@@ -20,8 +20,8 @@ pub struct BaseArgs {
     #[arg(skip)]
     pub verbose: bool,
 
-    /// Deprecated: quiet is now the default; this flag is accepted as a no-op
-    #[arg(long, short = 'q', env = "BRAINTRUST_QUIET", global = true, hide = true, value_parser = clap::builder::BoolishValueParser::new(), default_value_t = false)]
+    /// Reduce interactive UI output
+    #[arg(long, short = 'q', env = "BRAINTRUST_QUIET", global = true, value_parser = clap::builder::BoolishValueParser::new(), default_value_t = false)]
     pub quiet: bool,
 
     /// Disable ANSI color output

--- a/src/args.rs
+++ b/src/args.rs
@@ -24,6 +24,10 @@ pub struct BaseArgs {
     #[arg(long, env = "BRAINTRUST_NO_COLOR", global = true, value_parser = clap::builder::BoolishValueParser::new(), default_value_t = false)]
     pub no_color: bool,
 
+    /// Disable all interactive prompts
+    #[arg(long, env = "BRAINTRUST_NO_INPUT", global = true, value_parser = clap::builder::BoolishValueParser::new(), default_value_t = false)]
+    pub no_input: bool,
+
     /// Use a saved login profile (or via BRAINTRUST_PROFILE)
     #[arg(long, env = "BRAINTRUST_PROFILE", global = true)]
     pub profile: Option<String>,

--- a/src/args.rs
+++ b/src/args.rs
@@ -16,13 +16,16 @@ pub struct BaseArgs {
     #[arg(long, global = true)]
     pub json: bool,
 
-    /// Verbose mode — set at runtime by subcommands that support it
-    #[arg(skip)]
+    /// Increase output verbosity
+    #[arg(long, short = 'v', env = "BRAINTRUST_VERBOSE", global = true, conflicts_with = "quiet", value_parser = clap::builder::BoolishValueParser::new(), default_value_t = false)]
     pub verbose: bool,
 
     /// Reduce interactive UI output
     #[arg(long, short = 'q', env = "BRAINTRUST_QUIET", global = true, value_parser = clap::builder::BoolishValueParser::new(), default_value_t = false)]
     pub quiet: bool,
+
+    #[arg(skip)]
+    pub quiet_source: Option<ArgValueSource>,
 
     /// Disable ANSI color output
     #[arg(long, env = "BRAINTRUST_NO_COLOR", global = true, value_parser = clap::builder::BoolishValueParser::new(), default_value_t = false)]

--- a/src/args.rs
+++ b/src/args.rs
@@ -20,6 +20,10 @@ pub struct BaseArgs {
     #[arg(skip)]
     pub verbose: bool,
 
+    /// Deprecated: quiet is now the default; this flag is accepted as a no-op
+    #[arg(long, short = 'q', env = "BRAINTRUST_QUIET", global = true, hide = true, value_parser = clap::builder::BoolishValueParser::new(), default_value_t = false)]
+    pub quiet: bool,
+
     /// Disable ANSI color output
     #[arg(long, env = "BRAINTRUST_NO_COLOR", global = true, value_parser = clap::builder::BoolishValueParser::new(), default_value_t = false)]
     pub no_color: bool,

--- a/src/auth.rs
+++ b/src/auth.rs
@@ -13,8 +13,8 @@ use braintrust_sdk_rust::{BraintrustClient, LoginState};
 use clap::{Args, Subcommand};
 use crossterm::event::{self, Event, KeyCode, KeyEventKind};
 use dialoguer::{Confirm, Input, Password};
-use oauth2::basic::{BasicClient, BasicTokenType};
-use oauth2::reqwest::async_http_client;
+use oauth2::basic::{BasicClient, BasicErrorResponseType, BasicRequestTokenError, BasicTokenType};
+use oauth2::reqwest::{async_http_client, AsyncHttpClientError};
 use oauth2::{
     AuthUrl, AuthorizationCode, ClientId, CsrfToken, EmptyExtraTokenFields, PkceCodeChallenge,
     PkceCodeVerifier, RedirectUrl, RefreshToken, Scope, StandardTokenResponse, TokenResponse,
@@ -623,7 +623,8 @@ pub async fn resolve_auth(base: &BaseArgs) -> Result<ResolvedAuth> {
             ),
         )
     })?;
-    let refreshed = refresh_oauth_access_token(&api_url, &refresh_token, client_id).await?;
+    let refreshed =
+        refresh_oauth_access_token(&api_url, &refresh_token, client_id, &profile_name).await?;
     save_profile_oauth_access_token(&profile_name, &refreshed.access_token)?;
     if let Some(next_refresh_token) = refreshed.refresh_token.as_ref() {
         if next_refresh_token != &refresh_token {
@@ -1152,7 +1153,9 @@ async fn run_login_refresh(base: &BaseArgs) -> Result<()> {
         println!("Cached access token expiry before refresh: unknown");
     }
 
-    let refreshed = refresh_oauth_access_token(&api_url, &refresh_token, &client_id).await?;
+    let refreshed =
+        refresh_oauth_access_token(&api_url, &refresh_token, &client_id, profile_name.as_str())
+            .await?;
     save_profile_oauth_access_token(profile_name.as_str(), &refreshed.access_token)?;
     let mut refresh_rotated = false;
     if let Some(next_refresh_token) = refreshed.refresh_token.as_ref() {
@@ -2141,22 +2144,43 @@ async fn exchange_oauth_authorization_code(
     Ok(to_oauth_token_response(token_response))
 }
 
+fn map_refresh_oauth_error(
+    api_url: &str,
+    profile_name: &str,
+    err: BasicRequestTokenError<AsyncHttpClientError>,
+) -> anyhow::Error {
+    if let BasicRequestTokenError::ServerResponse(server_err) = &err {
+        if matches!(server_err.error(), BasicErrorResponseType::InvalidGrant) {
+            let mut message =
+                format!("oauth refresh token expired or was rejected for profile '{profile_name}'");
+            if let Some(description) = server_err.error_description() {
+                message.push_str(&format!(" ({description})"));
+            }
+            message.push_str(&format!(
+                "; re-run `bt auth login --oauth --profile {profile_name}`"
+            ));
+            return recoverable_auth_error(RecoverableAuthErrorKind::OauthRefreshToken, message);
+        }
+    }
+
+    anyhow::Error::new(err).context(format!(
+        "failed to call oauth token endpoint {}/oauth/token",
+        api_url.trim_end_matches('/')
+    ))
+}
+
 async fn refresh_oauth_access_token(
     api_url: &str,
     refresh_token: &str,
     client_id: &str,
+    profile_name: &str,
 ) -> Result<OAuthTokenResponse> {
     let oauth_client = build_oauth_client(api_url, client_id, None)?;
     let token_response = oauth_client
         .exchange_refresh_token(&RefreshToken::new(refresh_token.to_string()))
         .request_async(async_http_client)
         .await
-        .with_context(|| {
-            format!(
-                "failed to call oauth token endpoint {}/oauth/token",
-                api_url.trim_end_matches('/')
-            )
-        })?;
+        .map_err(|err| map_refresh_oauth_error(api_url, profile_name, err))?;
     Ok(to_oauth_token_response(token_response))
 }
 
@@ -2927,6 +2951,36 @@ mod tests {
         .context("while resolving auth");
 
         assert!(is_missing_credential_error(&err));
+    }
+
+    #[test]
+    fn invalid_grant_refresh_error_is_treated_as_recoverable() {
+        let err = map_refresh_oauth_error(
+            "https://api.example.com",
+            "work",
+            BasicRequestTokenError::ServerResponse(oauth2::basic::BasicErrorResponse::new(
+                BasicErrorResponseType::InvalidGrant,
+                Some("refresh token expired".to_string()),
+                None,
+            )),
+        );
+
+        assert!(is_missing_credential_error(&err));
+        assert!(err.to_string().contains("refresh token expired"));
+    }
+
+    #[test]
+    fn nonrecoverable_refresh_errors_remain_nonrecoverable() {
+        let err = map_refresh_oauth_error(
+            "https://api.example.com",
+            "work",
+            BasicRequestTokenError::Other("unexpected response".to_string()),
+        );
+
+        assert!(!is_missing_credential_error(&err));
+        assert!(err
+            .to_string()
+            .contains("failed to call oauth token endpoint"));
     }
 
     fn restore_env_var(key: &str, previous: Option<OsString>) {

--- a/src/auth.rs
+++ b/src/auth.rs
@@ -2642,14 +2642,13 @@ mod tests {
     fn make_base() -> BaseArgs {
         BaseArgs {
             json: false,
-            quiet: false,
+            verbose: false,
             no_color: false,
             profile: None,
             project: None,
             org_name: None,
             api_key: None,
             prefer_profile: false,
-            no_input: false,
             api_url: None,
             app_url: None,
             env_file: None,

--- a/src/auth.rs
+++ b/src/auth.rs
@@ -831,6 +831,7 @@ async fn run_login_oauth(base: &BaseArgs, args: AuthLoginArgs) -> Result<()> {
     Ok(())
 }
 
+#[allow(dead_code)]
 pub async fn login_interactive(base: &mut BaseArgs) -> Result<String> {
     let methods = ["OAuth (browser)", "API key"];
     let selected = ui::fuzzy_select("Select login method", &methods, 0)?;
@@ -842,6 +843,11 @@ pub async fn login_interactive(base: &mut BaseArgs) -> Result<String> {
     }
 }
 
+pub async fn login_setup_oauth(base: &mut BaseArgs) -> Result<String> {
+    login_interactive_oauth(base).await
+}
+
+#[allow(dead_code)]
 async fn login_interactive_api_key(base: &mut BaseArgs) -> Result<String> {
     let api_key = prompt_api_key()?;
 
@@ -2648,6 +2654,7 @@ mod tests {
             project: None,
             org_name: None,
             api_key: None,
+            api_key_source: None,
             prefer_profile: false,
             api_url: None,
             app_url: None,

--- a/src/auth.rs
+++ b/src/auth.rs
@@ -782,9 +782,6 @@ async fn run_login_oauth(base: &BaseArgs, args: AuthLoginArgs) -> Result<()> {
     if !ui::is_interactive() {
         bail!("oauth login requires an interactive terminal");
     }
-    if let Some(warning) = oauth_ignored_api_key_warning(base) {
-        eprintln!("{warning}");
-    }
 
     let api_url = base
         .api_url
@@ -1046,18 +1043,6 @@ fn commit_oauth_profile(
         },
     );
     save_auth_store(&store)
-}
-
-fn oauth_ignored_api_key_warning(base: &BaseArgs) -> Option<String> {
-    let api_key = base.api_key.as_deref()?.trim();
-    if api_key.is_empty() {
-        return None;
-    }
-
-    Some(
-        "warning: --api-key/BRAINTRUST_API_KEY is set; ignoring it because --oauth was requested"
-            .to_string(),
-    )
 }
 
 async fn run_login_refresh(base: &BaseArgs) -> Result<()> {
@@ -3027,21 +3012,6 @@ mod tests {
             err.to_string().contains("did not include code or error"),
             "unexpected error: {err}"
         );
-    }
-
-    #[test]
-    fn oauth_ignored_api_key_warning_is_none_without_api_key() {
-        let base = make_base();
-        assert_eq!(oauth_ignored_api_key_warning(&base), None);
-    }
-
-    #[test]
-    fn oauth_ignored_api_key_warning_is_some_with_api_key() {
-        let mut base = make_base();
-        base.api_key = Some("secret".to_string());
-        let warning = oauth_ignored_api_key_warning(&base).expect("warning");
-        assert!(warning.contains("ignoring it"));
-        assert!(warning.contains("--oauth"));
     }
 
     #[test]

--- a/src/auth.rs
+++ b/src/auth.rs
@@ -359,6 +359,9 @@ struct AuthLogoutArgs {
 }
 
 pub async fn run(base: BaseArgs, args: AuthArgs) -> Result<()> {
+    if !base.json {
+        crate::ui::set_quiet(false);
+    }
     match args.command {
         AuthCommand::Login(login_args) => run_login_set(&base, login_args).await,
         AuthCommand::Refresh => run_login_refresh(&base).await,
@@ -500,11 +503,7 @@ fn maybe_warn_api_key_override(base: &BaseArgs) {
 
     if let Some(profile_name) = ignored_profile {
         eprintln!(
-            "Warning: using --api-key/BRAINTRUST_API_KEY credentials; selected profile '{profile_name}' is ignored for this command. Use --prefer-profile or unset BRAINTRUST_API_KEY.",
-        );
-    } else {
-        eprintln!(
-            "Warning: using --api-key/BRAINTRUST_API_KEY credentials for this command. Use --prefer-profile or unset BRAINTRUST_API_KEY."
+            "Info: using --api-key/BRAINTRUST_API_KEY credentials; selected profile '{profile_name}' is ignored for this command. Use --prefer-profile or unset BRAINTRUST_API_KEY to use a profile with OAuth login.",
         );
     }
 }
@@ -888,59 +887,7 @@ async fn run_login_oauth(base: &BaseArgs, args: AuthLoginArgs) -> Result<()> {
     Ok(())
 }
 
-#[allow(dead_code)]
-pub async fn login_interactive(base: &mut BaseArgs) -> Result<String> {
-    let methods = ["OAuth (browser)", "API key"];
-    let selected = ui::fuzzy_select("Select login method", &methods, 0)?;
-
-    if selected == 0 {
-        login_interactive_oauth(base).await
-    } else {
-        login_interactive_api_key(base).await
-    }
-}
-
-pub async fn login_setup_oauth(base: &mut BaseArgs) -> Result<String> {
-    login_interactive_oauth(base).await
-}
-
-#[allow(dead_code)]
-async fn login_interactive_api_key(base: &mut BaseArgs) -> Result<String> {
-    let api_key = prompt_api_key()?;
-
-    let login_app_url = base
-        .app_url
-        .clone()
-        .unwrap_or_else(|| DEFAULT_APP_URL.to_string());
-    let login_orgs = fetch_login_orgs(&api_key, &login_app_url).await?;
-    let selected_org = select_login_org(
-        login_orgs.clone(),
-        base.org_name.as_deref(),
-        true,
-        false,
-        false,
-    )?;
-    let selected_api_url =
-        resolve_profile_api_url(base.api_url.clone(), selected_org.as_ref(), &login_orgs)?;
-    let profile_name = resolve_profile_name(
-        base.profile.as_deref(),
-        selected_org.as_ref().map(|org| org.name.as_str()),
-    )?;
-    confirm_profile_overwrite(&profile_name)?;
-
-    commit_api_key_profile(
-        &profile_name,
-        &api_key,
-        selected_api_url,
-        base.app_url.clone(),
-        selected_org.as_ref().map(|org| org.name.clone()),
-    )?;
-
-    base.profile = Some(profile_name.clone());
-    Ok(profile_name)
-}
-
-async fn login_interactive_oauth(base: &mut BaseArgs) -> Result<String> {
+pub(crate) async fn login_interactive_oauth(base: &mut BaseArgs) -> Result<String> {
     let api_url = base
         .api_url
         .clone()
@@ -978,7 +925,9 @@ async fn login_interactive_oauth(base: &mut BaseArgs) -> Result<String> {
 
     let _ = open::that(&authorize_url);
     eprintln!("Complete authorization in your browser.");
+    eprintln!();
     eprintln!("{}", dialoguer::console::style(&authorize_url).dim());
+    eprintln!();
 
     let callback = collect_oauth_callback(listener, is_ssh_session()).await?;
     if let Some(error) = callback.error {
@@ -1694,6 +1643,7 @@ fn select_login_org(
         }
     }));
     let label_refs: Vec<&str> = labels.iter().map(String::as_str).collect();
+    println!("\n\nA Braintrust organization is usually a team or a company.");
     let selection = ui::fuzzy_select("Select organization", &label_refs, 0)?;
     if allow_cross_org && selection == 0 {
         return Ok(None);
@@ -1832,6 +1782,7 @@ async fn collect_oauth_callback(
     let pasted = Input::<String>::new()
         .with_prompt("Callback URL/query/JSON (press Enter to wait for automatic callback)")
         .allow_empty(true)
+        .report(false)
         .interact_text()
         .context("failed to read callback URL")?;
     if pasted.trim().is_empty() {

--- a/src/auth.rs
+++ b/src/auth.rs
@@ -176,7 +176,7 @@ pub fn resolve_org_to_profile(identifier: &str, profiles: &[ProfileInfo]) -> Res
         }
         1 => Ok(matches[0].name.clone()),
         _ => {
-            if !ui::is_interactive() {
+            if !ui::can_prompt() {
                 bail!(
                     "multiple profiles for org '{identifier}': {}. Use --profile to disambiguate.",
                     matches
@@ -784,18 +784,7 @@ async fn run_login_set(base: &BaseArgs, args: AuthLoginArgs) -> Result<()> {
     if args.oauth {
         return run_login_oauth(base, args).await;
     }
-
-    let has_explicit_api_key = base.api_key.as_ref().is_some_and(|k| !k.trim().is_empty());
-
-    if !has_explicit_api_key && ui::is_interactive() {
-        let methods = ["OAuth (browser)", "API key"];
-        let selected = ui::fuzzy_select("Select login method", &methods, 0)?;
-        if selected == 0 {
-            return run_login_oauth(base, args).await;
-        }
-    }
-
-    let interactive = ui::is_interactive();
+    let interactive = ui::can_prompt();
 
     let api_key = match base.api_key.clone() {
         Some(value) if !value.trim().is_empty() => value,
@@ -1246,7 +1235,7 @@ fn resolve_selected_profile_name_for_debug(
         return Ok((name, "only profile"));
     }
 
-    if store.profiles.len() > 1 && ui::is_interactive() {
+    if store.profiles.len() > 1 && ui::can_prompt() {
         if let Some(name) = select_profile_interactive(None)? {
             return Ok((name, "interactive selection"));
         }
@@ -1375,15 +1364,15 @@ fn confirm_profile_overwrite(profile_name: &str) -> Result<()> {
     if !store.profiles.contains_key(profile_name) {
         return Ok(());
     }
-    if !ui::is_interactive() {
+    let Some(term) = ui::prompt_term() else {
         return Ok(());
-    }
+    };
     let confirmed = Confirm::new()
         .with_prompt(format!(
             "Profile '{profile_name}' already exists. Overwrite?"
         ))
         .default(false)
-        .interact()?;
+        .interact_on(&term)?;
     if !confirmed {
         bail!("login cancelled");
     }
@@ -1405,12 +1394,6 @@ fn format_login_success(
 }
 
 async fn run_profiles(base: &BaseArgs, _args: AuthProfilesArgs) -> Result<()> {
-    if resolve_api_key_override(base).is_some() {
-        println!("Auth source: --api-key/BRAINTRUST_API_KEY override");
-        eprintln!("Tip: pass --prefer-profile or unset BRAINTRUST_API_KEY to use profiles.");
-        return Ok(());
-    }
-
     let store = load_auth_store()?;
     if store.profiles.is_empty() {
         println!("No saved profiles. Run `bt auth login` to create one.");
@@ -1463,14 +1446,16 @@ fn run_login_delete(profile_name: &str, force: bool) -> Result<()> {
         );
     }
 
-    if !force && ui::is_interactive() {
-        let confirmed = Confirm::new()
-            .with_prompt(format!("Delete profile '{profile_name}'?"))
-            .default(false)
-            .interact()?;
-        if !confirmed {
-            eprintln!("Cancelled");
-            return Ok(());
+    if !force {
+        if let Some(term) = ui::prompt_term() {
+            let confirmed = Confirm::new()
+                .with_prompt(format!("Delete profile '{profile_name}'?"))
+                .default(false)
+                .interact_on(&term)?;
+            if !confirmed {
+                eprintln!("Cancelled");
+                return Ok(());
+            }
         }
     }
 
@@ -1508,7 +1493,7 @@ fn run_login_logout(base: BaseArgs, args: AuthLogoutArgs) -> Result<()> {
         p
     } else if store.profiles.len() == 1 {
         store.profiles.keys().next().unwrap().clone()
-    } else if ui::is_interactive() {
+    } else if ui::can_prompt() {
         let names: Vec<&str> = store.profiles.keys().map(|k| k.as_str()).collect();
         let idx = crate::ui::fuzzy_select("Select profile to log out", &names, 0)?;
         names[idx].to_string()
@@ -2327,14 +2312,12 @@ fn to_oauth_token_response(tokens: OAuth2StdTokenResponse) -> OAuthTokenResponse
 }
 
 fn prompt_api_key() -> Result<String> {
-    if !ui::is_interactive() {
-        bail!("--api-key is required in non-interactive mode");
-    }
-
+    let term = ui::prompt_term()
+        .ok_or_else(|| anyhow::anyhow!("--api-key is required in non-interactive mode"))?;
     let api_key = Password::new()
         .with_prompt("Braintrust API key")
         .allow_empty_password(false)
-        .interact()
+        .interact_on(&term)
         .context("failed to read API key")?;
 
     if api_key.trim().is_empty() {

--- a/src/auth.rs
+++ b/src/auth.rs
@@ -61,6 +61,13 @@ pub struct ProfileInfo {
     pub api_key_hint: Option<String>,
 }
 
+#[derive(Debug, Clone)]
+pub(crate) struct StoredProfileInfo {
+    pub name: String,
+    pub is_oauth: bool,
+    pub org_name: Option<String>,
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct AvailableOrg {
     pub id: String,
@@ -121,6 +128,19 @@ pub fn list_profiles() -> Result<Vec<ProfileInfo>> {
             user_name: p.user_name.clone(),
             email: p.email.clone(),
             api_key_hint: p.api_key_hint.clone(),
+        })
+        .collect())
+}
+
+pub(crate) fn list_stored_profiles() -> Result<Vec<StoredProfileInfo>> {
+    let store = load_auth_store()?;
+    Ok(store
+        .profiles
+        .iter()
+        .map(|(name, profile)| StoredProfileInfo {
+            name: name.clone(),
+            is_oauth: profile.auth_kind == AuthKind::Oauth,
+            org_name: profile.org_name.clone(),
         })
         .collect())
 }
@@ -216,6 +236,28 @@ pub async fn list_available_orgs(base: &BaseArgs) -> Result<Vec<AvailableOrg>> {
     };
 
     let mut orgs = fetch_login_orgs(&api_key, &app_url).await?;
+    orgs.sort_by(|a, b| {
+        a.name
+            .to_ascii_lowercase()
+            .cmp(&b.name.to_ascii_lowercase())
+            .then_with(|| a.name.cmp(&b.name))
+    });
+
+    Ok(orgs
+        .into_iter()
+        .map(|org| AvailableOrg {
+            id: org.id,
+            name: org.name,
+            api_url: org.api_url,
+        })
+        .collect())
+}
+
+pub(crate) async fn list_available_orgs_for_api_key(
+    api_key: &str,
+    app_url: &str,
+) -> Result<Vec<AvailableOrg>> {
+    let mut orgs = fetch_login_orgs(api_key, app_url).await?;
     orgs.sort_by(|a, b| {
         a.name
             .to_ascii_lowercase()
@@ -762,11 +804,16 @@ async fn run_login_set(base: &BaseArgs, args: AuthLoginArgs) -> Result<()> {
     )?;
     let selected_api_url =
         resolve_profile_api_url(base.api_url.clone(), selected_org.as_ref(), &login_orgs)?;
-    let profile_name = resolve_profile_name(
+    let store = load_auth_store()?;
+    let (profile_name, should_confirm_overwrite) = resolve_api_key_login_profile_name(
         base.profile.as_deref(),
         selected_org.as_ref().map(|org| org.name.as_str()),
+        &selected_api_url,
+        &store,
     )?;
-    confirm_profile_overwrite(&profile_name)?;
+    if should_confirm_overwrite {
+        confirm_profile_overwrite(&profile_name)?;
+    }
 
     commit_api_key_profile(
         &profile_name,
@@ -862,11 +909,19 @@ async fn run_login_oauth(base: &BaseArgs, args: AuthLoginArgs) -> Result<()> {
     )?;
     let selected_api_url =
         resolve_profile_api_url(base.api_url.clone(), selected_org.as_ref(), &login_orgs)?;
-    let profile_name = resolve_profile_name(
+    let store = load_auth_store()?;
+    let jwt_id = decode_jwt_identity(&oauth_tokens.access_token);
+    let (profile_name, should_confirm_overwrite) = resolve_oauth_login_profile_name(
         base.profile.as_deref(),
         selected_org.as_ref().map(|org| org.name.as_str()),
+        &selected_api_url,
+        &app_url,
+        &jwt_id,
+        &store,
     )?;
-    confirm_profile_overwrite(&profile_name)?;
+    if should_confirm_overwrite {
+        confirm_profile_overwrite(&profile_name)?;
+    }
 
     commit_oauth_profile(
         &profile_name,
@@ -960,11 +1015,19 @@ pub(crate) async fn login_interactive_oauth(base: &mut BaseArgs) -> Result<Strin
     )?;
     let selected_api_url =
         resolve_profile_api_url(base.api_url.clone(), selected_org.as_ref(), &login_orgs)?;
-    let profile_name = resolve_profile_name(
+    let store = load_auth_store()?;
+    let jwt_id = decode_jwt_identity(&oauth_tokens.access_token);
+    let (profile_name, should_confirm_overwrite) = resolve_oauth_login_profile_name(
         base.profile.as_deref(),
         selected_org.as_ref().map(|org| org.name.as_str()),
+        &selected_api_url,
+        &app_url,
+        &jwt_id,
+        &store,
     )?;
-    confirm_profile_overwrite(&profile_name)?;
+    if should_confirm_overwrite {
+        confirm_profile_overwrite(&profile_name)?;
+    }
 
     commit_oauth_profile(
         &profile_name,
@@ -979,7 +1042,7 @@ pub(crate) async fn login_interactive_oauth(base: &mut BaseArgs) -> Result<Strin
     Ok(profile_name)
 }
 
-fn commit_api_key_profile(
+pub(crate) fn commit_api_key_profile(
     profile_name: &str,
     api_key: &str,
     api_url: String,
@@ -1170,6 +1233,102 @@ fn resolve_profile_name(
         .filter(|name| !name.is_empty())
         .unwrap_or("profile")
         .to_string())
+}
+
+fn default_profile_name(suggested_org_name: Option<&str>) -> String {
+    suggested_org_name
+        .map(str::trim)
+        .filter(|name| !name.is_empty())
+        .unwrap_or("profile")
+        .to_string()
+}
+
+fn next_available_profile_name(base_name: &str, store: &AuthStore) -> String {
+    if !store.profiles.contains_key(base_name) {
+        return base_name.to_string();
+    }
+
+    (2u32..)
+        .map(|idx| format!("{base_name}-{idx}"))
+        .find(|candidate| !store.profiles.contains_key(candidate))
+        .expect("profile name sequence is infinite")
+}
+
+fn resolve_api_key_login_profile_name(
+    explicit_profile: Option<&str>,
+    suggested_org_name: Option<&str>,
+    selected_api_url: &str,
+    store: &AuthStore,
+) -> Result<(String, bool)> {
+    if let Some(profile_name) = explicit_profile {
+        let profile_name = resolve_profile_name(Some(profile_name), suggested_org_name)?;
+        return Ok((
+            profile_name.clone(),
+            store.profiles.contains_key(&profile_name),
+        ));
+    }
+
+    let default_name = default_profile_name(suggested_org_name);
+    let has_matching_api_key_profile = store.profiles.values().any(|profile| {
+        profile.auth_kind == AuthKind::ApiKey
+            && profile.api_url.as_deref() == Some(selected_api_url)
+            && profile.org_name.as_deref() == suggested_org_name
+    });
+
+    if has_matching_api_key_profile {
+        return Ok((next_available_profile_name(&default_name, store), false));
+    }
+
+    Ok((
+        default_name.clone(),
+        store.profiles.contains_key(&default_name),
+    ))
+}
+
+fn resolve_oauth_login_profile_name(
+    explicit_profile: Option<&str>,
+    suggested_org_name: Option<&str>,
+    selected_api_url: &str,
+    app_url: &str,
+    jwt_id: &JwtIdentity,
+    store: &AuthStore,
+) -> Result<(String, bool)> {
+    if let Some(profile_name) = explicit_profile {
+        let profile_name = resolve_profile_name(Some(profile_name), suggested_org_name)?;
+        return Ok((
+            profile_name.clone(),
+            store.profiles.contains_key(&profile_name),
+        ));
+    }
+
+    let matched_profile = store
+        .profiles
+        .iter()
+        .filter(|(_, profile)| {
+            profile.auth_kind == AuthKind::Oauth
+                && profile.api_url.as_deref() == Some(selected_api_url)
+                && profile.app_url.as_deref() == Some(app_url)
+                && profile.org_name.as_deref() == suggested_org_name
+                && profile.user_name == jwt_id.name
+                && profile.email == jwt_id.email
+        })
+        .max_by(|(left_name, left), (right_name, right)| {
+            left.oauth_access_expires_at
+                .unwrap_or_default()
+                .cmp(&right.oauth_access_expires_at.unwrap_or_default())
+                .then_with(|| left_name.cmp(right_name))
+        })
+        .map(|(name, _)| name.clone());
+
+    if let Some(profile_name) = matched_profile {
+        return Ok((profile_name, false));
+    }
+
+    let default_name = default_profile_name(suggested_org_name);
+    Ok((
+        default_name.clone(),
+        store.profiles.contains_key(&default_name),
+    ))
 }
 
 fn confirm_profile_overwrite(profile_name: &str) -> Result<()> {
@@ -3195,6 +3354,79 @@ mod tests {
         .expect("resolve");
         assert_eq!(resolved.api_key.as_deref(), Some("other-key"));
         assert_eq!(resolved.org_name.as_deref(), Some("acme-corp"));
+    }
+
+    #[test]
+    fn resolve_api_key_login_profile_name_creates_new_profile_for_matching_org() {
+        let mut store = AuthStore::default();
+        store.profiles.insert(
+            "acme".into(),
+            AuthProfile {
+                auth_kind: AuthKind::ApiKey,
+                api_url: Some("https://api.acme.example".into()),
+                org_name: Some("acme".into()),
+                ..Default::default()
+            },
+        );
+
+        let (profile_name, should_confirm) = resolve_api_key_login_profile_name(
+            None,
+            Some("acme"),
+            "https://api.acme.example",
+            &store,
+        )
+        .expect("resolve");
+
+        assert_eq!(profile_name, "acme-2");
+        assert!(!should_confirm);
+    }
+
+    #[test]
+    fn resolve_oauth_login_profile_name_reuses_most_recent_matching_profile() {
+        let mut store = AuthStore::default();
+        store.profiles.insert(
+            "older".into(),
+            AuthProfile {
+                auth_kind: AuthKind::Oauth,
+                api_url: Some("https://api.acme.example".into()),
+                app_url: Some("https://www.acme.example".into()),
+                org_name: Some("acme".into()),
+                oauth_access_expires_at: Some(100),
+                user_name: Some("Alice".into()),
+                email: Some("alice@example.com".into()),
+                ..Default::default()
+            },
+        );
+        store.profiles.insert(
+            "newer".into(),
+            AuthProfile {
+                auth_kind: AuthKind::Oauth,
+                api_url: Some("https://api.acme.example".into()),
+                app_url: Some("https://www.acme.example".into()),
+                org_name: Some("acme".into()),
+                oauth_access_expires_at: Some(200),
+                user_name: Some("Alice".into()),
+                email: Some("alice@example.com".into()),
+                ..Default::default()
+            },
+        );
+
+        let jwt_id = JwtIdentity {
+            name: Some("Alice".into()),
+            email: Some("alice@example.com".into()),
+        };
+        let (profile_name, should_confirm) = resolve_oauth_login_profile_name(
+            None,
+            Some("acme"),
+            "https://api.acme.example",
+            "https://www.acme.example",
+            &jwt_id,
+            &store,
+        )
+        .expect("resolve");
+
+        assert_eq!(profile_name, "newer");
+        assert!(!should_confirm);
     }
 
     #[test]

--- a/src/auth.rs
+++ b/src/auth.rs
@@ -59,6 +59,7 @@ pub struct ProfileInfo {
     pub user_name: Option<String>,
     pub email: Option<String>,
     pub api_key_hint: Option<String>,
+    pub is_oauth: bool,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -121,6 +122,7 @@ pub fn list_profiles() -> Result<Vec<ProfileInfo>> {
             user_name: p.user_name.clone(),
             email: p.email.clone(),
             api_key_hint: p.api_key_hint.clone(),
+            is_oauth: p.auth_kind == AuthKind::Oauth,
         })
         .collect())
 }

--- a/src/auth.rs
+++ b/src/auth.rs
@@ -2649,6 +2649,7 @@ mod tests {
         BaseArgs {
             json: false,
             verbose: false,
+            quiet: false,
             no_color: false,
             no_input: false,
             profile: None,

--- a/src/auth.rs
+++ b/src/auth.rs
@@ -2650,6 +2650,7 @@ mod tests {
             json: false,
             verbose: false,
             no_color: false,
+            no_input: false,
             profile: None,
             project: None,
             org_name: None,

--- a/src/auth.rs
+++ b/src/auth.rs
@@ -1,4 +1,5 @@
 use std::collections::BTreeMap;
+use std::error::Error as StdError;
 use std::fs;
 use std::io::{IsTerminal, Write};
 use std::path::{Path, PathBuf};
@@ -65,6 +66,48 @@ pub struct AvailableOrg {
     pub id: String,
     pub name: String,
     pub api_url: Option<String>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum RecoverableAuthErrorKind {
+    OauthProfileSelection,
+    OauthClientId,
+    OauthRefreshToken,
+    StoredCredential,
+}
+
+#[derive(Debug)]
+struct RecoverableAuthError {
+    kind: RecoverableAuthErrorKind,
+    message: String,
+}
+
+impl std::fmt::Display for RecoverableAuthError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(&self.message)
+    }
+}
+
+impl StdError for RecoverableAuthError {}
+
+fn recoverable_auth_error(kind: RecoverableAuthErrorKind, message: String) -> anyhow::Error {
+    anyhow::Error::new(RecoverableAuthError { kind, message })
+}
+
+pub fn is_missing_credential_error(err: &anyhow::Error) -> bool {
+    err.chain().any(|source| {
+        source
+            .downcast_ref::<RecoverableAuthError>()
+            .is_some_and(|err| {
+                matches!(
+                    err.kind,
+                    RecoverableAuthErrorKind::OauthProfileSelection
+                        | RecoverableAuthErrorKind::OauthClientId
+                        | RecoverableAuthErrorKind::OauthRefreshToken
+                        | RecoverableAuthErrorKind::StoredCredential
+                )
+            })
+    })
 }
 
 pub fn list_profiles() -> Result<Vec<ProfileInfo>> {
@@ -494,15 +537,23 @@ pub async fn resolve_auth(base: &BaseArgs) -> Result<ResolvedAuth> {
         .or_else(|| {
             (store.profiles.len() == 1).then(|| store.profiles.keys().next().unwrap().as_str())
         })
-        .ok_or_else(|| anyhow::anyhow!("oauth profile requested but none selected"))?
+        .ok_or_else(|| {
+            recoverable_auth_error(
+                RecoverableAuthErrorKind::OauthProfileSelection,
+                "oauth profile requested but none selected".to_string(),
+            )
+        })?
         .to_string();
     let profile = store
         .profiles
         .get(profile_name.as_str())
         .ok_or_else(|| anyhow::anyhow!("profile '{profile_name}' not found"))?;
     let client_id = profile.oauth_client_id.as_deref().ok_or_else(|| {
-        anyhow::anyhow!(
-            "oauth profile '{profile_name}' is missing client_id; re-run `bt auth login --oauth --profile {profile_name}`"
+        recoverable_auth_error(
+            RecoverableAuthErrorKind::OauthClientId,
+            format!(
+                "oauth profile '{profile_name}' is missing client_id; re-run `bt auth login --oauth --profile {profile_name}`"
+            ),
         )
     })?;
     let cached_expires_at = profile.oauth_access_expires_at;
@@ -519,8 +570,11 @@ pub async fn resolve_auth(base: &BaseArgs) -> Result<ResolvedAuth> {
     }
 
     let refresh_token = load_profile_oauth_refresh_token(&profile_name)?.ok_or_else(|| {
-        anyhow::anyhow!(
-            "oauth refresh token missing for profile '{profile_name}'; re-run `bt auth login --oauth --profile {profile_name}`"
+        recoverable_auth_error(
+            RecoverableAuthErrorKind::OauthRefreshToken,
+            format!(
+                "oauth refresh token missing for profile '{profile_name}'; re-run `bt auth login --oauth --profile {profile_name}`"
+            ),
         )
     })?;
     let refreshed = refresh_oauth_access_token(&api_url, &refresh_token, client_id).await?;
@@ -640,8 +694,11 @@ where
             None
         } else {
             Some(load_secret(profile_name)?.ok_or_else(|| {
-                anyhow::anyhow!(
-                    "no keychain credential found for profile '{profile_name}'; re-run `bt auth login --profile {profile_name}`"
+                recoverable_auth_error(
+                    RecoverableAuthErrorKind::StoredCredential,
+                    format!(
+                        "no keychain credential found for profile '{profile_name}'; re-run `bt auth login --profile {profile_name}`"
+                    ),
                 )
             })?)
         };
@@ -2716,6 +2773,34 @@ mod tests {
 
     fn assert_invalid_api_url<T>(result: Result<T>) {
         assert_err_contains(result, "invalid api_url");
+    }
+
+    #[test]
+    fn missing_credential_error_helper_detects_typed_auth_errors() {
+        let err = recoverable_auth_error(
+            RecoverableAuthErrorKind::OauthRefreshToken,
+            "oauth refresh token missing".to_string(),
+        );
+
+        assert!(is_missing_credential_error(&err));
+    }
+
+    #[test]
+    fn missing_credential_error_helper_ignores_unrelated_errors() {
+        let err = anyhow::anyhow!("some unrelated error");
+
+        assert!(!is_missing_credential_error(&err));
+    }
+
+    #[test]
+    fn missing_credential_error_helper_detects_errors_through_context() {
+        let err = recoverable_auth_error(
+            RecoverableAuthErrorKind::StoredCredential,
+            "missing stored credential".to_string(),
+        )
+        .context("while resolving auth");
+
+        assert!(is_missing_credential_error(&err));
     }
 
     fn restore_env_var(key: &str, previous: Option<OsString>) {

--- a/src/auth.rs
+++ b/src/auth.rs
@@ -330,6 +330,20 @@ struct LoginOrgInfo {
     api_url: Option<String>,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ApiKeyOrgMismatchAction {
+    UseApiKey,
+    UseOauth,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum RequestedOrgResolution {
+    NoRequestedOrg,
+    UseRequestedOrg,
+    IgnoreRequestedOrg,
+    SwitchToOauth,
+}
+
 #[derive(Debug, Clone, Deserialize)]
 struct OAuthTokenResponse {
     access_token: String,
@@ -365,10 +379,7 @@ enum AuthCommand {
 }
 
 #[derive(Debug, Clone, Args)]
-struct AuthProfilesArgs {
-    #[arg(long)]
-    verbose: bool,
-}
+struct AuthProfilesArgs {}
 
 #[derive(Debug, Clone, Args)]
 struct AuthLoginArgs {
@@ -383,10 +394,6 @@ struct AuthLoginArgs {
     /// Do not try to open a browser automatically
     #[arg(long)]
     no_browser: bool,
-
-    /// Show org IDs and API URLs in org selector
-    #[arg(long, short = 'v')]
-    verbose: bool,
 }
 
 #[derive(Debug, Clone, Args)]
@@ -401,9 +408,6 @@ struct AuthLogoutArgs {
 }
 
 pub async fn run(base: BaseArgs, args: AuthArgs) -> Result<()> {
-    if !base.json {
-        crate::ui::set_quiet(false);
-    }
     match args.command {
         AuthCommand::Login(login_args) => run_login_set(&base, login_args).await,
         AuthCommand::Refresh => run_login_refresh(&base).await,
@@ -796,12 +800,28 @@ async fn run_login_set(base: &BaseArgs, args: AuthLoginArgs) -> Result<()> {
         .clone()
         .unwrap_or_else(|| DEFAULT_APP_URL.to_string());
     let login_orgs = fetch_login_orgs(&api_key, &login_app_url).await?;
+    let requested_org_resolution = resolve_requested_org_for_api_key_login(
+        &login_orgs,
+        base.org_name.as_deref(),
+        ui::can_prompt(),
+        prompt_for_auth_method_for_missing_requested_org,
+    )?;
+    if requested_org_resolution == RequestedOrgResolution::SwitchToOauth {
+        return run_login_oauth(base, args).await;
+    }
     let selected_org = select_login_org(
         login_orgs.clone(),
-        base.org_name.as_deref(),
+        match requested_org_resolution {
+            RequestedOrgResolution::UseRequestedOrg => base.org_name.as_deref(),
+            RequestedOrgResolution::NoRequestedOrg | RequestedOrgResolution::IgnoreRequestedOrg => {
+                None
+            }
+            RequestedOrgResolution::SwitchToOauth => unreachable!("handled above"),
+        },
         interactive,
-        args.verbose,
+        base.verbose,
         true,
+        explicitly_quiet(base),
     )?;
     let selected_api_url =
         resolve_profile_api_url(base.api_url.clone(), selected_org.as_ref(), &login_orgs)?;
@@ -878,7 +898,12 @@ async fn run_login_oauth(base: &BaseArgs, args: AuthLoginArgs) -> Result<()> {
         }
     }
 
-    let callback = collect_oauth_callback(listener, args.no_browser || is_ssh_session()).await?;
+    let callback = collect_oauth_callback(
+        listener,
+        args.no_browser || is_ssh_session(),
+        explicitly_quiet(base),
+    )
+    .await?;
     if let Some(error) = callback.error {
         bail!("oauth authorization failed: {error}");
     }
@@ -905,8 +930,9 @@ async fn run_login_oauth(base: &BaseArgs, args: AuthLoginArgs) -> Result<()> {
         login_orgs.clone(),
         base.org_name.as_deref(),
         ui::can_prompt(),
-        args.verbose,
+        base.verbose,
         true,
+        explicitly_quiet(base),
     )?;
     let selected_api_url =
         resolve_profile_api_url(base.api_url.clone(), selected_org.as_ref(), &login_orgs)?;
@@ -983,7 +1009,8 @@ pub(crate) async fn login_interactive_oauth(base: &mut BaseArgs) -> Result<Strin
     eprintln!("{}", dialoguer::console::style(&authorize_url).dim());
     eprintln!();
 
-    let callback = collect_oauth_callback(listener, is_ssh_session()).await?;
+    let callback =
+        collect_oauth_callback(listener, is_ssh_session(), explicitly_quiet(base)).await?;
     if let Some(error) = callback.error {
         bail!("oauth authorization failed: {error}");
     }
@@ -1013,6 +1040,7 @@ pub(crate) async fn login_interactive_oauth(base: &mut BaseArgs) -> Result<Strin
         ui::can_prompt(),
         false,
         false,
+        explicitly_quiet(base),
     )?;
     let selected_api_url =
         resolve_profile_api_url(base.api_url.clone(), selected_org.as_ref(), &login_orgs)?;
@@ -1368,7 +1396,7 @@ fn format_login_success(
     }
 }
 
-async fn run_profiles(base: &BaseArgs, args: AuthProfilesArgs) -> Result<()> {
+async fn run_profiles(base: &BaseArgs, _args: AuthProfilesArgs) -> Result<()> {
     if resolve_api_key_override(base).is_some() {
         println!("Auth source: --api-key/BRAINTRUST_API_KEY override");
         eprintln!("Tip: pass --prefer-profile or unset BRAINTRUST_API_KEY to use profiles.");
@@ -1405,7 +1433,7 @@ async fn run_profiles(base: &BaseArgs, args: AuthProfilesArgs) -> Result<()> {
         crate::ui::print_command_status(cmd_status, &format_verification_line(v));
     }
 
-    if args.verbose {
+    if base.verbose {
         if let Ok(path) = auth_store_path() {
             eprintln!("\nCredentials: {}", path.display());
         }
@@ -1735,6 +1763,7 @@ fn select_login_org(
     interactive: bool,
     verbose: bool,
     allow_cross_org: bool,
+    quiet_requested: bool,
 ) -> Result<Option<LoginOrgInfo>> {
     if orgs.is_empty() {
         bail!("no organizations found for this credential");
@@ -1747,23 +1776,10 @@ fn select_login_org(
     });
 
     if let Some(name) = requested_org_name {
-        let selected = orgs
-            .iter()
-            .find(|org| org.name == name)
-            .or_else(|| {
-                let lowered = name.to_ascii_lowercase();
-                orgs.iter()
-                    .find(|org| org.name.to_ascii_lowercase() == lowered)
-            })
-            .cloned();
-        return selected.map(Some).ok_or_else(|| {
-            let available = orgs
-                .iter()
-                .map(|org| org.name.as_str())
-                .collect::<Vec<_>>()
-                .join(", ");
-            anyhow::anyhow!("org '{name}' not found. Available: {available}")
-        });
+        return find_login_org(&orgs, name)
+            .cloned()
+            .map(Some)
+            .ok_or_else(|| missing_requested_org_error(&orgs, name));
     }
 
     if orgs.len() == 1 {
@@ -1791,7 +1807,9 @@ fn select_login_org(
         }
     }));
     let label_refs: Vec<&str> = labels.iter().map(String::as_str).collect();
-    eprintln!("\n\nA Braintrust organization is usually a team or a company.");
+    if !quiet_requested {
+        eprintln!("\n\nA Braintrust organization is usually a team or a company.");
+    }
     let selection = ui::fuzzy_select("Select organization", &label_refs, 0)?;
     if allow_cross_org && selection == 0 {
         return Ok(None);
@@ -1802,6 +1820,78 @@ fn select_login_org(
             .nth(selection - offset)
             .expect("selected index should be in range"),
     ))
+}
+
+fn find_login_org<'a>(
+    orgs: &'a [LoginOrgInfo],
+    requested_org_name: &str,
+) -> Option<&'a LoginOrgInfo> {
+    orgs.iter()
+        .find(|org| org.name == requested_org_name)
+        .or_else(|| {
+            let lowered = requested_org_name.to_ascii_lowercase();
+            orgs.iter()
+                .find(|org| org.name.to_ascii_lowercase() == lowered)
+        })
+}
+
+fn missing_requested_org_error(orgs: &[LoginOrgInfo], requested_org_name: &str) -> anyhow::Error {
+    let available = orgs
+        .iter()
+        .map(|org| org.name.as_str())
+        .collect::<Vec<_>>()
+        .join(", ");
+    anyhow::anyhow!("org '{requested_org_name}' not found. Available: {available}")
+}
+
+fn resolve_requested_org_for_api_key_login<F>(
+    orgs: &[LoginOrgInfo],
+    requested_org_name: Option<&str>,
+    can_prompt: bool,
+    choose_auth_method: F,
+) -> Result<RequestedOrgResolution>
+where
+    F: FnOnce(&str, &[LoginOrgInfo]) -> Result<ApiKeyOrgMismatchAction>,
+{
+    let Some(requested_org_name) = requested_org_name else {
+        return Ok(RequestedOrgResolution::NoRequestedOrg);
+    };
+
+    if find_login_org(orgs, requested_org_name).is_some() {
+        return Ok(RequestedOrgResolution::UseRequestedOrg);
+    }
+
+    if !can_prompt {
+        return Err(missing_requested_org_error(orgs, requested_org_name));
+    }
+
+    match choose_auth_method(requested_org_name, orgs)? {
+        ApiKeyOrgMismatchAction::UseApiKey => Ok(RequestedOrgResolution::IgnoreRequestedOrg),
+        ApiKeyOrgMismatchAction::UseOauth => Ok(RequestedOrgResolution::SwitchToOauth),
+    }
+}
+
+fn prompt_for_auth_method_for_missing_requested_org(
+    requested_org_name: &str,
+    orgs: &[LoginOrgInfo],
+) -> Result<ApiKeyOrgMismatchAction> {
+    let api_key_label = if orgs.len() == 1 {
+        format!("API key ({})", orgs[0].name)
+    } else {
+        "API key (use available org)".to_string()
+    };
+    let methods = ["OAuth (browser)".to_string(), api_key_label];
+    let method_refs: Vec<&str> = methods.iter().map(String::as_str).collect();
+    let selection = ui::fuzzy_select(
+        &format!("Org '{requested_org_name}' is not available for this API key. Continue with"),
+        &method_refs,
+        0,
+    )?;
+    Ok(match selection {
+        0 => ApiKeyOrgMismatchAction::UseOauth,
+        1 => ApiKeyOrgMismatchAction::UseApiKey,
+        _ => unreachable!("fuzzy_select returned out-of-range index"),
+    })
 }
 
 fn resolve_profile_api_url(
@@ -1938,6 +2028,7 @@ async fn wait_for_oauth_callback(listener: TcpListener) -> Result<OAuthCallbackP
 async fn collect_oauth_callback(
     listener: TcpListener,
     prefer_manual: bool,
+    quiet_requested: bool,
 ) -> Result<OAuthCallbackParams> {
     match oauth_callback_mode(prefer_manual) {
         OAuthCallbackMode::ListenerOnly => {
@@ -1948,13 +2039,15 @@ async fn collect_oauth_callback(
         OAuthCallbackMode::PromptThenListener => {
             let term = ui::prompt_term()
                 .ok_or_else(|| anyhow::anyhow!("interactive mode requires TTY"))?;
-            println!("Remote/SSH OAuth flow: open the URL in a browser on your local machine.");
-            println!(
-                "After approving access, your browser may show a localhost connection error on remote hosts."
-            );
-            println!(
-                "Copy the full URL from the browser address bar (or just code=...&state=...) and paste it below."
-            );
+            if !quiet_requested {
+                println!("Remote/SSH OAuth flow: open the URL in a browser on your local machine.");
+                println!(
+                    "After approving access, your browser may show a localhost connection error on remote hosts."
+                );
+                println!(
+                    "Copy the full URL from the browser address bar (or just code=...&state=...) and paste it below."
+                );
+            }
             let pasted = Input::<String>::new()
                 .with_prompt("Callback URL/query/JSON (press Enter to wait for automatic callback)")
                 .allow_empty(true)
@@ -1967,6 +2060,10 @@ async fn collect_oauth_callback(
             parse_oauth_callback_input(&pasted)
         }
     }
+}
+
+fn explicitly_quiet(base: &BaseArgs) -> bool {
+    base.quiet && base.quiet_source.is_some()
 }
 
 async fn wait_for_oauth_callback_or_stdin(listener: TcpListener) -> Result<OAuthCallbackParams> {
@@ -2857,6 +2954,7 @@ mod tests {
             json: false,
             verbose: false,
             quiet: false,
+            quiet_source: None,
             no_color: false,
             no_input: false,
             profile: None,
@@ -3481,6 +3579,80 @@ mod tests {
 
         assert_eq!(profile_name, "newer");
         assert!(!should_confirm);
+    }
+
+    fn login_org(id: &str, name: &str) -> LoginOrgInfo {
+        LoginOrgInfo {
+            id: id.to_string(),
+            name: name.to_string(),
+            api_url: None,
+        }
+    }
+
+    #[test]
+    fn resolve_requested_org_for_api_key_login_keeps_matching_requested_org() {
+        let orgs = vec![login_org("org_1", "acme")];
+
+        let resolution =
+            resolve_requested_org_for_api_key_login(&orgs, Some("acme"), false, |_, _| {
+                panic!("prompt should not be called")
+            })
+            .expect("resolve");
+
+        assert_eq!(resolution, RequestedOrgResolution::UseRequestedOrg);
+    }
+
+    #[test]
+    fn resolve_requested_org_for_api_key_login_errors_without_prompt() {
+        let orgs = vec![login_org("org_1", "braintrustdata.com")];
+
+        let err =
+            resolve_requested_org_for_api_key_login(&orgs, Some("ced-test-1"), false, |_, _| {
+                panic!("prompt should not be called")
+            })
+            .expect_err("should fail");
+
+        assert!(err
+            .to_string()
+            .contains("org 'ced-test-1' not found. Available: braintrustdata.com"));
+    }
+
+    #[test]
+    fn resolve_requested_org_for_api_key_login_can_switch_to_oauth() {
+        let orgs = vec![login_org("org_1", "braintrustdata.com")];
+
+        let resolution = resolve_requested_org_for_api_key_login(
+            &orgs,
+            Some("ced-test-1"),
+            true,
+            |requested_org_name, available_orgs| {
+                assert_eq!(requested_org_name, "ced-test-1");
+                assert_eq!(available_orgs.len(), 1);
+                Ok(ApiKeyOrgMismatchAction::UseOauth)
+            },
+        )
+        .expect("resolve");
+
+        assert_eq!(resolution, RequestedOrgResolution::SwitchToOauth);
+    }
+
+    #[test]
+    fn resolve_requested_org_for_api_key_login_can_continue_with_api_key() {
+        let orgs = vec![login_org("org_1", "braintrustdata.com")];
+
+        let resolution = resolve_requested_org_for_api_key_login(
+            &orgs,
+            Some("ced-test-1"),
+            true,
+            |requested_org_name, available_orgs| {
+                assert_eq!(requested_org_name, "ced-test-1");
+                assert_eq!(available_orgs.len(), 1);
+                Ok(ApiKeyOrgMismatchAction::UseApiKey)
+            },
+        )
+        .expect("resolve");
+
+        assert_eq!(resolution, RequestedOrgResolution::IgnoreRequestedOrg);
     }
 
     #[test]

--- a/src/auth.rs
+++ b/src/auth.rs
@@ -59,7 +59,6 @@ pub struct ProfileInfo {
     pub user_name: Option<String>,
     pub email: Option<String>,
     pub api_key_hint: Option<String>,
-    pub is_oauth: bool,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -122,7 +121,6 @@ pub fn list_profiles() -> Result<Vec<ProfileInfo>> {
             user_name: p.user_name.clone(),
             email: p.email.clone(),
             api_key_hint: p.api_key_hint.clone(),
-            is_oauth: p.auth_kind == AuthKind::Oauth,
         })
         .collect())
 }
@@ -511,7 +509,12 @@ fn maybe_warn_api_key_override(base: &BaseArgs) {
 }
 
 fn resolve_api_key_override(base: &BaseArgs) -> Option<String> {
-    if base.prefer_profile {
+    if base.prefer_profile
+        && !matches!(
+            base.api_key_source,
+            Some(crate::args::ArgValueSource::CommandLine)
+        )
+    {
         return None;
     }
     let value = base.api_key.as_deref()?.trim();
@@ -2943,6 +2946,39 @@ mod tests {
         .expect("resolve");
         assert_eq!(resolved.api_key.as_deref(), Some("profile-key"));
         assert_eq!(resolved.org_name.as_deref(), Some("Example Org"));
+    }
+
+    #[test]
+    fn resolve_auth_prefers_cli_api_key_even_with_prefer_profile() {
+        let mut base = make_base();
+        base.api_key = Some("explicit-key".to_string());
+        base.api_key_source = Some(crate::args::ArgValueSource::CommandLine);
+        base.prefer_profile = true;
+        base.profile = Some("work".to_string());
+
+        let mut store = AuthStore::default();
+        store.profiles.insert(
+            "work".to_string(),
+            AuthProfile {
+                auth_kind: AuthKind::ApiKey,
+                api_url: Some("https://api.example.com".to_string()),
+                app_url: None,
+                org_name: Some("Example Org".to_string()),
+                oauth_client_id: None,
+                oauth_access_expires_at: None,
+                ..Default::default()
+            },
+        );
+
+        let resolved = resolve_auth_from_store_with_secret_lookup(
+            &base,
+            &store,
+            |_| Ok(Some("profile-key".to_string())),
+            &None,
+        )
+        .expect("resolve");
+        assert_eq!(resolved.api_key.as_deref(), Some("explicit-key"));
+        assert_eq!(resolved.org_name, None);
     }
 
     #[test]

--- a/src/auth.rs
+++ b/src/auth.rs
@@ -784,10 +784,6 @@ async fn run_login_set(base: &BaseArgs, args: AuthLoginArgs) -> Result<()> {
 }
 
 async fn run_login_oauth(base: &BaseArgs, args: AuthLoginArgs) -> Result<()> {
-    if !ui::is_interactive() {
-        bail!("oauth login requires an interactive terminal");
-    }
-
     let api_url = base
         .api_url
         .clone()
@@ -860,7 +856,7 @@ async fn run_login_oauth(base: &BaseArgs, args: AuthLoginArgs) -> Result<()> {
     let selected_org = select_login_org(
         login_orgs.clone(),
         base.org_name.as_deref(),
-        true,
+        ui::can_prompt(),
         args.verbose,
         true,
     )?;
@@ -958,7 +954,7 @@ pub(crate) async fn login_interactive_oauth(base: &mut BaseArgs) -> Result<Strin
     let selected_org = select_login_org(
         login_orgs.clone(),
         base.org_name.as_deref(),
-        true,
+        ui::can_prompt(),
         false,
         false,
     )?;
@@ -1633,7 +1629,7 @@ fn select_login_org(
         }
     }));
     let label_refs: Vec<&str> = labels.iter().map(String::as_str).collect();
-    println!("\n\nA Braintrust organization is usually a team or a company.");
+    eprintln!("\n\nA Braintrust organization is usually a team or a company.");
     let selection = ui::fuzzy_select("Select organization", &label_refs, 0)?;
     if allow_cross_org && selection == 0 {
         return Ok(None);
@@ -1710,6 +1706,29 @@ struct OAuthCallbackParams {
     error: Option<String>,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum OAuthCallbackMode {
+    ListenerOnly,
+    ListenerOrStdin,
+    PromptThenListener,
+}
+
+fn oauth_callback_mode(prefer_manual: bool) -> OAuthCallbackMode {
+    if prefer_manual {
+        if ui::can_prompt() {
+            OAuthCallbackMode::PromptThenListener
+        } else {
+            OAuthCallbackMode::ListenerOnly
+        }
+    } else if ui::is_interactive() {
+        OAuthCallbackMode::ListenerOrStdin
+    } else if ui::can_prompt() {
+        OAuthCallbackMode::PromptThenListener
+    } else {
+        OAuthCallbackMode::ListenerOnly
+    }
+}
+
 async fn wait_for_oauth_callback(listener: TcpListener) -> Result<OAuthCallbackParams> {
     let (mut stream, _) = tokio::time::timeout(OAUTH_CALLBACK_TIMEOUT, listener.accept())
         .await
@@ -1758,27 +1777,34 @@ async fn collect_oauth_callback(
     listener: TcpListener,
     prefer_manual: bool,
 ) -> Result<OAuthCallbackParams> {
-    if !prefer_manual {
-        return wait_for_oauth_callback_or_stdin(listener).await;
+    match oauth_callback_mode(prefer_manual) {
+        OAuthCallbackMode::ListenerOnly => {
+            eprintln!("Waiting for browser authorization...");
+            wait_for_oauth_callback(listener).await
+        }
+        OAuthCallbackMode::ListenerOrStdin => wait_for_oauth_callback_or_stdin(listener).await,
+        OAuthCallbackMode::PromptThenListener => {
+            let term = ui::prompt_term()
+                .ok_or_else(|| anyhow::anyhow!("interactive mode requires TTY"))?;
+            println!("Remote/SSH OAuth flow: open the URL in a browser on your local machine.");
+            println!(
+                "After approving access, your browser may show a localhost connection error on remote hosts."
+            );
+            println!(
+                "Copy the full URL from the browser address bar (or just code=...&state=...) and paste it below."
+            );
+            let pasted = Input::<String>::new()
+                .with_prompt("Callback URL/query/JSON (press Enter to wait for automatic callback)")
+                .allow_empty(true)
+                .report(false)
+                .interact_text_on(&term)
+                .context("failed to read callback URL")?;
+            if pasted.trim().is_empty() {
+                return wait_for_oauth_callback(listener).await;
+            }
+            parse_oauth_callback_input(&pasted)
+        }
     }
-
-    println!("Remote/SSH OAuth flow: open the URL in a browser on your local machine.");
-    println!(
-        "After approving access, your browser may show a localhost connection error on remote hosts."
-    );
-    println!(
-        "Copy the full URL from the browser address bar (or just code=...&state=...) and paste it below."
-    );
-    let pasted = Input::<String>::new()
-        .with_prompt("Callback URL/query/JSON (press Enter to wait for automatic callback)")
-        .allow_empty(true)
-        .report(false)
-        .interact_text()
-        .context("failed to read callback URL")?;
-    if pasted.trim().is_empty() {
-        return wait_for_oauth_callback(listener).await;
-    }
-    parse_oauth_callback_input(&pasted)
 }
 
 async fn wait_for_oauth_callback_or_stdin(listener: TcpListener) -> Result<OAuthCallbackParams> {
@@ -3286,6 +3312,31 @@ mod tests {
             format_verification_line(&v),
             "bad — api_key — org: corp — invalid API key"
         );
+    }
+
+    #[tokio::test]
+    async fn oauth_callback_mode_uses_listener_only_when_input_is_disabled() {
+        let _guard = env_test_lock().lock().await;
+        ui::set_no_input(true);
+        assert_eq!(oauth_callback_mode(false), OAuthCallbackMode::ListenerOnly);
+        assert_eq!(oauth_callback_mode(true), OAuthCallbackMode::ListenerOnly);
+        ui::set_no_input(false);
+    }
+
+    #[test]
+    fn oauth_callback_mode_prefers_manual_prompt_when_interactive() {
+        ui::set_no_input(false);
+
+        if ui::is_interactive() {
+            assert_eq!(
+                oauth_callback_mode(true),
+                OAuthCallbackMode::PromptThenListener
+            );
+            assert_eq!(
+                oauth_callback_mode(false),
+                OAuthCallbackMode::ListenerOrStdin
+            );
+        }
     }
 
     #[tokio::test]

--- a/src/eval.rs
+++ b/src/eval.rs
@@ -294,15 +294,6 @@ pub struct EvalArgs {
     )]
     pub filter: Vec<String>,
 
-    /// Show verbose evaluator errors and stderr output.
-    #[arg(
-        long,
-        env = "BT_EVAL_VERBOSE",
-        value_parser = clap::builder::BoolishValueParser::new(),
-        default_value_t = false
-    )]
-    pub verbose: bool,
-
     /// Re-run evals when input files change.
     #[arg(
         long,
@@ -385,7 +376,7 @@ pub async fn run(base: BaseArgs, args: EvalArgs) -> Result<()> {
         num_workers: args.num_workers,
         list: args.list,
         filter: args.filter,
-        verbose: args.verbose,
+        verbose: base.verbose,
         extra_args: args.extra_args,
     };
 
@@ -4273,7 +4264,6 @@ mod tests {
             "BT_EVAL_NUM_WORKERS",
             "BT_EVAL_LIST",
             "BT_EVAL_FILTER",
-            "BT_EVAL_VERBOSE",
             "BT_EVAL_WATCH",
             "BT_EVAL_DEV",
             "BT_EVAL_DEV_HOST",
@@ -4287,7 +4277,6 @@ mod tests {
         set_env_var("BT_EVAL_NUM_WORKERS", "4");
         set_env_var("BT_EVAL_LIST", "yes");
         set_env_var("BT_EVAL_FILTER", "metadata.case=smoke.*,metadata.kind=fast");
-        set_env_var("BT_EVAL_VERBOSE", "1");
         set_env_var("BT_EVAL_WATCH", "on");
         set_env_var("BT_EVAL_DEV", "true");
         set_env_var("BT_EVAL_DEV_HOST", "127.0.0.1");
@@ -4307,7 +4296,6 @@ mod tests {
                 "metadata.kind=fast".to_string()
             ]
         );
-        assert!(parsed.eval.verbose);
         assert!(parsed.eval.watch);
         assert!(parsed.eval.dev);
         assert_eq!(parsed.eval.dev_host, "127.0.0.1");

--- a/src/functions/mod.rs
+++ b/src/functions/mod.rs
@@ -398,10 +398,6 @@ pub(crate) struct PullArgs {
         value_parser = BoolishValueParser::new()
     )]
     pub force: bool,
-
-    /// Show skipped files in output.
-    #[arg(long, default_value_t = false)]
-    pub verbose: bool,
 }
 
 impl PullArgs {
@@ -424,9 +420,6 @@ pub struct ViewArgs {
     /// Open in browser
     #[arg(long)]
     web: bool,
-    /// Show all configuration details
-    #[arg(long)]
-    verbose: bool,
 }
 
 impl ViewArgs {
@@ -590,7 +583,7 @@ pub async fn run_typed(base: BaseArgs, args: FunctionArgs, kind: FunctionTypeFil
     match args.command {
         None | Some(FunctionCommands::List) => list::run(&ctx, base.json, ft).await,
         Some(FunctionCommands::View(v)) => {
-            view::run(&ctx, v.slug(), base.json, v.web, v.verbose, ft).await
+            view::run(&ctx, v.slug(), base.json, v.web, base.verbose, ft).await
         }
         Some(FunctionCommands::Delete(d)) => delete::run(&ctx, d.slug(), d.force, ft).await,
         Some(FunctionCommands::Invoke(i)) => invoke::run(&ctx, &i, base.json, ft).await,
@@ -615,7 +608,7 @@ pub async fn run(base: BaseArgs, args: FunctionsArgs) -> Result<()> {
                         v.inner.slug(),
                         base.json,
                         v.inner.web,
-                        v.inner.verbose,
+                        base.verbose,
                         v.function_type.or(function_type),
                     )
                     .await

--- a/src/functions/pull.rs
+++ b/src/functions/pull.rs
@@ -238,7 +238,7 @@ pub async fn run(base: BaseArgs, args: PullArgs) -> Result<()> {
             materializable.push(row);
         } else {
             summary.unsupported_records_skipped += 1;
-            if args.verbose {
+            if base.verbose {
                 eprintln!(
                     "{} skipping '{}' because it is not a prompt",
                     style("warning:").yellow(),
@@ -415,7 +415,7 @@ pub async fn run(base: BaseArgs, args: PullArgs) -> Result<()> {
             }
         }
     }
-    emit_summary(&base, &summary, args.verbose)?;
+    emit_summary(&base, &summary, base.verbose)?;
     if failure {
         bail!("functions pull failed; see summary for details");
     }
@@ -1612,7 +1612,6 @@ mod tests {
             id: Some("missing".to_string()),
             version: None,
             force: false,
-            verbose: false,
         };
 
         let err = apply_selector_narrowing(vec![row], &args).expect_err("should fail");
@@ -1668,7 +1667,6 @@ mod tests {
             id: None,
             version: None,
             force: false,
-            verbose: false,
         };
 
         let narrowed = apply_selector_narrowing(rows, &args).expect("should narrow");

--- a/src/functions/push.rs
+++ b/src/functions/push.rs
@@ -3439,6 +3439,7 @@ mod tests {
             org_name: None,
             project: None,
             api_key: None,
+            api_key_source: None,
             prefer_profile: false,
             api_url: None,
             app_url: None,

--- a/src/functions/push.rs
+++ b/src/functions/push.rs
@@ -3435,6 +3435,7 @@ mod tests {
             json: false,
             verbose: false,
             quiet: false,
+            quiet_source: None,
             no_color: false,
             no_input: false,
             profile: None,

--- a/src/functions/push.rs
+++ b/src/functions/push.rs
@@ -3433,14 +3433,13 @@ mod tests {
     fn test_base_args() -> BaseArgs {
         BaseArgs {
             json: false,
-            quiet: false,
+            verbose: false,
             no_color: false,
             profile: None,
             org_name: None,
             project: None,
             api_key: None,
             prefer_profile: false,
-            no_input: false,
             api_url: None,
             app_url: None,
             env_file: None,

--- a/src/functions/push.rs
+++ b/src/functions/push.rs
@@ -3434,6 +3434,7 @@ mod tests {
         BaseArgs {
             json: false,
             verbose: false,
+            quiet: false,
             no_color: false,
             no_input: false,
             profile: None,

--- a/src/functions/push.rs
+++ b/src/functions/push.rs
@@ -3435,6 +3435,7 @@ mod tests {
             json: false,
             verbose: false,
             no_color: false,
+            no_input: false,
             profile: None,
             org_name: None,
             project: None,

--- a/src/main.rs
+++ b/src/main.rs
@@ -446,31 +446,4 @@ mod tests {
 
         assert_eq!(cli.command.base().api_key_source, None);
     }
-
-    #[test]
-    fn deprecated_global_quiet_flag_still_parses_for_other_commands() {
-        let matches = Cli::command()
-            .try_get_matches_from(["bt", "status", "--quiet"])
-            .expect("matches");
-        let cli = Cli::from_arg_matches(&matches).expect("cli");
-
-        assert!(cli.command.base().quiet);
-    }
-
-    #[test]
-    fn deprecated_global_quiet_flag_still_parses_for_setup_subcommands() {
-        let matches = Cli::command()
-            .try_get_matches_from(["bt", "setup", "skills", "--quiet"])
-            .expect("matches");
-        let cli = Cli::from_arg_matches(&matches).expect("cli");
-
-        assert!(cli.command.base().quiet);
-    }
-
-    #[test]
-    fn setup_instrument_quiet_no_longer_aliases_background() {
-        Cli::command()
-            .try_get_matches_from(["bt", "setup", "instrument", "--quiet", "--tui"])
-            .expect("matches");
-    }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -81,6 +81,7 @@ Flags
   -o, --org <ORG>            Override active org [env: BRAINTRUST_ORG_NAME]
       -p, --project <PROJECT>    Override active project [env: BRAINTRUST_DEFAULT_PROJECT]
       --json                 Output as JSON
+  -v, --verbose              Increase output verbosity [env: BRAINTRUST_VERBOSE=]
   -q, --quiet                Reduce interactive UI output [env: BRAINTRUST_QUIET=]
       --no-color             Disable ANSI color output
       --no-input             Disable all interactive prompts
@@ -202,6 +203,10 @@ impl Commands {
             Commands::Status(cmd) => &mut cmd.base,
         }
     }
+
+    fn verbose_by_default(&self) -> bool {
+        !matches!(self, Commands::Setup(_))
+    }
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -234,6 +239,7 @@ async fn try_main() -> Result<()> {
     let matches = Cli::command().get_matches_from(&argv);
     let mut cli = Cli::from_arg_matches(&matches).expect("clap matches should parse");
     apply_base_arg_sources(&matches, cli.command.base_mut());
+    apply_base_output_defaults(&mut cli.command);
     configure_output(cli.command.base());
 
     match cli.command {
@@ -262,7 +268,21 @@ async fn try_main() -> Result<()> {
 }
 
 fn apply_base_arg_sources(matches: &ArgMatches, base: &mut BaseArgs) {
+    base.quiet_source = find_value_source(matches, "quiet").and_then(map_value_source);
     base.api_key_source = find_value_source(matches, "api_key").and_then(map_value_source);
+}
+
+fn apply_base_output_defaults(command: &mut Commands) {
+    let verbose_by_default = command.verbose_by_default();
+    let base = command.base_mut();
+
+    if base.quiet {
+        base.verbose = false;
+        return;
+    }
+
+    base.verbose = base.verbose || verbose_by_default;
+    base.quiet = !base.verbose;
 }
 
 fn find_value_source(matches: &ArgMatches, id: &str) -> Option<ValueSource> {
@@ -446,5 +466,59 @@ mod tests {
         restore_env_var("BRAINTRUST_API_KEY", previous_api_key);
 
         assert_eq!(cli.command.base().api_key_source, None);
+    }
+
+    #[test]
+    fn apply_base_output_defaults_keeps_setup_quiet_by_default() {
+        let matches = Cli::command()
+            .try_get_matches_from([
+                "bt",
+                "setup",
+                "--no-instrument",
+                "--global",
+                "--agent",
+                "codex",
+            ])
+            .expect("matches");
+        let mut cli = Cli::from_arg_matches(&matches).expect("cli");
+
+        apply_base_output_defaults(&mut cli.command);
+
+        assert!(cli.command.base().quiet);
+        assert!(!cli.command.base().verbose);
+    }
+
+    #[test]
+    fn apply_base_output_defaults_keeps_status_verbose_by_default() {
+        let matches = Cli::command()
+            .try_get_matches_from(["bt", "status"])
+            .expect("matches");
+        let mut cli = Cli::from_arg_matches(&matches).expect("cli");
+
+        apply_base_output_defaults(&mut cli.command);
+
+        assert!(!cli.command.base().quiet);
+        assert!(cli.command.base().verbose);
+    }
+
+    #[test]
+    fn apply_base_output_defaults_honors_explicit_verbose_for_setup() {
+        let matches = Cli::command()
+            .try_get_matches_from([
+                "bt",
+                "setup",
+                "--verbose",
+                "--no-instrument",
+                "--global",
+                "--agent",
+                "codex",
+            ])
+            .expect("matches");
+        let mut cli = Cli::from_arg_matches(&matches).expect("cli");
+
+        apply_base_output_defaults(&mut cli.command);
+
+        assert!(!cli.command.base().quiet);
+        assert!(cli.command.base().verbose);
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -81,6 +81,7 @@ Flags
   -o, --org <ORG>            Override active org [env: BRAINTRUST_ORG_NAME]
       -p, --project <PROJECT>    Override active project [env: BRAINTRUST_DEFAULT_PROJECT]
       --json                 Output as JSON
+  -q, --quiet                Reduce interactive UI output [env: BRAINTRUST_QUIET=]
       --no-color             Disable ANSI color output
       --no-input             Disable all interactive prompts
       --api-url <URL>        Override API URL [env: BRAINTRUST_API_URL]
@@ -295,9 +296,9 @@ fn configure_output(base: &BaseArgs) {
         ui::set_animations_enabled(false);
     }
 
-    ui::set_quiet(true);
+    ui::set_quiet(base.quiet);
     ui::set_no_input(base.no_input);
-    ui::set_animations_enabled(false);
+    ui::set_animations_enabled(!term_is_dumb && !base.quiet);
 
     if disable_color {
         dialoguer::console::set_colors_enabled(false);

--- a/src/main.rs
+++ b/src/main.rs
@@ -260,7 +260,16 @@ async fn try_main() -> Result<()> {
 }
 
 fn apply_base_arg_sources(matches: &ArgMatches, base: &mut BaseArgs) {
-    base.api_key_source = matches.value_source("api_key").and_then(map_value_source);
+    base.api_key_source = find_value_source(matches, "api_key").and_then(map_value_source);
+}
+
+fn find_value_source(matches: &ArgMatches, id: &str) -> Option<ValueSource> {
+    match matches.try_contains_id(id) {
+        Ok(_) => matches.value_source(id),
+        Err(_) => matches
+            .subcommand()
+            .and_then(|(_, sub_matches)| find_value_source(sub_matches, id)),
+    }
 }
 
 fn map_value_source(source: ValueSource) -> Option<ArgValueSource> {
@@ -375,5 +384,37 @@ fn print_error(err: &anyhow::Error, code: ExitCode) {
     eprintln!("error: {err}");
     if code == ExitCode::Error {
         eprintln!("If this seems like a bug, file an issue at https://github.com/braintrustdata/bt/issues/new and include `bt --version`, `bt status --json`, and the command you ran.");
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn apply_base_arg_sources_tracks_cli_api_key() {
+        let matches = Cli::command()
+            .try_get_matches_from(["bt", "status", "--api-key", "secret"])
+            .expect("matches");
+        let mut cli = Cli::from_arg_matches(&matches).expect("cli");
+
+        apply_base_arg_sources(&matches, cli.command.base_mut());
+
+        assert_eq!(
+            cli.command.base().api_key_source,
+            Some(ArgValueSource::CommandLine)
+        );
+    }
+
+    #[test]
+    fn apply_base_arg_sources_leaves_api_key_source_empty_when_unset() {
+        let matches = Cli::command()
+            .try_get_matches_from(["bt", "status"])
+            .expect("matches");
+        let mut cli = Cli::from_arg_matches(&matches).expect("cli");
+
+        apply_base_arg_sources(&matches, cli.command.base_mut());
+
+        assert_eq!(cli.command.base().api_key_source, None);
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,5 @@
 use anyhow::Result;
-use clap::{Parser, Subcommand};
+use clap::{parser::ValueSource, ArgMatches, CommandFactory, FromArgMatches, Parser, Subcommand};
 use std::ffi::{OsStr, OsString};
 
 mod args;
@@ -31,7 +31,7 @@ mod ui;
 mod util_cmd;
 mod utils;
 
-use crate::args::{BaseArgs, CLIArgs};
+use crate::args::{ArgValueSource, BaseArgs, CLIArgs};
 
 const DEFAULT_CANARY_VERSION: &str = concat!(env!("CARGO_PKG_VERSION"), "-canary.dev");
 const CLI_VERSION: &str = match option_env!("BT_VERSION_STRING") {
@@ -176,6 +176,30 @@ impl Commands {
             Commands::Status(cmd) => &cmd.base,
         }
     }
+
+    fn base_mut(&mut self) -> &mut BaseArgs {
+        match self {
+            Commands::Init(cmd) => &mut cmd.base,
+            Commands::Setup(cmd) => &mut cmd.base,
+            Commands::Docs(cmd) => &mut cmd.base,
+            Commands::Sql(cmd) => &mut cmd.base,
+            Commands::Auth(cmd) => &mut cmd.base,
+            Commands::View(cmd) => &mut cmd.base,
+            #[cfg(unix)]
+            Commands::Eval(cmd) => &mut cmd.base,
+            Commands::Projects(cmd) => &mut cmd.base,
+            Commands::Prompts(cmd) => &mut cmd.base,
+            Commands::SelfCommand(cmd) => &mut cmd.base,
+            Commands::Tools(cmd) => &mut cmd.base,
+            Commands::Scorers(cmd) => &mut cmd.base,
+            Commands::Functions(cmd) => &mut cmd.base,
+            Commands::Experiments(cmd) => &mut cmd.base,
+            Commands::Sync(cmd) => &mut cmd.base,
+            Commands::Util(cmd) => &mut cmd.base,
+            Commands::Switch(cmd) => &mut cmd.base,
+            Commands::Status(cmd) => &mut cmd.base,
+        }
+    }
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -205,7 +229,9 @@ async fn try_main() -> Result<()> {
     let argv: Vec<OsString> = std::env::args_os().collect();
     env::bootstrap_from_args(&argv)?;
 
-    let cli = Cli::parse_from(argv);
+    let matches = Cli::command().get_matches_from(&argv);
+    let mut cli = Cli::from_arg_matches(&matches).expect("clap matches should parse");
+    apply_base_arg_sources(&matches, cli.command.base_mut());
     configure_output(cli.command.base());
 
     match cli.command {
@@ -231,6 +257,18 @@ async fn try_main() -> Result<()> {
     }
 
     Ok(())
+}
+
+fn apply_base_arg_sources(matches: &ArgMatches, base: &mut BaseArgs) {
+    base.api_key_source = matches.value_source("api_key").and_then(map_value_source);
+}
+
+fn map_value_source(source: ValueSource) -> Option<ArgValueSource> {
+    match source {
+        ValueSource::CommandLine => Some(ArgValueSource::CommandLine),
+        ValueSource::EnvVariable => Some(ArgValueSource::EnvVariable),
+        _ => None,
+    }
 }
 
 fn configure_output(base: &BaseArgs) {

--- a/src/main.rs
+++ b/src/main.rs
@@ -80,10 +80,8 @@ Flags
       --profile <PROFILE>    Use a saved login profile [env: BRAINTRUST_PROFILE]
   -o, --org <ORG>            Override active org [env: BRAINTRUST_ORG_NAME]
   -p, --project <PROJECT>    Override active project [env: BRAINTRUST_DEFAULT_PROJECT]
-  -q, --quiet                Suppress non-essential output
       --json                 Output as JSON
       --no-color             Disable ANSI color output
-      --no-input             Disable all interactive prompts
       --api-url <URL>        Override API URL [env: BRAINTRUST_API_URL]
       --app-url <URL>        Override app URL [env: BRAINTRUST_APP_URL]
       --env-file <PATH>      Path to a .env file to load
@@ -249,14 +247,8 @@ fn configure_output(base: &BaseArgs) {
         ui::set_animations_enabled(false);
     }
 
-    if base.quiet {
-        ui::set_quiet(true);
-        ui::set_animations_enabled(false);
-    }
-
-    if base.no_input {
-        ui::set_no_input(true);
-    }
+    ui::set_quiet(true);
+    ui::set_animations_enabled(false);
 
     if disable_color {
         dialoguer::console::set_colors_enabled(false);

--- a/src/main.rs
+++ b/src/main.rs
@@ -392,15 +392,36 @@ fn print_error(err: &anyhow::Error, code: ExitCode) {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::env;
+    use std::ffi::OsString;
+    use std::sync::{Mutex, OnceLock};
+
+    fn env_test_lock() -> &'static Mutex<()> {
+        static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+        LOCK.get_or_init(|| Mutex::new(()))
+    }
+
+    fn restore_env_var(key: &str, previous: Option<OsString>) {
+        match previous {
+            Some(value) => env::set_var(key, value),
+            None => env::remove_var(key),
+        }
+    }
 
     #[test]
     fn apply_base_arg_sources_tracks_cli_api_key() {
+        let _guard = env_test_lock().lock().expect("env test lock");
+        let previous_api_key = env::var_os("BRAINTRUST_API_KEY");
+        env::remove_var("BRAINTRUST_API_KEY");
+
         let matches = Cli::command()
             .try_get_matches_from(["bt", "status", "--api-key", "secret"])
             .expect("matches");
         let mut cli = Cli::from_arg_matches(&matches).expect("cli");
 
         apply_base_arg_sources(&matches, cli.command.base_mut());
+
+        restore_env_var("BRAINTRUST_API_KEY", previous_api_key);
 
         assert_eq!(
             cli.command.base().api_key_source,
@@ -410,6 +431,10 @@ mod tests {
 
     #[test]
     fn apply_base_arg_sources_leaves_api_key_source_empty_when_unset() {
+        let _guard = env_test_lock().lock().expect("env test lock");
+        let previous_api_key = env::var_os("BRAINTRUST_API_KEY");
+        env::remove_var("BRAINTRUST_API_KEY");
+
         let matches = Cli::command()
             .try_get_matches_from(["bt", "status"])
             .expect("matches");
@@ -417,6 +442,35 @@ mod tests {
 
         apply_base_arg_sources(&matches, cli.command.base_mut());
 
+        restore_env_var("BRAINTRUST_API_KEY", previous_api_key);
+
         assert_eq!(cli.command.base().api_key_source, None);
+    }
+
+    #[test]
+    fn deprecated_global_quiet_flag_still_parses_for_other_commands() {
+        let matches = Cli::command()
+            .try_get_matches_from(["bt", "status", "--quiet"])
+            .expect("matches");
+        let cli = Cli::from_arg_matches(&matches).expect("cli");
+
+        assert!(cli.command.base().quiet);
+    }
+
+    #[test]
+    fn deprecated_global_quiet_flag_still_parses_for_setup_subcommands() {
+        let matches = Cli::command()
+            .try_get_matches_from(["bt", "setup", "skills", "--quiet"])
+            .expect("matches");
+        let cli = Cli::from_arg_matches(&matches).expect("cli");
+
+        assert!(cli.command.base().quiet);
+    }
+
+    #[test]
+    fn setup_instrument_quiet_no_longer_aliases_background() {
+        Cli::command()
+            .try_get_matches_from(["bt", "setup", "instrument", "--quiet", "--tui"])
+            .expect("matches");
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -79,9 +79,10 @@ Additional
 Flags
       --profile <PROFILE>    Use a saved login profile [env: BRAINTRUST_PROFILE]
   -o, --org <ORG>            Override active org [env: BRAINTRUST_ORG_NAME]
-  -p, --project <PROJECT>    Override active project [env: BRAINTRUST_DEFAULT_PROJECT]
+      -p, --project <PROJECT>    Override active project [env: BRAINTRUST_DEFAULT_PROJECT]
       --json                 Output as JSON
       --no-color             Disable ANSI color output
+      --no-input             Disable all interactive prompts
       --api-url <URL>        Override API URL [env: BRAINTRUST_API_URL]
       --app-url <URL>        Override app URL [env: BRAINTRUST_APP_URL]
       --env-file <PATH>      Path to a .env file to load
@@ -295,6 +296,7 @@ fn configure_output(base: &BaseArgs) {
     }
 
     ui::set_quiet(true);
+    ui::set_no_input(base.no_input);
     ui::set_animations_enabled(false);
 
     if disable_color {

--- a/src/prompts/mod.rs
+++ b/src/prompts/mod.rs
@@ -48,10 +48,6 @@ pub struct ViewArgs {
     /// Open in browser instead of showing in terminal
     #[arg(long)]
     web: bool,
-
-    /// Show all model parameters and configuration
-    #[arg(long)]
-    verbose: bool,
 }
 
 impl ViewArgs {
@@ -93,7 +89,7 @@ pub async fn run(base: BaseArgs, args: PromptsArgs) -> Result<()> {
         }
         Some(PromptsCommands::View(p)) => {
             let ctx = resolve_project_context(&base, true).await?;
-            view::run(&ctx, p.slug(), base.json, p.web, p.verbose).await
+            view::run(&ctx, p.slug(), base.json, p.web, base.verbose).await
         }
         Some(PromptsCommands::Delete(p)) => {
             let ctx = resolve_project_context(&base, false).await?;
@@ -122,7 +118,6 @@ mod tests {
                 slug_positional: Some("my-prompt".to_string()),
                 slug_flag: None,
                 web: false,
-                verbose: false,
             }
         ))));
     }

--- a/src/setup/mod.rs
+++ b/src/setup/mod.rs
@@ -12,7 +12,7 @@ use serde::Serialize;
 use serde_json::{Map, Value};
 use tokio::process::Command;
 
-use crate::args::{ArgValueSource, BaseArgs};
+use crate::args::{ArgValueSource, BaseArgs, DEFAULT_API_URL, DEFAULT_APP_URL};
 use crate::auth;
 use crate::auth::LoginContext;
 use crate::config;
@@ -513,40 +513,57 @@ async fn run_setup_wizard(mut base: BaseArgs, flags: WizardFlags) -> Result<()> 
     } = flags;
     let mut had_failures = false;
     let verbose = base.verbose;
+    let will_instrument = !flag_no_instrument && find_git_root().is_some();
 
     // ── Step 1: Auth ──
     if verbose {
         print_wizard_step(1, "Auth");
     }
-    let project_flag = base.project.clone();
-    let client = ensure_setup_auth(&mut base, !flag_no_instrument, !flag_no_instrument).await?;
-    let org = client.org_name().to_string();
+    let project_flag = will_instrument.then(|| base.project.clone()).flatten();
+    let setup_client = if will_instrument {
+        Some(ensure_setup_auth(&mut base, !flag_no_instrument, !flag_no_instrument).await?)
+    } else {
+        None
+    };
+    let org = setup_client
+        .as_ref()
+        .map(|client| client.org_name().to_string());
 
     if verbose {
-        eprintln!("   {} Using org '{}'", style("✓").green(), org);
+        if let Some(org) = org.as_deref() {
+            eprintln!("   {} Using org '{}'", style("✓").green(), org);
+        } else {
+            eprintln!("   {}", style("Skipped").dim());
+        }
     }
 
     // ── Step 2: Project ──
     if verbose {
         print_wizard_step(2, "Project");
     }
-    let project = select_project_with_skip(&client, project_flag.as_deref(), !verbose).await?;
+    let project = if let Some(client) = setup_client.as_ref() {
+        select_project_with_skip(client, project_flag.as_deref(), !verbose).await?
+    } else {
+        None
+    };
     if verbose {
         if let Some(ref project) = project {
-            if find_git_root().is_some() && maybe_init(&org, project)? {
-                eprintln!(
-                    "   {} Linked to {}/{}",
-                    style("✓").green(),
-                    org,
-                    project.name
-                );
+            if let Some(org) = org.as_deref() {
+                if maybe_init(org, project)? {
+                    eprintln!(
+                        "   {} Linked to {}/{}",
+                        style("✓").green(),
+                        org,
+                        project.name
+                    );
+                }
             }
         } else {
             eprintln!("   {}", style("Skipped").dim());
         }
     } else if let Some(ref project) = project {
-        if find_git_root().is_some() {
-            let _ = maybe_init(&org, project)?;
+        if let Some(org) = org.as_deref() {
+            let _ = maybe_init(org, project)?;
         }
     }
 
@@ -775,16 +792,14 @@ async fn run_setup_wizard(mut base: BaseArgs, flags: WizardFlags) -> Result<()> 
 }
 
 async fn run_default_setup(mut base: BaseArgs, args: SetupArgs) -> Result<()> {
-    let needs_auth = !args.no_instrument;
-    if needs_auth {
+    let will_instrument = !args.no_instrument && find_git_root().is_some();
+    if will_instrument {
         let project_flag = base.project.clone();
         let client = ensure_setup_auth(&mut base, false, true).await?;
         let org = client.org_name().to_string();
         let project = select_project_with_skip(&client, project_flag.as_deref(), true).await?;
         if let Some(ref project) = project {
-            if find_git_root().is_some() {
-                let _ = maybe_init(&org, project)?;
-            }
+            let _ = maybe_init(&org, project)?;
         }
     }
 
@@ -830,7 +845,7 @@ async fn run_default_setup(mut base: BaseArgs, args: SetupArgs) -> Result<()> {
     }
 
     if !args.no_instrument {
-        if find_git_root().is_some() {
+        if will_instrument {
             run_instrument_setup(
                 base,
                 InstrumentSetupArgs {
@@ -861,18 +876,55 @@ fn in_ci() -> bool {
     std::env::var_os("CI").is_some()
 }
 
+fn apply_setup_config_fallbacks(base: &mut BaseArgs) {
+    let cfg = config::load().unwrap_or_default();
+
+    if base
+        .org_name
+        .as_deref()
+        .map(str::trim)
+        .is_none_or(str::is_empty)
+    {
+        base.org_name = cfg
+            .org
+            .map(|value| value.trim().to_string())
+            .filter(|value| !value.is_empty());
+    }
+
+    if base
+        .project
+        .as_deref()
+        .map(str::trim)
+        .is_none_or(str::is_empty)
+    {
+        base.project = cfg
+            .project
+            .map(|value| value.trim().to_string())
+            .filter(|value| !value.is_empty());
+    }
+}
+
+fn setup_can_prompt(base: &BaseArgs) -> bool {
+    !base.json && !base.no_input && !in_ci() && ui::can_prompt()
+}
+
 fn resolve_profile_name_for_setup(
     base: &BaseArgs,
     profiles: &[auth::ProfileInfo],
     prompt_for_choice: bool,
-) -> Result<String> {
+) -> Result<Option<String>> {
     if let Some(profile_name) = base
         .profile
         .as_deref()
         .map(str::trim)
         .filter(|value| !value.is_empty())
     {
-        return Ok(profile_name.to_string());
+        if profiles.iter().any(|profile| profile.name == profile_name) {
+            return Ok(Some(profile_name.to_string()));
+        }
+        bail!(
+            "profile '{profile_name}' not found; run `bt auth profiles` to see available profiles"
+        );
     }
 
     if let Some(org_name) = base.org_name.as_deref() {
@@ -881,7 +933,7 @@ fn resolve_profile_name_for_setup(
             .find(|profile| profile.name == org_name)
             .map(|profile| profile.name.clone())
         {
-            return Ok(profile_name);
+            return Ok(Some(profile_name));
         }
 
         let mut matches = profiles
@@ -892,56 +944,210 @@ fn resolve_profile_name_for_setup(
         matches.sort();
 
         return match matches.len() {
-            0 => auth::resolve_org_to_profile(org_name, profiles),
-            1 => Ok(matches.remove(0)),
+            0 => Ok(None),
+            1 => Ok(Some(matches.remove(0))),
             _ if prompt_for_choice => auth::select_profile_interactive(Some(org_name))?
+                .map(Some)
                 .ok_or_else(|| anyhow!("no profile selected")),
-            _ => Ok(matches.remove(0)),
+            _ => bail!(
+                "multiple profiles for org '{org_name}': {}. Use --profile to disambiguate.",
+                matches.join(", ")
+            ),
         };
     }
 
     if profiles.len() == 1 {
-        return Ok(profiles[0].name.clone());
+        return Ok(Some(profiles[0].name.clone()));
     }
 
     if prompt_for_choice {
-        auth::select_profile_interactive(None)?.ok_or_else(|| anyhow!("no profile selected"))
+        auth::select_profile_interactive(None)?
+            .map(Some)
+            .ok_or_else(|| anyhow!("no profile selected"))
     } else {
-        let mut names = profiles
-            .iter()
-            .map(|profile| profile.name.clone())
-            .collect::<Vec<_>>();
-        names.sort();
-        Ok(names.remove(0))
+        Ok(None)
     }
 }
 
-async fn ensure_auth(
+fn find_http_error(err: &anyhow::Error) -> Option<&crate::http::HttpError> {
+    err.chain()
+        .find_map(|source| source.downcast_ref::<crate::http::HttpError>())
+}
+
+async fn list_available_orgs_for_setup(
+    api_key: &str,
+    app_url: &str,
+) -> Result<Vec<auth::AvailableOrg>> {
+    match auth::list_available_orgs_for_api_key(api_key, app_url).await {
+        Ok(orgs) => Ok(orgs),
+        Err(err) => {
+            if let Some(http_err) = find_http_error(&err) {
+                if matches!(http_err.status.as_u16(), 401 | 403) {
+                    return Ok(Vec::new());
+                }
+            }
+            if err
+                .to_string()
+                .contains("no organizations found for this API key")
+            {
+                return Ok(Vec::new());
+            }
+            Err(err)
+        }
+    }
+}
+
+fn find_available_org<'a>(
+    orgs: &'a [auth::AvailableOrg],
+    org_name: &str,
+) -> Option<&'a auth::AvailableOrg> {
+    orgs.iter().find(|org| org.name == org_name).or_else(|| {
+        let lowered = org_name.to_ascii_lowercase();
+        orgs.iter()
+            .find(|org| org.name.to_ascii_lowercase() == lowered)
+    })
+}
+
+fn build_api_key_login_context(
+    base: &BaseArgs,
+    api_key: &str,
+    org: &auth::AvailableOrg,
+) -> LoginContext {
+    let api_url = base
+        .api_url
+        .clone()
+        .or_else(|| org.api_url.clone())
+        .unwrap_or_else(|| DEFAULT_API_URL.to_string());
+    let app_url = base
+        .app_url
+        .clone()
+        .unwrap_or_else(|| DEFAULT_APP_URL.to_string());
+
+    LoginContext {
+        login: braintrust_sdk_rust::LoginState {
+            api_key: api_key.to_string(),
+            org_id: org.id.clone(),
+            org_name: org.name.clone(),
+            api_url: Some(api_url.clone()),
+        },
+        api_url,
+        app_url,
+    }
+}
+
+async fn build_api_key_client(
+    base: &BaseArgs,
+    api_key: &str,
+    org: &auth::AvailableOrg,
+) -> Result<ApiClient> {
+    ApiClient::new(&build_api_key_login_context(base, api_key, org))
+}
+
+async fn project_exists_in_org(client: &ApiClient, project_name: &str) -> Result<bool> {
+    let projects = crate::projects::api::list_projects(client).await?;
+    Ok(projects
+        .into_iter()
+        .any(|project| project.name == project_name))
+}
+
+async fn orgs_with_project(
+    base: &BaseArgs,
+    api_key: &str,
+    orgs: &[auth::AvailableOrg],
+    project_name: &str,
+) -> Result<Vec<auth::AvailableOrg>> {
+    let mut matches = Vec::new();
+    for org in orgs {
+        let client = build_api_key_client(base, api_key, org).await?;
+        if project_exists_in_org(&client, project_name).await? {
+            matches.push(org.clone());
+        }
+    }
+    Ok(matches)
+}
+
+fn prompt_for_org_choice(prompt: &str, orgs: &[auth::AvailableOrg]) -> Result<auth::AvailableOrg> {
+    let labels: Vec<&str> = orgs.iter().map(|org| org.name.as_str()).collect();
+    let idx = FuzzySelect::with_theme(&ColorfulTheme::default())
+        .with_prompt(prompt)
+        .items(&labels)
+        .default(0)
+        .interact_on(&ui::prompt_term().ok_or_else(|| anyhow!("interactive mode requires TTY"))?)?;
+    Ok(orgs[idx].clone())
+}
+
+fn select_api_key_org_for_setup(
+    base: &BaseArgs,
+    orgs: &[auth::AvailableOrg],
+    project_name: Option<&str>,
+    preferred_org_names: &[String],
+) -> Result<auth::AvailableOrg> {
+    let mut candidates = if preferred_org_names.is_empty() {
+        orgs.to_vec()
+    } else {
+        orgs.iter()
+            .filter(|org| preferred_org_names.iter().any(|name| name == &org.name))
+            .cloned()
+            .collect::<Vec<_>>()
+    };
+
+    candidates.sort_by(|left, right| left.name.cmp(&right.name));
+    candidates.dedup_by(|left, right| left.name == right.name);
+
+    if candidates.len() == 1 {
+        return Ok(candidates.remove(0));
+    }
+
+    if setup_can_prompt(base) {
+        let prompt = if project_name.is_some() {
+            "Select organization for the requested project"
+        } else {
+            "Select organization"
+        };
+        return prompt_for_org_choice(prompt, &candidates);
+    }
+
+    bail!("organization choice required in non-interactive mode; pass --org <NAME>")
+}
+
+fn matching_profile_org_names(
+    profiles: &[auth::StoredProfileInfo],
+    only_oauth: Option<bool>,
+) -> Vec<String> {
+    let mut org_names = profiles
+        .iter()
+        .filter(|profile| {
+            only_oauth
+                .map(|expected| profile.is_oauth == expected)
+                .unwrap_or(true)
+        })
+        .filter_map(|profile| profile.org_name.clone())
+        .collect::<Vec<_>>();
+    org_names.sort();
+    org_names.dedup();
+    org_names
+}
+
+async fn ensure_profile_or_oauth_auth(
     base: &mut BaseArgs,
     prompt_for_profile_choice: bool,
 ) -> Result<(LoginContext, bool)> {
-    if matches!(base.api_key_source, Some(ArgValueSource::CommandLine)) {
-        return Ok((auth::login(base).await?, false));
-    }
-
-    if matches!(base.api_key_source, Some(ArgValueSource::EnvVariable)) && !base.prefer_profile {
-        return Ok((auth::login(base).await?, false));
-    }
-
     let profiles = auth::list_profiles()?;
-    if !profiles.is_empty() {
-        let should_prompt_for_profile_choice = prompt_for_profile_choice
-            && !base.json
-            && !base.no_input
-            && !in_ci()
-            && ui::can_prompt();
-        let profile_name =
-            resolve_profile_name_for_setup(base, &profiles, should_prompt_for_profile_choice)?;
-        base.profile = Some(profile_name.clone());
+    let can_prompt = setup_can_prompt(base);
+    let should_prompt_for_profile_choice = prompt_for_profile_choice && can_prompt;
+    let selected_profile =
+        resolve_profile_name_for_setup(base, &profiles, should_prompt_for_profile_choice)?;
+    let mut auth_base = base.clone();
+    auth_base.api_key = None;
+    auth_base.api_key_source = None;
 
-        match auth::login(base).await {
+    if let Some(profile_name) = selected_profile {
+        auth_base.profile = Some(profile_name.clone());
+
+        match auth::login(&auth_base).await {
             Ok(ctx) => {
-                let is_oauth = auth::resolve_auth(base).await?.is_oauth;
+                base.profile = auth_base.profile.clone();
+                let is_oauth = auth::resolve_auth(&auth_base).await?.is_oauth;
                 return Ok((ctx, is_oauth));
             }
             Err(err) if auth::is_missing_credential_error(&err) => {
@@ -951,18 +1157,34 @@ async fn ensure_auth(
                         profile_name, err
                     );
                 }
-                auth::login_interactive_oauth(base).await?;
-                return Ok((auth::login(base).await?, true));
+                if !can_prompt {
+                    bail!(
+                        "setup needs interactive OAuth re-authentication; rerun without --no-input/--json or pass a working API key"
+                    );
+                }
+                auth::login_interactive_oauth(&mut auth_base).await?;
+                base.profile = auth_base.profile.clone();
+                return Ok((auth::login(&auth_base).await?, true));
             }
             Err(err) => return Err(err),
         }
     }
 
-    if base.verbose {
-        eprintln!("No auth profiles found. Starting OAuth login.\n");
+    if !can_prompt {
+        if profiles.is_empty() {
+            bail!(
+                "setup needs interactive authentication; rerun without --no-input/--json or pass a valid API key/profile"
+            );
+        }
+        bail!("profile selection required in non-interactive mode; pass --profile <NAME>");
     }
-    auth::login_interactive_oauth(base).await?;
-    Ok((auth::login(base).await?, true))
+
+    if base.verbose {
+        eprintln!("Starting OAuth login.\n");
+    }
+    auth::login_interactive_oauth(&mut auth_base).await?;
+    base.profile = auth_base.profile.clone();
+    Ok((auth::login(&auth_base).await?, true))
 }
 
 async fn ensure_setup_auth(
@@ -970,7 +1192,226 @@ async fn ensure_setup_auth(
     prompt_for_profile_choice: bool,
     will_instrument: bool,
 ) -> Result<ApiClient> {
-    let (login_ctx, is_oauth) = ensure_auth(base, prompt_for_profile_choice).await?;
+    apply_setup_config_fallbacks(base);
+
+    let explicit_api_key = base
+        .api_key
+        .as_deref()
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(str::to_string);
+    let stored_profiles = auth::list_stored_profiles()?;
+    let project_name = base
+        .project
+        .as_deref()
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(str::to_string);
+    let org_name = base
+        .org_name
+        .as_deref()
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(str::to_string);
+    let profile_name = base
+        .profile
+        .as_deref()
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(str::to_string);
+
+    if let Some(api_key) = explicit_api_key.as_deref() {
+        let app_url = base
+            .app_url
+            .clone()
+            .unwrap_or_else(|| DEFAULT_APP_URL.to_string());
+        let available_orgs = list_available_orgs_for_setup(api_key, &app_url).await?;
+
+        if let Some(profile_name) = profile_name.as_deref() {
+            let profile = stored_profiles
+                .iter()
+                .find(|profile| profile.name == profile_name)
+                .ok_or_else(|| anyhow!("profile '{profile_name}' not found"))?;
+            let target_org = match org_name.as_deref() {
+                Some(org_name) => {
+                    if profile.org_name.as_deref() != Some(org_name) {
+                        bail!(
+                            "profile '{profile_name}' belongs to org '{}' but '{}' was requested",
+                            profile.org_name.as_deref().unwrap_or("(none)"),
+                            org_name
+                        );
+                    }
+                    org_name
+                }
+                None => profile.org_name.as_deref().ok_or_else(|| {
+                    anyhow!("profile '{profile_name}' does not have a default org")
+                })?,
+            };
+
+            if let Some(org) = find_available_org(&available_orgs, target_org) {
+                let client = build_api_key_client(base, api_key, org).await?;
+                if let Some(project_name) = project_name.as_deref() {
+                    if !project_exists_in_org(&client, project_name).await? {
+                        bail!("project '{project_name}' not found in org '{}'", org.name);
+                    }
+                }
+                return Ok(client);
+            }
+
+            let (login_ctx, is_oauth) =
+                ensure_profile_or_oauth_auth(base, prompt_for_profile_choice).await?;
+            let client = ApiClient::new(&login_ctx)?;
+            if let Some(project_name) = project_name.as_deref() {
+                if !project_exists_in_org(&client, project_name).await? {
+                    bail!(
+                        "project '{project_name}' not found in org '{}'",
+                        client.org_name()
+                    );
+                }
+            }
+            if should_create_api_key_for_instrumentation(is_oauth, base, will_instrument) {
+                maybe_create_api_key_for_instrumentation(base, &client).await?;
+            }
+            return Ok(client);
+        }
+
+        if let Some(org_name) = org_name.as_deref() {
+            let matching_profile_count = stored_profiles
+                .iter()
+                .filter(|profile| profile.org_name.as_deref() == Some(org_name))
+                .count();
+            if base.prefer_profile && matching_profile_count == 0 {
+                bail!("no profile found for org '{org_name}'");
+            }
+
+            if let Some(org) = find_available_org(&available_orgs, org_name) {
+                let client = build_api_key_client(base, api_key, org).await?;
+                if let Some(project_name) = project_name.as_deref() {
+                    if !project_exists_in_org(&client, project_name).await? {
+                        bail!("project '{project_name}' not found in org '{org_name}'");
+                    }
+                }
+                return Ok(client);
+            }
+
+            let (login_ctx, is_oauth) =
+                ensure_profile_or_oauth_auth(base, prompt_for_profile_choice).await?;
+            let client = ApiClient::new(&login_ctx)?;
+            if let Some(project_name) = project_name.as_deref() {
+                if !project_exists_in_org(&client, project_name).await? {
+                    bail!(
+                        "project '{project_name}' not found in org '{}'",
+                        client.org_name()
+                    );
+                }
+            }
+            if should_create_api_key_for_instrumentation(is_oauth, base, will_instrument) {
+                maybe_create_api_key_for_instrumentation(base, &client).await?;
+            }
+            return Ok(client);
+        }
+
+        if base.prefer_profile {
+            if stored_profiles.is_empty() {
+                let matched_orgs = match project_name.as_deref() {
+                    Some(project_name) => {
+                        orgs_with_project(base, api_key, &available_orgs, project_name).await?
+                    }
+                    None => available_orgs.clone(),
+                };
+                if matched_orgs.is_empty() {
+                    let (login_ctx, is_oauth) =
+                        ensure_profile_or_oauth_auth(base, prompt_for_profile_choice).await?;
+                    let client = ApiClient::new(&login_ctx)?;
+                    if should_create_api_key_for_instrumentation(is_oauth, base, will_instrument) {
+                        maybe_create_api_key_for_instrumentation(base, &client).await?;
+                    }
+                    return Ok(client);
+                }
+                let org = select_api_key_org_for_setup(
+                    base,
+                    &matched_orgs,
+                    project_name.as_deref(),
+                    &[],
+                )?;
+                let client = build_api_key_client(base, api_key, &org).await?;
+                let api_url = base
+                    .api_url
+                    .clone()
+                    .or_else(|| org.api_url.clone())
+                    .unwrap_or_else(|| DEFAULT_API_URL.to_string());
+                auth::commit_api_key_profile(
+                    &org.name,
+                    api_key,
+                    api_url,
+                    base.app_url.clone(),
+                    Some(org.name.clone()),
+                )?;
+                return Ok(client);
+            }
+
+            let preferred_org_names = matching_profile_org_names(&stored_profiles, None);
+            let matching_orgs = available_orgs
+                .iter()
+                .filter(|org| preferred_org_names.iter().any(|name| name == &org.name))
+                .cloned()
+                .collect::<Vec<_>>();
+            if matching_orgs.is_empty() {
+                let (login_ctx, is_oauth) =
+                    ensure_profile_or_oauth_auth(base, prompt_for_profile_choice).await?;
+                let client = ApiClient::new(&login_ctx)?;
+                if should_create_api_key_for_instrumentation(is_oauth, base, will_instrument) {
+                    maybe_create_api_key_for_instrumentation(base, &client).await?;
+                }
+                return Ok(client);
+            }
+
+            let candidate_orgs = match project_name.as_deref() {
+                Some(project_name) => {
+                    orgs_with_project(base, api_key, &matching_orgs, project_name).await?
+                }
+                None => matching_orgs,
+            };
+            if candidate_orgs.is_empty() {
+                let (login_ctx, is_oauth) =
+                    ensure_profile_or_oauth_auth(base, prompt_for_profile_choice).await?;
+                let client = ApiClient::new(&login_ctx)?;
+                if should_create_api_key_for_instrumentation(is_oauth, base, will_instrument) {
+                    maybe_create_api_key_for_instrumentation(base, &client).await?;
+                }
+                return Ok(client);
+            }
+            let org = select_api_key_org_for_setup(
+                base,
+                &candidate_orgs,
+                project_name.as_deref(),
+                &preferred_org_names,
+            )?;
+            return build_api_key_client(base, api_key, &org).await;
+        }
+
+        let candidate_orgs = match project_name.as_deref() {
+            Some(project_name) => {
+                orgs_with_project(base, api_key, &available_orgs, project_name).await?
+            }
+            None => available_orgs.clone(),
+        };
+        if candidate_orgs.is_empty() {
+            let (login_ctx, is_oauth) =
+                ensure_profile_or_oauth_auth(base, prompt_for_profile_choice).await?;
+            let client = ApiClient::new(&login_ctx)?;
+            if should_create_api_key_for_instrumentation(is_oauth, base, will_instrument) {
+                maybe_create_api_key_for_instrumentation(base, &client).await?;
+            }
+            return Ok(client);
+        }
+        let org =
+            select_api_key_org_for_setup(base, &candidate_orgs, project_name.as_deref(), &[])?;
+        return build_api_key_client(base, api_key, &org).await;
+    }
+
+    let (login_ctx, is_oauth) =
+        ensure_profile_or_oauth_auth(base, prompt_for_profile_choice).await?;
     let client = ApiClient::new(&login_ctx)?;
     if should_create_api_key_for_instrumentation(is_oauth, base, will_instrument) {
         maybe_create_api_key_for_instrumentation(base, &client).await?;
@@ -1062,19 +1503,19 @@ async fn select_project_for_setup(
     project_name: Option<&str>,
 ) -> Result<crate::projects::api::Project> {
     if let Some(name) = project_name {
-        let project = with_spinner(
-            "Loading project...",
-            crate::projects::api::get_project_by_name(client, name),
+        let projects = with_spinner(
+            "Loading projects...",
+            crate::projects::api::list_projects(client),
         )
         .await?;
-        match project {
-            Some(p) => return Ok(p),
-            None => bail!(
-                "project '{}' not found in org '{}'",
-                name,
-                client.org_name()
-            ),
+        if let Some(project) = projects.into_iter().find(|project| project.name == name) {
+            return Ok(project);
         }
+        bail!(
+            "project '{}' not found in org '{}'",
+            name,
+            client.org_name()
+        )
     }
 
     let mut projects = with_spinner(
@@ -3534,7 +3975,7 @@ mod tests {
     }
 
     #[test]
-    fn resolve_profile_name_for_setup_uses_first_alphabetical_profile_without_prompt() {
+    fn resolve_profile_name_for_setup_requires_prompt_when_multiple_profiles_exist() {
         let base = make_base_args();
         let profiles = vec![
             auth::ProfileInfo {
@@ -3555,7 +3996,24 @@ mod tests {
 
         let resolved =
             resolve_profile_name_for_setup(&base, &profiles, false).expect("resolve profile");
-        assert_eq!(resolved, "alpha");
+        assert_eq!(resolved, None);
+    }
+
+    #[test]
+    fn resolve_profile_name_for_setup_errors_for_unknown_explicit_profile() {
+        let mut base = make_base_args();
+        base.profile = Some("missing".to_string());
+        let profiles = vec![auth::ProfileInfo {
+            name: "work".to_string(),
+            org_name: Some("Acme".to_string()),
+            user_name: None,
+            email: None,
+            api_key_hint: None,
+        }];
+
+        let err =
+            resolve_profile_name_for_setup(&base, &profiles, false).expect_err("missing profile");
+        assert!(err.to_string().contains("profile 'missing' not found"));
     }
 
     #[test]

--- a/src/setup/mod.rs
+++ b/src/setup/mod.rs
@@ -1461,8 +1461,11 @@ async fn maybe_create_api_key_for_instrumentation(
     let existing: Vec<String> = client
         .get::<ApiKeyList>("/v1/api_key")
         .await
-        .map(|r| r.objects.into_iter().map(|k| k.name).collect())
-        .unwrap_or_default();
+        .context("failed to list existing Braintrust API keys before creating one")?
+        .objects
+        .into_iter()
+        .map(|k| k.name)
+        .collect();
 
     let name = if !existing.iter().any(|n| n == &base_name) {
         base_name

--- a/src/setup/mod.rs
+++ b/src/setup/mod.rs
@@ -53,21 +53,58 @@ pub struct SetupArgs {
     #[command(subcommand)]
     command: Option<SetupSubcommand>,
 
-    /// Set up coding-agent skills (skips interactive selection in wizard)
-    #[arg(long)]
+    /// Set up coding-agent skills [default]
+    #[arg(long, conflicts_with = "no_skills")]
     skills: bool,
 
-    /// Set up MCP server (skips interactive selection in wizard)
-    #[arg(long)]
+    /// Do not set up coding-agent skills
+    #[arg(long, conflicts_with = "skills")]
+    no_skills: bool,
+
+    /// Set up MCP server
+    #[arg(long, conflicts_with = "no_mcp")]
     mcp: bool,
 
-    /// Run instrumentation agent (skips interactive prompt in wizard)
+    /// Do not set up MCP server [default]
+    #[arg(long, conflicts_with = "mcp")]
+    no_mcp: bool,
+
+    /// Run instrumentation agent [default]
     #[arg(long)]
     instrument: bool,
 
-    /// Skip skills and MCP setup (skips interactive selection in wizard)
-    #[arg(long, conflicts_with_all = ["skills", "mcp"])]
-    no_mcp_skill: bool,
+    /// Do not run instrumentation agent (skills and MCP are still configured)
+    #[arg(
+        long,
+        conflicts_with = "instrument",
+        conflicts_with = "tui",
+        conflicts_with = "background",
+        conflicts_with = "yolo"
+    )]
+    no_instrument: bool,
+
+    /// Run the agent in interactive TUI mode [default]
+    #[arg(long, conflicts_with = "background", conflicts_with = "no_instrument")]
+    tui: bool,
+
+    /// Run the agent in background (non-interactive) mode
+    #[arg(long, conflicts_with = "tui", conflicts_with = "no_instrument")]
+    background: bool,
+
+    /// Language(s) to instrument (repeatable; case-insensitive).
+    /// When provided, the agent skips language auto-detection and instruments
+    /// the specified language(s) directly.
+    #[arg(long = "language", value_enum, ignore_case = true)]
+    languages: Vec<LanguageArg>,
+
+    /// Run the interactive setup wizard, prompting for every choice not already
+    /// specified as a flag.
+    #[arg(long, short = 'i')]
+    interactive: bool,
+
+    /// Show additional setup output
+    #[arg(long, short = 'v')]
+    verbose: bool,
 
     #[command(flatten)]
     agents: AgentsSetupArgs,
@@ -87,24 +124,27 @@ enum SetupSubcommand {
 
 #[derive(Debug, Clone, Args)]
 struct AgentsSetupArgs {
-    /// Agent(s) to configure (repeatable)
-    #[arg(long = "agent", value_enum)]
-    agents: Vec<AgentArg>,
+    /// Agent to configure
+    #[arg(long, value_enum)]
+    agent: Option<AgentArg>,
 
     /// Configure the current git repo root
     #[arg(long, conflicts_with = "global")]
     local: bool,
 
-    /// Configure user-wide state
+    /// Configure user-wide state [default]
     #[arg(long)]
     global: bool,
 
-    /// Workflow docs to prefetch (repeatable)
+    /// Workflow docs to prefetch (repeatable) [default: all]
     #[arg(long = "workflow", value_enum)]
     workflows: Vec<WorkflowArg>,
 
-    /// Skip confirmation prompts and use defaults
-    #[arg(long, short = 'y')]
+    /// Do not fetch workflow docs during setup
+    #[arg(long, conflicts_with = "workflows")]
+    no_workflow: bool,
+
+    #[arg(skip)]
     yes: bool,
 
     /// Do not auto-fetch workflow docs during setup
@@ -119,28 +159,26 @@ struct AgentsSetupArgs {
     #[arg(long, default_value_t = crate::sync::default_workers())]
     workers: usize,
 
-    /// Grant the agent full permissions and run it in the background without prompting.
-    /// Equivalent to choosing "Background" with all tool restrictions lifted.
-    #[arg(long)]
+    /// Grant the agent full permissions (bypass permission prompts)
+    #[arg(long, conflicts_with = "no_instrument")]
     yolo: bool,
 }
 
 #[derive(Debug, Clone, Args)]
 struct AgentsMcpSetupArgs {
-    /// Agent(s) to configure MCP for (repeatable)
-    #[arg(long = "agent", value_enum)]
-    agents: Vec<AgentArg>,
+    /// Agent to configure MCP for
+    #[arg(long, value_enum)]
+    agent: Option<AgentArg>,
 
     /// Configure MCP in the current git repo root
     #[arg(long, conflicts_with = "global")]
     local: bool,
 
-    /// Configure MCP in user-wide state
+    /// Configure MCP in user-wide state [default]
     #[arg(long)]
     global: bool,
 
-    /// Skip confirmation prompts and use defaults
-    #[arg(long, short = 'y')]
+    #[arg(skip)]
     yes: bool,
 }
 
@@ -154,12 +192,11 @@ struct InstrumentSetupArgs {
     #[arg(long)]
     agent_cmd: Option<String>,
 
-    /// Workflow docs to prefetch alongside instrument (repeatable; always includes instrument)
+    /// Workflow docs to prefetch alongside instrument (repeatable; always includes instrument) [default: all]
     #[arg(long = "workflow", value_enum)]
     workflows: Vec<WorkflowArg>,
 
-    /// Skip confirmation prompts and use defaults
-    #[arg(long, short = 'y')]
+    #[arg(skip)]
     yes: bool,
 
     /// Refresh prefetched docs by clearing existing output before download
@@ -170,10 +207,6 @@ struct InstrumentSetupArgs {
     #[arg(long, default_value_t = crate::sync::default_workers())]
     workers: usize,
 
-    /// Suppress streaming agent output; show a spinner and print results at the end
-    #[arg(long, short = 'q')]
-    quiet: bool,
-
     /// Language(s) to instrument (repeatable; case-insensitive).
     /// When provided, the agent skips language auto-detection and instruments
     /// the specified language(s) directly.
@@ -181,15 +214,22 @@ struct InstrumentSetupArgs {
     #[arg(long = "language", value_enum, ignore_case = true)]
     languages: Vec<LanguageArg>,
 
-    /// Run the agent in interactive mode: inherits the terminal so the user can
-    /// approve/deny tool uses directly. Conflicts with --quiet and --yolo.
-    #[arg(long, short = 'i', conflicts_with_all = ["quiet", "yolo"])]
-    interactive: bool,
+    /// Run the agent in interactive TUI mode [default]
+    #[arg(long, conflicts_with = "background")]
+    tui: bool,
 
-    /// Grant the agent full permissions and run it in the background without prompting.
-    /// Skips the run-mode selection question. Conflicts with --interactive.
-    #[arg(long, conflicts_with = "interactive")]
+    /// Run the agent in background (non-interactive) mode
+    #[arg(long, conflicts_with = "tui")]
+    background: bool,
+
+    /// Grant the agent full permissions (bypass permission prompts)
+    #[arg(long)]
     yolo: bool,
+
+    /// Set up skills and write the task file but do not launch the agent.
+    #[arg(skip)]
+    #[allow(dead_code)]
+    skip_launch: bool,
 }
 
 #[derive(Debug, Clone, Args)]
@@ -210,7 +250,6 @@ enum AgentArg {
     Codex,
     Cursor,
     Opencode,
-    All,
 }
 
 #[derive(Debug, Clone, Copy, Eq, PartialEq, Hash, Ord, PartialOrd, Serialize)]
@@ -374,7 +413,18 @@ struct SkillsAliasResult {
     path: PathBuf,
 }
 
-pub async fn run_setup_top(base: BaseArgs, args: SetupArgs) -> Result<()> {
+pub async fn run_setup_top(mut base: BaseArgs, mut args: SetupArgs) -> Result<()> {
+    if args.verbose {
+        base.verbose = true;
+        crate::ui::set_quiet(false);
+        crate::ui::set_animations_enabled(true);
+    }
+    if base.json && args.instrument {
+        bail!("--json conflicts with --instrument: JSON mode implies --no-instrument");
+    }
+    if base.json {
+        args.no_instrument = true;
+    }
     match args.command {
         Some(SetupSubcommand::Skills(setup)) => run_setup(base, setup).await,
         Some(SetupSubcommand::Instrument(instrument)) => {
@@ -385,15 +435,22 @@ pub async fn run_setup_top(base: BaseArgs, args: SetupArgs) -> Result<()> {
         None => {
             if should_prompt_setup_action(&base, &args.agents) {
                 let wizard_flags = WizardFlags {
+                    interactive: args.interactive,
                     yolo: args.agents.yolo,
                     skills: args.skills,
+                    no_skills: args.no_skills,
                     mcp: args.mcp,
+                    no_mcp: args.no_mcp,
                     local: args.agents.local,
                     global: args.agents.global,
                     instrument: args.instrument,
-                    agents: args.agents.agents,
-                    no_mcp_skill: args.no_mcp_skill,
+                    no_instrument: args.no_instrument,
+                    tui: args.tui,
+                    background: args.background,
+                    agent: args.agents.agent,
                     workflows: args.agents.workflows,
+                    no_workflow: args.agents.no_workflow,
+                    languages: args.languages,
                 };
                 run_setup_wizard(base, wizard_flags).await
             } else {
@@ -405,51 +462,66 @@ pub async fn run_setup_top(base: BaseArgs, args: SetupArgs) -> Result<()> {
 
 pub use docs::run_docs_top;
 
+#[allow(dead_code)]
 struct WizardFlags {
+    interactive: bool,
     yolo: bool,
     skills: bool,
+    no_skills: bool,
     mcp: bool,
+    no_mcp: bool,
     local: bool,
     global: bool,
     instrument: bool,
-    agents: Vec<AgentArg>,
-    no_mcp_skill: bool,
+    no_instrument: bool,
+    tui: bool,
+    background: bool,
+    agent: Option<AgentArg>,
     workflows: Vec<WorkflowArg>,
+    no_workflow: bool,
+    languages: Vec<LanguageArg>,
 }
 
 async fn run_setup_wizard(mut base: BaseArgs, flags: WizardFlags) -> Result<()> {
     let WizardFlags {
+        interactive: _,
         yolo,
         skills: flag_skills,
+        no_skills: flag_no_skills,
         mcp: flag_mcp,
+        no_mcp: flag_no_mcp,
         local: flag_local,
         global: flag_global,
         instrument: flag_instrument,
-        agents: flag_agents,
-        no_mcp_skill: flag_no_mcp_skill,
+        no_instrument: flag_no_instrument,
+        tui: flag_tui,
+        background: flag_background,
+        agent: flag_agent,
         workflows: flag_workflows,
+        no_workflow: _,
+        languages: flag_languages,
     } = flags;
     let mut had_failures = false;
-    let quiet = base.quiet;
+    let verbose = base.verbose;
 
     // ── Step 1: Auth ──
-    if !quiet {
+    if verbose {
         print_wizard_step(1, "Auth");
     }
     let project_flag = base.project.clone();
     let login_ctx = ensure_auth(&mut base).await?;
     let client = ApiClient::new(&login_ctx)?;
     let org = client.org_name().to_string();
-    if !quiet {
+    if verbose {
         eprintln!("   {} Using org '{}'", style("✓").green(), org);
     }
 
     // ── Step 2: Project ──
-    if !quiet {
+    if verbose {
         print_wizard_step(2, "Project");
     }
-    let project = select_project_with_skip(&client, project_flag.as_deref(), quiet).await?;
-    if !quiet {
+    let project = select_project_with_skip(&client, project_flag.as_deref(), !verbose).await?;
+    if verbose {
         if let Some(ref project) = project {
             if find_git_root().is_some() && maybe_init(&org, project)? {
                 eprintln!(
@@ -469,12 +541,12 @@ async fn run_setup_wizard(mut base: BaseArgs, flags: WizardFlags) -> Result<()> 
     }
 
     // ── Step 3: Agent tools (skills + MCP) ──
-    if !quiet {
+    if verbose {
         print_wizard_step(3, "Agents");
     }
     let mut multiselect_hint_shown = false;
-    let (wants_skills, wants_mcp) = if flag_no_mcp_skill {
-        if !quiet {
+    let (wants_skills, wants_mcp) = if flag_no_skills && flag_no_mcp {
+        if verbose {
             eprintln!(
                 "{} What would you like to set up? · {}",
                 style("✔").green(),
@@ -482,8 +554,12 @@ async fn run_setup_wizard(mut base: BaseArgs, flags: WizardFlags) -> Result<()> 
             );
         }
         (false, false)
+    } else if flag_no_skills {
+        (false, flag_mcp || !flag_no_mcp)
+    } else if flag_no_mcp {
+        (flag_skills || !flag_no_skills, false)
     } else if flag_skills || flag_mcp {
-        if !quiet {
+        if verbose {
             let chosen: Vec<&str> = [("Skills", flag_skills), ("MCP", flag_mcp)]
                 .iter()
                 .filter(|(_, v)| *v)
@@ -501,7 +577,7 @@ async fn run_setup_wizard(mut base: BaseArgs, flags: WizardFlags) -> Result<()> 
         }
         (flag_skills, flag_mcp)
     } else {
-        if !quiet {
+        if verbose {
             eprintln!(
                 "   {}",
                 style("(Un)select option with Space, confirm selection with Enter.").dim()
@@ -520,7 +596,7 @@ async fn run_setup_wizard(mut base: BaseArgs, flags: WizardFlags) -> Result<()> 
 
     let setup_context = if wants_skills || wants_mcp {
         let scope = if flag_local {
-            if !quiet {
+            if verbose {
                 eprintln!(
                     "{} Select install scope · {}",
                     style("✔").green(),
@@ -529,7 +605,7 @@ async fn run_setup_wizard(mut base: BaseArgs, flags: WizardFlags) -> Result<()> 
             }
             InstallScope::Local
         } else if flag_global {
-            if !quiet {
+            if verbose {
                 eprintln!(
                     "{} Select install scope · {}",
                     style("✔").green(),
@@ -544,8 +620,8 @@ async fn run_setup_wizard(mut base: BaseArgs, flags: WizardFlags) -> Result<()> 
         let home = home_dir().ok_or_else(|| anyhow!("failed to resolve HOME/USERPROFILE"))?;
         let local_root = resolve_local_root_for_scope(scope)?;
         let detected = detect_agents(local_root.as_deref(), &home);
-        let agents = resolve_selected_agents(&flag_agents, &detected);
-        if !quiet && !flag_agents.is_empty() {
+        let agents = resolve_selected_agents(flag_agent, &detected);
+        if verbose && flag_agent.is_some() {
             let agent_names: Vec<String> = agents
                 .iter()
                 .map(|a| style(a.as_str()).green().to_string())
@@ -562,18 +638,17 @@ async fn run_setup_wizard(mut base: BaseArgs, flags: WizardFlags) -> Result<()> 
     };
 
     if wants_skills {
-        if !quiet {
+        if verbose {
             eprintln!("   {}", style("Skills:").bold());
         }
-        if let Some((scope, ref agents, _)) = setup_context {
-            let agent_args: Vec<AgentArg> =
-                agents.iter().map(|a| map_agent_to_agent_arg(*a)).collect();
+        if let Some((scope, _, _)) = setup_context {
             let args = AgentsSetupArgs {
-                agents: agent_args,
+                agent: flag_agent,
                 local: matches!(scope, InstallScope::Local),
                 global: matches!(scope, InstallScope::Global),
                 workflows: Vec::new(),
-                yes: false,
+                no_workflow: false,
+                yes: true,
                 no_fetch_docs: true,
                 refresh_docs: false,
                 workers: crate::sync::default_workers(),
@@ -581,7 +656,7 @@ async fn run_setup_wizard(mut base: BaseArgs, flags: WizardFlags) -> Result<()> 
             };
             let outcome = execute_skills_setup(&base, &args, true).await?;
             for r in &outcome.results {
-                if !quiet {
+                if verbose {
                     print_wizard_agent_result(r);
                 }
                 if matches!(r.status, InstallStatus::Failed) {
@@ -592,14 +667,14 @@ async fn run_setup_wizard(mut base: BaseArgs, flags: WizardFlags) -> Result<()> 
     }
 
     if wants_mcp {
-        if !quiet {
+        if verbose {
             eprintln!("   {}", style("MCP:").bold());
         }
         if let Some((scope, ref agents, ref home)) = setup_context {
             let local_root = resolve_local_root_for_scope(scope)?;
             let outcome = execute_mcp_install(scope, local_root.as_deref(), home, agents);
             for r in &outcome.results {
-                if !quiet {
+                if verbose {
                     print_wizard_agent_result(r);
                 }
                 if matches!(r.status, InstallStatus::Failed) {
@@ -612,17 +687,25 @@ async fn run_setup_wizard(mut base: BaseArgs, flags: WizardFlags) -> Result<()> 
         }
     }
 
-    if !wants_skills && !wants_mcp && !quiet {
+    if !wants_skills && !wants_mcp && verbose {
         eprintln!("   {}", style("Skipped").dim());
     }
 
     // ── Step 4: Instrument ──
-    if !quiet {
+    if verbose {
         print_wizard_step(4, "Instrument");
     }
     if find_git_root().is_some() {
-        let instrument = if flag_instrument {
-            if !quiet {
+        let instrument = if flag_no_instrument {
+            if verbose {
+                eprintln!(
+                    "Run instrumentation agent to set up tracing in this repo? {}",
+                    style("no").dim()
+                );
+            }
+            false
+        } else if flag_instrument {
+            if verbose {
                 eprintln!(
                     "Run instrumentation agent to set up tracing in this repo? {}",
                     style("yes").green()
@@ -636,16 +719,12 @@ async fn run_setup_wizard(mut base: BaseArgs, flags: WizardFlags) -> Result<()> 
                 .interact()?
         };
         if instrument {
-            let instrument_agent = match flag_agents.as_slice() {
-                [single] => match single {
-                    AgentArg::Claude => Some(InstrumentAgentArg::Claude),
-                    AgentArg::Codex => Some(InstrumentAgentArg::Codex),
-                    AgentArg::Cursor => Some(InstrumentAgentArg::Cursor),
-                    AgentArg::Opencode => Some(InstrumentAgentArg::Opencode),
-                    AgentArg::All => None,
-                },
-                _ => None,
-            };
+            let instrument_agent = flag_agent.map(|a| match a {
+                AgentArg::Claude => InstrumentAgentArg::Claude,
+                AgentArg::Codex => InstrumentAgentArg::Codex,
+                AgentArg::Cursor => InstrumentAgentArg::Cursor,
+                AgentArg::Opencode => InstrumentAgentArg::Opencode,
+            });
             run_instrument_setup(
                 base,
                 InstrumentSetupArgs {
@@ -655,23 +734,24 @@ async fn run_setup_wizard(mut base: BaseArgs, flags: WizardFlags) -> Result<()> 
                     yes: false,
                     refresh_docs: false,
                     workers: crate::sync::default_workers(),
-                    quiet: false,
-                    languages: Vec::new(),
-                    interactive: false,
+                    languages: flag_languages,
+                    tui: flag_tui,
+                    background: flag_background,
                     yolo,
+                    skip_launch: false,
                 },
                 !multiselect_hint_shown,
             )
             .await?;
-        } else if !quiet {
+        } else if verbose {
             eprintln!("   {}", style("Skipped").dim());
         }
-    } else if !quiet {
+    } else if verbose {
         eprintln!("   {}", style("Skipped").dim());
     }
 
     // ── Done ──
-    if !quiet {
+    if verbose {
         print_wizard_done(had_failures);
     }
     if had_failures {
@@ -840,7 +920,7 @@ async fn execute_skills_setup(
     let mut warnings = Vec::new();
     let mut notes = Vec::new();
     let mut results = Vec::new();
-    let show_progress = !base.json && !quiet && !base.quiet;
+    let show_progress = !base.json && !quiet;
 
     if show_progress {
         println!("Configuring coding agents for Braintrust");
@@ -976,13 +1056,13 @@ async fn run_instrument_setup(
     let mut selected = if let Some(agent_arg) = args.agent {
         map_instrument_agent_arg(agent_arg)
     } else {
-        pick_agent_mode_target(&resolve_selected_agents(&[], &detected))
+        pick_agent_mode_target(&resolve_selected_agents(None, &detected))
             .ok_or_else(|| anyhow!("no detected agents available for instrumentation"))?
     };
 
     if args.agent.is_none() && ui::is_interactive() && !args.yes {
         selected = prompt_instrument_agent(selected)?;
-    } else if args.agent.is_some() && !base.quiet {
+    } else if args.agent.is_some() && base.verbose {
         eprintln!(
             "{} Select agent to instrument this repo · {}",
             style("✔").green(),
@@ -990,7 +1070,7 @@ async fn run_instrument_setup(
         );
     }
 
-    let mut hint_pending = print_hint && !base.quiet;
+    let mut hint_pending = print_hint && base.verbose;
     let selected_workflows = resolve_instrument_workflow_selection(&args, &mut hint_pending)?;
 
     let selected_languages: Vec<LanguageArg> = if !args.languages.is_empty() {
@@ -1039,10 +1119,11 @@ async fn run_instrument_setup(
         .await?;
     } else {
         let setup_args = AgentsSetupArgs {
-            agents: vec![map_agent_to_agent_arg(selected)],
+            agent: Some(map_agent_to_agent_arg(selected)),
             local: true,
             global: false,
             workflows: selected_workflows.clone(),
+            no_workflow: false,
             yes: true,
             no_fetch_docs: false,
             refresh_docs: args.refresh_docs,
@@ -1060,15 +1141,16 @@ async fn run_instrument_setup(
     }
 
     // Determine run mode: interactive TUI vs background (autonomous).
-    // --yolo:        background, full bypassPermissions (no restrictions)
-    // --interactive: interactive TUI
+    // --yolo:       background, full bypassPermissions (no restrictions)
+    // --tui:        interactive TUI
+    // --background: background, restricted to language package managers
     // --yes or non-interactive terminal: background, restricted to language package managers
     // Otherwise: ask the user.
-    let (run_interactive, bypass_permissions) = if args.interactive {
+    let (run_interactive, bypass_permissions) = if args.tui {
         (true, false)
     } else if args.yolo {
         (false, true)
-    } else if args.yes || !ui::is_interactive() {
+    } else if args.background || args.yes || !ui::is_interactive() {
         (false, false)
     } else {
         let pkg_mgrs = package_manager_cmds_for_languages(&selected_languages).join(", ");
@@ -1132,8 +1214,8 @@ async fn run_instrument_setup(
         eprintln!();
     }
 
-    let show_output = !base.json && !args.quiet;
-    let status = if args.quiet && !base.json {
+    let show_output = !base.json && !args.background;
+    let status = if args.background && !base.json {
         with_spinner(
             "Running agent instrumentation…",
             run_agent_invocation(&root, &invocation, false),
@@ -1869,7 +1951,7 @@ fn resolve_setup_selection(args: &AgentsSetupArgs, home: &Path) -> Result<SetupS
     );
     let interactive = ui::is_interactive() && !args.yes;
     let mut prompted_agents: Option<Vec<Agent>> = None;
-    let mut prompted_workflows: Option<Vec<WorkflowArg>> = if args.no_fetch_docs {
+    let mut prompted_workflows: Option<Vec<WorkflowArg>> = if args.no_fetch_docs || args.no_workflow {
         Some(Vec::new())
     } else {
         None
@@ -1887,7 +1969,7 @@ fn resolve_setup_selection(args: &AgentsSetupArgs, home: &Path) -> Result<SetupS
         if scope.is_none() {
             steps.push(SetupWizardStep::Scope);
         }
-        if args.agents.is_empty() {
+        if args.agent.is_none() {
             steps.push(SetupWizardStep::Agents);
         }
         if !args.no_fetch_docs && args.workflows.is_empty() {
@@ -1913,7 +1995,7 @@ fn resolve_setup_selection(args: &AgentsSetupArgs, home: &Path) -> Result<SetupS
                     let current_scope = scope.ok_or_else(|| anyhow!("scope not selected"))?;
                     let local_root = resolve_local_root_for_scope(current_scope)?;
                     let detected = detect_agents(local_root.as_deref(), home);
-                    let defaults = resolve_selected_agents(&[], &detected);
+                    let defaults = resolve_selected_agents(None, &detected);
                     match prompt_agents_selection(&defaults)? {
                         Some(selected) => {
                             prompted_agents = Some(selected);
@@ -1960,7 +2042,7 @@ fn resolve_setup_selection(args: &AgentsSetupArgs, home: &Path) -> Result<SetupS
     let detected = detect_agents(local_root.as_deref(), home);
     let selected_agents = match prompted_agents {
         Some(value) => value,
-        None => resolve_selected_agents(&args.agents, &detected),
+        None => resolve_selected_agents(args.agent, &detected),
     };
     if selected_agents.is_empty() {
         bail!("no agents selected for installation");
@@ -1999,7 +2081,7 @@ fn resolve_mcp_selection(args: &AgentsMcpSetupArgs, home: &Path) -> Result<McpSe
         if scope.is_none() {
             steps.push(McpWizardStep::Scope);
         }
-        if args.agents.is_empty() {
+        if args.agent.is_none() {
             steps.push(McpWizardStep::Agents);
         }
 
@@ -2022,7 +2104,7 @@ fn resolve_mcp_selection(args: &AgentsMcpSetupArgs, home: &Path) -> Result<McpSe
                     let current_scope = scope.ok_or_else(|| anyhow!("scope not selected"))?;
                     let local_root = resolve_local_root_for_scope(current_scope)?;
                     let detected = detect_agents(local_root.as_deref(), home);
-                    let defaults = resolve_selected_agents(&[], &detected);
+                    let defaults = resolve_selected_agents(None, &detected);
                     match prompt_agents_selection(&defaults)? {
                         Some(selected) => {
                             prompted_agents = Some(selected);
@@ -2054,7 +2136,7 @@ fn resolve_mcp_selection(args: &AgentsMcpSetupArgs, home: &Path) -> Result<McpSe
     let detected = detect_agents(local_root.as_deref(), home);
     let selected_agents = match prompted_agents {
         Some(value) => value,
-        None => resolve_selected_agents(&args.agents, &detected),
+        None => resolve_selected_agents(args.agent, &detected),
     };
     if selected_agents.is_empty() {
         bail!("no agents selected for MCP setup");
@@ -2354,8 +2436,8 @@ fn resolve_scope_from_flags(
     })
 }
 
-fn resolve_selected_agents(requested: &[AgentArg], detected: &[DetectionSignal]) -> Vec<Agent> {
-    if requested.is_empty() {
+fn resolve_selected_agents(requested: Option<AgentArg>, detected: &[DetectionSignal]) -> Vec<Agent> {
+    let Some(arg) = requested else {
         let mut inferred = BTreeSet::new();
         for signal in detected {
             inferred.insert(signal.agent);
@@ -2364,26 +2446,15 @@ fn resolve_selected_agents(requested: &[AgentArg], detected: &[DetectionSignal])
             return ALL_AGENTS.to_vec();
         }
         return inferred.into_iter().collect();
-    }
+    };
 
-    if requested.contains(&AgentArg::All) {
-        return ALL_AGENTS.to_vec();
-    }
-
-    let mut out = BTreeSet::new();
-    for value in requested {
-        let mapped = match value {
-            AgentArg::Claude => Some(Agent::Claude),
-            AgentArg::Codex => Some(Agent::Codex),
-            AgentArg::Cursor => Some(Agent::Cursor),
-            AgentArg::Opencode => Some(Agent::Opencode),
-            AgentArg::All => None,
-        };
-        if let Some(agent) = mapped {
-            out.insert(agent);
-        }
-    }
-    out.into_iter().collect()
+    let agent = match arg {
+        AgentArg::Claude => Agent::Claude,
+        AgentArg::Codex => Agent::Codex,
+        AgentArg::Cursor => Agent::Cursor,
+        AgentArg::Opencode => Agent::Opencode,
+    };
+    vec![agent]
 }
 
 fn map_instrument_agent_arg(agent: InstrumentAgentArg) -> Agent {
@@ -3137,9 +3208,9 @@ mod tests {
     use std::time::{SystemTime, UNIX_EPOCH};
 
     #[test]
-    fn all_agent_arg_expands_to_all_agents() {
+    fn no_agent_arg_defaults_to_all_agents() {
         let detected = vec![];
-        let resolved = resolve_selected_agents(&[AgentArg::All], &detected);
+        let resolved = resolve_selected_agents(None, &detected);
         assert_eq!(
             resolved,
             vec![Agent::Claude, Agent::Codex, Agent::Cursor, Agent::Opencode]
@@ -3152,7 +3223,7 @@ mod tests {
             agent: Agent::Codex,
             reason: "hint".to_string(),
         }];
-        let resolved = resolve_selected_agents(&[], &detected);
+        let resolved = resolve_selected_agents(None, &detected);
         assert_eq!(resolved, vec![Agent::Codex]);
     }
 
@@ -3254,10 +3325,11 @@ mod tests {
     #[test]
     fn resolve_setup_selection_honors_no_fetch_docs() {
         let args = AgentsSetupArgs {
-            agents: vec![AgentArg::Codex],
+            agent: Some(AgentArg::Codex),
             local: false,
             global: true,
             workflows: vec![WorkflowArg::Evaluate],
+            no_workflow: false,
             yes: true,
             no_fetch_docs: true,
             refresh_docs: false,
@@ -3288,10 +3360,11 @@ mod tests {
             yes: true,
             refresh_docs: false,
             workers: crate::sync::default_workers(),
-            quiet: false,
             languages: Vec::new(),
-            interactive: false,
+            tui: false,
+            background: false,
             yolo: false,
+            skip_launch: false,
         };
 
         let selected = resolve_instrument_workflow_selection(&args, &mut false)
@@ -3311,10 +3384,11 @@ mod tests {
             yes: true,
             refresh_docs: false,
             workers: crate::sync::default_workers(),
-            quiet: false,
             languages: Vec::new(),
-            interactive: false,
+            tui: false,
+            background: false,
             yolo: false,
+            skip_launch: false,
         };
 
         let selected = resolve_instrument_workflow_selection(&args, &mut false)

--- a/src/setup/mod.rs
+++ b/src/setup/mod.rs
@@ -3904,7 +3904,13 @@ fn print_mcp_human_report(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::sync::{Mutex, OnceLock};
     use std::time::{SystemTime, UNIX_EPOCH};
+
+    fn cwd_test_lock() -> &'static Mutex<()> {
+        static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+        LOCK.get_or_init(|| Mutex::new(()))
+    }
 
     fn make_base_args() -> BaseArgs {
         BaseArgs {
@@ -4646,6 +4652,7 @@ mod tests {
 
     #[test]
     fn resolve_scope_from_flags_yes_defaults_to_local_in_git_repo() {
+        let _guard = cwd_test_lock().lock().expect("lock cwd test");
         let unique = SystemTime::now()
             .duration_since(UNIX_EPOCH)
             .expect("clock")
@@ -4668,6 +4675,7 @@ mod tests {
 
     #[test]
     fn resolve_scope_from_flags_yes_falls_back_to_global_outside_git_repo() {
+        let _guard = cwd_test_lock().lock().expect("lock cwd test");
         let unique = SystemTime::now()
             .duration_since(UNIX_EPOCH)
             .expect("clock")

--- a/src/setup/mod.rs
+++ b/src/setup/mod.rs
@@ -11,7 +11,7 @@ use serde::Serialize;
 use serde_json::{Map, Value};
 use tokio::process::Command;
 
-use crate::args::BaseArgs;
+use crate::args::{ArgValueSource, BaseArgs};
 use crate::auth;
 use crate::auth::LoginContext;
 use crate::config;
@@ -94,7 +94,12 @@ pub struct SetupArgs {
     /// Language(s) to instrument (repeatable; case-insensitive).
     /// When provided, the agent skips language auto-detection and instruments
     /// the specified language(s) directly.
-    #[arg(long = "language", value_enum, ignore_case = true)]
+    #[arg(
+        long = "language",
+        value_enum,
+        ignore_case = true,
+        conflicts_with = "no_instrument"
+    )]
     languages: Vec<LanguageArg>,
 
     /// Run the interactive setup wizard, prompting for every choice not already
@@ -129,7 +134,7 @@ enum SetupSubcommand {
 #[derive(Debug, Clone, Args)]
 struct AgentsSetupArgs {
     /// Agent to configure
-    #[arg(long, value_enum)]
+    #[arg(long, alias = "agents", value_enum)]
     agent: Option<AgentArg>,
 
     /// Configure the current git repo root
@@ -164,14 +169,14 @@ struct AgentsSetupArgs {
     workers: usize,
 
     /// Grant the agent full permissions (bypass permission prompts)
-    #[arg(long, conflicts_with = "no_instrument")]
+    #[arg(long)]
     yolo: bool,
 }
 
 #[derive(Debug, Clone, Args)]
 struct AgentsMcpSetupArgs {
     /// Agent to configure MCP for
-    #[arg(long, value_enum)]
+    #[arg(long, alias = "agents", value_enum)]
     agent: Option<AgentArg>,
 
     /// Configure MCP in the current git repo root
@@ -447,28 +452,28 @@ pub async fn run_setup_top(mut base: BaseArgs, mut args: SetupArgs) -> Result<()
         Some(SetupSubcommand::Mcp(mcp)) => run_mcp_setup(base, mcp),
         Some(SetupSubcommand::Doctor(doctor)) => run_doctor(base, doctor),
         None => {
-            if should_prompt_setup_action(&base, &args.agents) {
-                let wizard_flags = WizardFlags {
-                    interactive: args.interactive,
-                    yolo: args.agents.yolo,
-                    skills: args.skills,
-                    no_skills: args.no_skills,
-                    mcp: args.mcp,
-                    no_mcp: args.no_mcp,
-                    local: args.agents.local,
-                    global: args.agents.global,
-                    instrument: args.instrument,
-                    no_instrument: args.no_instrument,
-                    tui: args.tui,
-                    background: args.background,
-                    agent: args.agents.agent,
-                    workflows: args.agents.workflows,
-                    no_workflow: args.agents.no_workflow,
-                    languages: args.languages,
-                };
+            let wizard_flags = WizardFlags {
+                interactive: args.interactive,
+                yolo: args.agents.yolo,
+                skills: args.skills,
+                no_skills: args.no_skills,
+                mcp: args.mcp,
+                no_mcp: args.no_mcp,
+                local: args.agents.local,
+                global: args.agents.global,
+                instrument: args.instrument,
+                no_instrument: args.no_instrument,
+                tui: args.tui,
+                background: args.background,
+                agent: args.agents.agent,
+                workflows: args.agents.workflows.clone(),
+                no_workflow: args.agents.no_workflow,
+                languages: args.languages.clone(),
+            };
+            if args.interactive {
                 run_setup_wizard(base, wizard_flags).await
             } else {
-                run_setup(base, args.agents).await
+                run_default_setup(base, args).await
             }
         }
     }
@@ -599,7 +604,7 @@ async fn run_setup_wizard(mut base: BaseArgs, flags: WizardFlags) -> Result<()> 
             multiselect_hint_shown = true;
         }
         let choices = ["Skills", "MCP"];
-        let defaults = [true, true];
+        let defaults = [true, false];
         let selected = MultiSelect::with_theme(&ColorfulTheme::default())
             .with_prompt("What would you like to set up?")
             .items(&choices)
@@ -634,7 +639,12 @@ async fn run_setup_wizard(mut base: BaseArgs, flags: WizardFlags) -> Result<()> 
         let home = home_dir().ok_or_else(|| anyhow!("failed to resolve HOME/USERPROFILE"))?;
         let local_root = resolve_local_root_for_scope(scope)?;
         let detected = detect_agents(local_root.as_deref(), &home);
-        let agents = resolve_selected_agents(flag_agent, &detected);
+        let agents = vec![resolve_default_agent_selection(
+            flag_agent,
+            &detected,
+            "Select coding agent",
+            true,
+        )?];
         if verbose && flag_agent.is_some() {
             let agent_names: Vec<String> = agents
                 .iter()
@@ -729,7 +739,7 @@ async fn run_setup_wizard(mut base: BaseArgs, flags: WizardFlags) -> Result<()> 
         } else {
             Confirm::with_theme(&ColorfulTheme::default())
                 .with_prompt("Run instrumentation agent to set up tracing in this repo?")
-                .default(false)
+                .default(true)
                 .interact()?
         };
         if instrument {
@@ -774,37 +784,153 @@ async fn run_setup_wizard(mut base: BaseArgs, flags: WizardFlags) -> Result<()> 
     Ok(())
 }
 
+async fn run_default_setup(mut base: BaseArgs, args: SetupArgs) -> Result<()> {
+    let login_ctx = ensure_auth(&mut base).await?;
+    let client = ApiClient::new(&login_ctx)?;
+    let org = client.org_name().to_string();
+    let project = select_project_for_setup(&client, base.project.as_deref()).await?;
+
+    if find_git_root().is_some() {
+        let _ = maybe_init(&org, &project)?;
+    }
+
+    let scope = default_setup_scope(&args.agents);
+    let home = home_dir().ok_or_else(|| anyhow!("failed to resolve HOME/USERPROFILE"))?;
+    let local_root = resolve_local_root_for_scope(scope)?;
+    let detected = detect_agents(local_root.as_deref(), &home);
+    let selected_agent = resolve_default_agent_selection(
+        args.agents.agent,
+        &detected,
+        "Select coding agent",
+        ui::is_interactive(),
+    )?;
+
+    if args.skills || !args.no_skills {
+        run_setup(
+            base.clone(),
+            AgentsSetupArgs {
+                agent: Some(map_agent_to_agent_arg(selected_agent)),
+                local: matches!(scope, InstallScope::Local),
+                global: matches!(scope, InstallScope::Global),
+                workflows: args.agents.workflows.clone(),
+                no_workflow: args.agents.no_workflow,
+                yes: true,
+                no_fetch_docs: args.agents.no_fetch_docs,
+                refresh_docs: args.agents.refresh_docs,
+                workers: args.agents.workers,
+                yolo: args.agents.yolo,
+            },
+        )
+        .await?;
+    }
+
+    if args.mcp && !args.no_mcp {
+        run_mcp_setup(
+            base.clone(),
+            AgentsMcpSetupArgs {
+                agent: Some(map_agent_to_agent_arg(selected_agent)),
+                local: matches!(scope, InstallScope::Local),
+                global: matches!(scope, InstallScope::Global),
+                yes: true,
+            },
+        )?;
+    }
+
+    if !args.no_instrument {
+        if find_git_root().is_some() {
+            run_instrument_setup(
+                base,
+                InstrumentSetupArgs {
+                    agent: Some(map_agent_to_instrument_agent_arg(selected_agent)),
+                    agent_cmd: None,
+                    workflows: args.agents.workflows,
+                    yes: true,
+                    refresh_docs: args.agents.refresh_docs,
+                    workers: args.agents.workers,
+                    languages: args.languages,
+                    tui: args.tui,
+                    background: args.background,
+                    yolo: args.agents.yolo,
+                    skip_launch: false,
+                },
+                false,
+            )
+            .await?;
+        } else if !base.json {
+            eprintln!("Skipping instrumentation: not inside a git repository.");
+        }
+    }
+
+    Ok(())
+}
+
 async fn ensure_auth(base: &mut BaseArgs) -> Result<LoginContext> {
-    if base.api_key.is_some() {
+    if matches!(base.api_key_source, Some(ArgValueSource::CommandLine)) {
         return auth::login(base).await;
     }
 
     let profiles = auth::list_profiles()?;
-    match profiles.len() {
-        0 => {
-            eprintln!("No auth profiles found. Let's set one up.\n");
-            auth::login_interactive(base).await?;
+    if base.prefer_profile {
+        return login_with_existing_or_oauth(base, &profiles).await;
+    }
+
+    if matches!(base.api_key_source, Some(ArgValueSource::EnvVariable)) {
+        return auth::login(base).await;
+    }
+
+    login_with_existing_or_oauth(base, &profiles).await
+}
+
+async fn login_with_existing_or_oauth(
+    base: &mut BaseArgs,
+    profiles: &[auth::ProfileInfo],
+) -> Result<LoginContext> {
+    if profiles.is_empty() {
+        eprintln!("No auth profiles found. Let's set one up.\n");
+        auth::login_setup_oauth(base).await?;
+        return auth::login(base).await;
+    }
+
+    let profile_name = choose_setup_profile(base, profiles)?;
+    base.profile = Some(profile_name);
+    match auth::login(base).await {
+        Ok(ctx) => Ok(ctx),
+        Err(err) if should_force_reauth(&err) => {
+            auth::login_setup_oauth(base).await?;
             auth::login(base).await
         }
-        1 => {
-            let p = &profiles[0];
-            base.profile = Some(p.name.clone());
-            auth::login(base).await
-        }
-        _ => {
-            let name = auth::select_profile_interactive(None)?
-                .ok_or_else(|| anyhow!("no profile selected"))?;
-            base.profile = Some(name);
-            auth::login(base).await
-        }
+        Err(err) => Err(err),
     }
 }
 
-async fn select_project_with_skip(
+fn choose_setup_profile(base: &BaseArgs, profiles: &[auth::ProfileInfo]) -> Result<String> {
+    if let Some(profile_name) = base.profile.as_ref().map(|value| value.trim()) {
+        if !profile_name.is_empty() {
+            return Ok(profile_name.to_string());
+        }
+    }
+
+    if let Some(org) = base.org_name.as_deref() {
+        return auth::resolve_org_to_profile(org, profiles);
+    }
+
+    profiles
+        .first()
+        .map(|profile| profile.name.clone())
+        .ok_or_else(|| anyhow!("no auth profiles found"))
+}
+
+fn should_force_reauth(err: &anyhow::Error) -> bool {
+    let msg = err.to_string();
+    msg.contains("oauth refresh token missing")
+        || msg.contains("oauth profile requested but none selected")
+        || msg.contains("re-run `bt auth login --oauth")
+}
+
+async fn select_project_for_setup(
     client: &ApiClient,
     project_name: Option<&str>,
-    quiet: bool,
-) -> Result<Option<crate::projects::api::Project>> {
+) -> Result<crate::projects::api::Project> {
     if let Some(name) = project_name {
         let project = with_spinner(
             "Loading project...",
@@ -812,12 +938,7 @@ async fn select_project_with_skip(
         )
         .await?;
         match project {
-            Some(p) => {
-                if !quiet {
-                    eprintln!("{} Select project · {}", style("✔").green(), p.name);
-                }
-                return Ok(Some(p));
-            }
+            Some(p) => return Ok(p),
             None => bail!(
                 "project '{}' not found in org '{}'",
                 name,
@@ -832,21 +953,74 @@ async fn select_project_with_skip(
     )
     .await?;
 
-    if projects.is_empty() {
-        bail!("no projects found in org '{}'", client.org_name());
+    if projects.len() == 1 && projects[0].name == "My Project" {
+        return create_or_fetch_project(client, &default_setup_project_name()).await;
     }
 
     projects.sort_by(|a, b| a.name.cmp(&b.name));
-    let mut labels: Vec<String> = projects.iter().map(|p| p.name.clone()).collect();
-    labels.push("Skip (not recommended)".to_string());
+    if !ui::is_interactive() {
+        bail!(
+            "multiple project choices available; pass --project <NAME> or run `bt setup` in an interactive terminal"
+        );
+    }
 
+    let mut labels: Vec<String> = projects.iter().map(|p| p.name.clone()).collect();
+    labels.push("Create new project".to_string());
     let selection = ui::fuzzy_select("Select project", &labels, 0)?;
 
     if selection == labels.len() - 1 {
-        Ok(None)
-    } else {
-        Ok(Some(projects[selection].clone()))
+        let default_name = default_setup_project_name();
+        let name: String = dialoguer::Input::with_theme(&ColorfulTheme::default())
+            .with_prompt("Project name")
+            .default(default_name)
+            .interact_text()?;
+        let trimmed = name.trim();
+        if trimmed.is_empty() {
+            bail!("project name cannot be empty");
+        }
+        return create_or_fetch_project(client, trimmed).await;
     }
+
+    Ok(projects[selection].clone())
+}
+
+async fn select_project_with_skip(
+    client: &ApiClient,
+    project_name: Option<&str>,
+    quiet: bool,
+) -> Result<Option<crate::projects::api::Project>> {
+    let project = select_project_for_setup(client, project_name).await?;
+    if !quiet {
+        eprintln!("{} Select project · {}", style("✔").green(), project.name);
+    }
+    Ok(Some(project))
+}
+
+async fn create_or_fetch_project(
+    client: &ApiClient,
+    name: &str,
+) -> Result<crate::projects::api::Project> {
+    if let Some(project) = crate::projects::api::get_project_by_name(client, name).await? {
+        return Ok(project);
+    }
+    match crate::projects::api::create_project(client, name).await {
+        Ok(project) => Ok(project),
+        Err(_) => crate::projects::api::get_project_by_name(client, name)
+            .await?
+            .ok_or_else(|| anyhow!("failed to create project '{name}'")),
+    }
+}
+
+fn default_setup_project_name() -> String {
+    let output = std::process::Command::new("whoami").output();
+    let user = output
+        .ok()
+        .filter(|result| result.status.success())
+        .and_then(|result| String::from_utf8(result.stdout).ok())
+        .map(|stdout| stdout.trim().to_string())
+        .filter(|name| !name.is_empty())
+        .unwrap_or_else(|| "braintrust".to_string());
+    format!("{user}-test")
 }
 
 /// Returns `true` if config was written or already matched, `false` if user declined.
@@ -884,6 +1058,14 @@ fn maybe_init(org: &str, project: &crate::projects::api::Project) -> Result<bool
     };
     config::save_local(&cfg, true)?;
     Ok(true)
+}
+
+fn default_setup_scope(args: &AgentsSetupArgs) -> InstallScope {
+    if args.local {
+        InstallScope::Local
+    } else {
+        InstallScope::Global
+    }
 }
 
 async fn run_setup(base: BaseArgs, args: AgentsSetupArgs) -> Result<()> {
@@ -1044,16 +1226,6 @@ impl LanguageArg {
     }
 }
 
-fn should_prompt_setup_action(base: &BaseArgs, args: &AgentsSetupArgs) -> bool {
-    if base.json || !ui::is_interactive() {
-        return false;
-    }
-    !args.yes
-        && !args.no_fetch_docs
-        && !args.refresh_docs
-        && args.workers == crate::sync::default_workers()
-}
-
 async fn run_instrument_setup(
     base: BaseArgs,
     args: InstrumentSetupArgs,
@@ -1067,16 +1239,14 @@ async fn run_instrument_setup(
     })?;
     let mut detected = detect_agents(Some(&root), &home);
 
-    let mut selected = if let Some(agent_arg) = args.agent {
-        map_instrument_agent_arg(agent_arg)
-    } else {
-        pick_agent_mode_target(&resolve_selected_agents(None, &detected))
-            .ok_or_else(|| anyhow!("no detected agents available for instrumentation"))?
-    };
+    let selected = resolve_default_agent_selection(
+        args.agent.map(map_instrument_agent_arg_to_agent_arg),
+        &detected,
+        "Select agent to instrument this repo",
+        ui::is_interactive() && !args.yes,
+    )?;
 
-    if args.agent.is_none() && ui::is_interactive() && !args.yes {
-        selected = prompt_instrument_agent(selected)?;
-    } else if args.agent.is_some() && base.verbose {
+    if args.agent.is_some() && base.verbose {
         eprintln!(
             "{} Select agent to instrument this repo · {}",
             style("✔").green(),
@@ -1087,23 +1257,7 @@ async fn run_instrument_setup(
     let mut hint_pending = print_hint && base.verbose;
     let selected_workflows = resolve_instrument_workflow_selection(&args, &mut hint_pending)?;
 
-    let selected_languages: Vec<LanguageArg> = if !args.languages.is_empty() {
-        args.languages.clone()
-    } else if ui::is_interactive() && !args.yes {
-        if hint_pending {
-            eprintln!(
-                "   {}",
-                style("(Un)select option with Space, confirm selection with Enter.").dim()
-            );
-        }
-        let detected_langs = detect_languages_from_dir(&std::env::current_dir()?);
-        let Some(langs) = prompt_instrument_language_selection(&detected_langs)? else {
-            bail!("instrument setup cancelled by user");
-        };
-        langs
-    } else {
-        Vec::new()
-    };
+    let selected_languages: Vec<LanguageArg> = args.languages.clone();
 
     let show_progress = !base.json;
     let mut warnings = Vec::new();
@@ -1167,26 +1321,7 @@ async fn run_instrument_setup(
     } else if args.background || args.yes || !ui::is_interactive() {
         (false, false)
     } else {
-        let pkg_mgrs = package_manager_cmds_for_languages(&selected_languages).join(", ");
-        let background_label = format!(
-            "Background (automatic) — runs autonomously; \
-             allowed package managers: {pkg_mgrs}"
-        );
-        let choices = [
-            background_label.as_str(),
-            "Interactive TUI — agent opens in its terminal UI; \
-             you review and approve each tool use",
-        ];
-        let selection = Select::with_theme(&ColorfulTheme::default())
-            .with_prompt("How do you want to run the agent?")
-            .items(&choices)
-            .default(0)
-            .interact_opt()?;
-        let Some(index) = selection else {
-            bail!("instrument setup cancelled by user");
-        };
-        let interactive = index == 1;
-        (interactive, false)
+        (true, false)
     };
 
     let docs_output_dir = root.join(".bt").join("skills").join("docs");
@@ -1287,7 +1422,7 @@ async fn run_instrument_setup(
 
 fn resolve_instrument_workflow_selection(
     args: &InstrumentSetupArgs,
-    hint_pending: &mut bool,
+    _hint_pending: &mut bool,
 ) -> Result<Vec<WorkflowArg>> {
     if !args.workflows.is_empty() {
         let mut selected = resolve_workflow_selection(&args.workflows);
@@ -1299,23 +1434,10 @@ fn resolve_instrument_workflow_selection(
         return Ok(selected);
     }
 
-    if ui::is_interactive() && !args.yes {
-        if *hint_pending {
-            eprintln!(
-                "   {}",
-                style("(Un)select option with Space, confirm selection with Enter.").dim()
-            );
-            *hint_pending = false;
-        }
-        let Some(selected) = prompt_instrument_workflow_selection()? else {
-            bail!("instrument setup cancelled by user");
-        };
-        return Ok(selected);
-    }
-
-    Ok(vec![WorkflowArg::Instrument])
+    Ok(resolve_workflow_selection(&[]))
 }
 
+#[allow(dead_code)]
 fn prompt_instrument_workflow_selection() -> Result<Option<Vec<WorkflowArg>>> {
     let choices = ["observe", "annotate", "evaluate", "deploy"];
     let defaults = [true, false, true, false];
@@ -1339,6 +1461,7 @@ fn prompt_instrument_workflow_selection() -> Result<Option<Vec<WorkflowArg>>> {
     }))
 }
 
+#[allow(dead_code)]
 fn detect_languages_from_dir(dir: &std::path::Path) -> Vec<LanguageArg> {
     // (indicator filename suffix, language)
     let indicators: &[(&str, LanguageArg)] = &[
@@ -1404,6 +1527,7 @@ fn detect_languages_from_dir(dir: &std::path::Path) -> Vec<LanguageArg> {
     found.into_iter().collect()
 }
 
+#[allow(dead_code)]
 fn prompt_instrument_language_selection(
     detected: &[LanguageArg],
 ) -> Result<Option<Vec<LanguageArg>>> {
@@ -1464,6 +1588,15 @@ fn map_agent_to_agent_arg(agent: Agent) -> AgentArg {
         Agent::Codex => AgentArg::Codex,
         Agent::Cursor => AgentArg::Cursor,
         Agent::Opencode => AgentArg::Opencode,
+    }
+}
+
+fn map_agent_to_instrument_agent_arg(agent: Agent) -> InstrumentAgentArg {
+    match agent {
+        Agent::Claude => InstrumentAgentArg::Claude,
+        Agent::Codex => InstrumentAgentArg::Codex,
+        Agent::Cursor => InstrumentAgentArg::Cursor,
+        Agent::Opencode => InstrumentAgentArg::Opencode,
     }
 }
 
@@ -1542,6 +1675,7 @@ async fn prefetch_workflow_docs(
     Ok(())
 }
 
+#[allow(dead_code)]
 fn prompt_instrument_agent(default_agent: Agent) -> Result<Agent> {
     let choices = ALL_AGENTS
         .iter()
@@ -1957,14 +2091,8 @@ fn run_mcp_setup(base: BaseArgs, args: AgentsMcpSetupArgs) -> Result<()> {
 }
 
 fn resolve_setup_selection(args: &AgentsSetupArgs, home: &Path) -> Result<SetupSelection> {
-    let mut scope = initial_scope(
-        args.local,
-        args.global,
-        args.yes,
-        YesScopeDefault::LocalIfGit,
-    );
+    let mut scope = initial_scope(args.local, args.global, args.yes, YesScopeDefault::Global);
     let interactive = ui::is_interactive() && !args.yes;
-    let mut prompted_agents: Option<Vec<Agent>> = None;
     let mut prompted_workflows: Option<Vec<WorkflowArg>> = if args.no_fetch_docs || args.no_workflow
     {
         Some(Vec::new())
@@ -1976,16 +2104,12 @@ fn resolve_setup_selection(args: &AgentsSetupArgs, home: &Path) -> Result<SetupS
         #[derive(Clone, Copy)]
         enum SetupWizardStep {
             Scope,
-            Agents,
             Workflows,
         }
 
         let mut steps = Vec::new();
         if scope.is_none() {
             steps.push(SetupWizardStep::Scope);
-        }
-        if args.agent.is_none() {
-            steps.push(SetupWizardStep::Agents);
         }
         if !args.no_fetch_docs && args.workflows.is_empty() {
             steps.push(SetupWizardStep::Workflows);
@@ -2006,24 +2130,6 @@ fn resolve_setup_selection(args: &AgentsSetupArgs, home: &Path) -> Result<SetupS
                         idx -= 1;
                     }
                 },
-                SetupWizardStep::Agents => {
-                    let current_scope = scope.ok_or_else(|| anyhow!("scope not selected"))?;
-                    let local_root = resolve_local_root_for_scope(current_scope)?;
-                    let detected = detect_agents(local_root.as_deref(), home);
-                    let defaults = resolve_selected_agents(None, &detected);
-                    match prompt_agents_selection(&defaults)? {
-                        Some(selected) => {
-                            prompted_agents = Some(selected);
-                            idx += 1;
-                        }
-                        None => {
-                            if idx == 0 {
-                                bail!("setup cancelled by user");
-                            }
-                            idx -= 1;
-                        }
-                    }
-                }
                 SetupWizardStep::Workflows => {
                     let defaults = resolve_workflow_selection(&[]);
                     match prompt_workflows_selection(&defaults)? {
@@ -2055,13 +2161,13 @@ fn resolve_setup_selection(args: &AgentsSetupArgs, home: &Path) -> Result<SetupS
     };
     let local_root = resolve_local_root_for_scope(scope)?;
     let detected = detect_agents(local_root.as_deref(), home);
-    let selected_agents = match prompted_agents {
-        Some(value) => value,
-        None => resolve_selected_agents(args.agent, &detected),
-    };
-    if selected_agents.is_empty() {
-        bail!("no agents selected for installation");
-    }
+    let selected_agent = resolve_default_agent_selection(
+        args.agent,
+        &detected,
+        "Select agent to configure",
+        interactive,
+    )?;
+    let selected_agents = vec![selected_agent];
 
     let selected_workflows = if args.no_fetch_docs {
         Vec::new()
@@ -2083,23 +2189,17 @@ fn resolve_setup_selection(args: &AgentsSetupArgs, home: &Path) -> Result<SetupS
 fn resolve_mcp_selection(args: &AgentsMcpSetupArgs, home: &Path) -> Result<McpSelection> {
     let mut scope = initial_scope(args.local, args.global, args.yes, YesScopeDefault::Global);
     let interactive = ui::is_interactive() && !args.yes;
-    let mut prompted_agents: Option<Vec<Agent>> = None;
 
     if interactive {
         #[derive(Clone, Copy)]
         enum McpWizardStep {
             Scope,
-            Agents,
         }
 
         let mut steps = Vec::new();
         if scope.is_none() {
             steps.push(McpWizardStep::Scope);
         }
-        if args.agent.is_none() {
-            steps.push(McpWizardStep::Agents);
-        }
-
         let mut idx = 0usize;
         while idx < steps.len() {
             match steps[idx] {
@@ -2115,24 +2215,6 @@ fn resolve_mcp_selection(args: &AgentsMcpSetupArgs, home: &Path) -> Result<McpSe
                         idx -= 1;
                     }
                 },
-                McpWizardStep::Agents => {
-                    let current_scope = scope.ok_or_else(|| anyhow!("scope not selected"))?;
-                    let local_root = resolve_local_root_for_scope(current_scope)?;
-                    let detected = detect_agents(local_root.as_deref(), home);
-                    let defaults = resolve_selected_agents(None, &detected);
-                    match prompt_agents_selection(&defaults)? {
-                        Some(selected) => {
-                            prompted_agents = Some(selected);
-                            idx += 1;
-                        }
-                        None => {
-                            if idx == 0 {
-                                bail!("MCP setup cancelled by user");
-                            }
-                            idx -= 1;
-                        }
-                    }
-                }
             }
         }
     }
@@ -2149,13 +2231,13 @@ fn resolve_mcp_selection(args: &AgentsMcpSetupArgs, home: &Path) -> Result<McpSe
     };
     let local_root = resolve_local_root_for_scope(scope)?;
     let detected = detect_agents(local_root.as_deref(), home);
-    let selected_agents = match prompted_agents {
-        Some(value) => value,
-        None => resolve_selected_agents(args.agent, &detected),
-    };
-    if selected_agents.is_empty() {
-        bail!("no agents selected for MCP setup");
-    }
+    let selected_agent = resolve_default_agent_selection(
+        args.agent,
+        &detected,
+        "Select agent to configure MCP for",
+        interactive,
+    )?;
+    let selected_agents = vec![selected_agent];
 
     Ok(McpSelection {
         scope,
@@ -2358,7 +2440,7 @@ fn prompt_scope_selection(prompt: &str) -> Result<Option<InstallScope>> {
     let idx = Select::with_theme(&ColorfulTheme::default())
         .with_prompt(prompt)
         .items(&choices)
-        .default(0)
+        .default(1)
         .interact_opt()?;
     Ok(idx.map(|i| {
         if i == 0 {
@@ -2369,29 +2451,21 @@ fn prompt_scope_selection(prompt: &str) -> Result<Option<InstallScope>> {
     }))
 }
 
-fn prompt_agents_selection(defaults: &[Agent]) -> Result<Option<Vec<Agent>>> {
-    let default_set: BTreeSet<Agent> = defaults.iter().copied().collect();
+fn prompt_agent_selection(prompt: &str, default: Agent) -> Result<Option<Agent>> {
     let labels = ALL_AGENTS
         .iter()
         .map(|agent| agent.as_str())
         .collect::<Vec<_>>();
-    let default_flags = ALL_AGENTS
+    let default_index = ALL_AGENTS
         .iter()
-        .map(|agent| default_set.contains(agent))
-        .collect::<Vec<_>>();
-
-    let selected = MultiSelect::with_theme(&ColorfulTheme::default())
-        .with_prompt("Select agents to configure (Esc: back)")
+        .position(|agent| *agent == default)
+        .unwrap_or(0);
+    let selected = FuzzySelect::with_theme(&ColorfulTheme::default())
+        .with_prompt(prompt)
         .items(&labels)
-        .defaults(&default_flags)
+        .default(default_index)
         .interact_opt()?;
-
-    Ok(selected.map(|indexes| {
-        indexes
-            .into_iter()
-            .map(|index| ALL_AGENTS[index])
-            .collect::<Vec<_>>()
-    }))
+    Ok(selected.map(|index| ALL_AGENTS[index]))
 }
 
 fn prompt_workflows_selection(defaults: &[WorkflowArg]) -> Result<Option<Vec<WorkflowArg>>> {
@@ -2451,36 +2525,55 @@ fn resolve_scope_from_flags(
     })
 }
 
-fn resolve_selected_agents(
+fn resolve_default_agent_selection(
     requested: Option<AgentArg>,
     detected: &[DetectionSignal],
-) -> Vec<Agent> {
-    let Some(arg) = requested else {
-        let mut inferred = BTreeSet::new();
-        for signal in detected {
-            inferred.insert(signal.agent);
-        }
-        if inferred.is_empty() {
-            return ALL_AGENTS.to_vec();
-        }
-        return inferred.into_iter().collect();
-    };
+    prompt: &str,
+    allow_prompt: bool,
+) -> Result<Agent> {
+    if let Some(arg) = requested {
+        return Ok(map_agent_arg(arg));
+    }
 
-    let agent = match arg {
-        AgentArg::Claude => Agent::Claude,
-        AgentArg::Codex => Agent::Codex,
-        AgentArg::Cursor => Agent::Cursor,
-        AgentArg::Opencode => Agent::Opencode,
-    };
-    vec![agent]
+    let path_agents = detected_agents_on_path(detected);
+    if path_agents.len() == 1 {
+        return Ok(path_agents[0]);
+    }
+
+    if allow_prompt {
+        let default = pick_agent_mode_target(&path_agents).unwrap_or(Agent::Codex);
+        return prompt_agent_selection(prompt, default)?
+            .ok_or_else(|| anyhow!("setup cancelled by user"));
+    }
+
+    bail!("multiple coding agents available; pass --agent <AGENT> or re-run in an interactive terminal");
 }
 
+#[allow(dead_code)]
 fn map_instrument_agent_arg(agent: InstrumentAgentArg) -> Agent {
     match agent {
         InstrumentAgentArg::Claude => Agent::Claude,
         InstrumentAgentArg::Codex => Agent::Codex,
         InstrumentAgentArg::Cursor => Agent::Cursor,
         InstrumentAgentArg::Opencode => Agent::Opencode,
+    }
+}
+
+fn map_instrument_agent_arg_to_agent_arg(agent: InstrumentAgentArg) -> AgentArg {
+    match agent {
+        InstrumentAgentArg::Claude => AgentArg::Claude,
+        InstrumentAgentArg::Codex => AgentArg::Codex,
+        InstrumentAgentArg::Cursor => AgentArg::Cursor,
+        InstrumentAgentArg::Opencode => AgentArg::Opencode,
+    }
+}
+
+fn map_agent_arg(agent: AgentArg) -> Agent {
+    match agent {
+        AgentArg::Claude => Agent::Claude,
+        AgentArg::Codex => Agent::Codex,
+        AgentArg::Cursor => Agent::Cursor,
+        AgentArg::Opencode => Agent::Opencode,
     }
 }
 
@@ -2496,6 +2589,16 @@ fn pick_agent_mode_target(candidates: &[Agent]) -> Option<Agent> {
         }
     }
     candidates.first().copied()
+}
+
+fn detected_agents_on_path(detected: &[DetectionSignal]) -> Vec<Agent> {
+    let mut agents = BTreeSet::new();
+    for signal in detected {
+        if signal.reason.contains("binary found in PATH") {
+            agents.insert(signal.agent);
+        }
+    }
+    agents.into_iter().collect()
 }
 
 fn resolve_workflow_selection(requested: &[WorkflowArg]) -> Vec<WorkflowArg> {
@@ -3226,23 +3329,32 @@ mod tests {
     use std::time::{SystemTime, UNIX_EPOCH};
 
     #[test]
-    fn no_agent_arg_defaults_to_all_agents() {
-        let detected = vec![];
-        let resolved = resolve_selected_agents(None, &detected);
-        assert_eq!(
-            resolved,
-            vec![Agent::Claude, Agent::Codex, Agent::Cursor, Agent::Opencode]
-        );
+    fn single_path_agent_is_selected_by_default() {
+        let detected = vec![DetectionSignal {
+            agent: Agent::Codex,
+            reason: "`codex` binary found in PATH".to_string(),
+        }];
+        let resolved =
+            resolve_default_agent_selection(None, &detected, "Select coding agent", false)
+                .expect("resolve default agent");
+        assert_eq!(resolved, Agent::Codex);
     }
 
     #[test]
-    fn detection_drives_default_selection() {
-        let detected = vec![DetectionSignal {
-            agent: Agent::Codex,
-            reason: "hint".to_string(),
-        }];
-        let resolved = resolve_selected_agents(None, &detected);
-        assert_eq!(resolved, vec![Agent::Codex]);
+    fn default_agent_selection_requires_prompt_when_path_is_ambiguous() {
+        let detected = vec![
+            DetectionSignal {
+                agent: Agent::Codex,
+                reason: "`codex` binary found in PATH".to_string(),
+            },
+            DetectionSignal {
+                agent: Agent::Claude,
+                reason: "`claude` binary found in PATH".to_string(),
+            },
+        ];
+        let err = resolve_default_agent_selection(None, &detected, "Select coding agent", false)
+            .expect_err("ambiguous path detection should fail");
+        assert!(err.to_string().contains("pass --agent"));
     }
 
     #[test]
@@ -3394,7 +3506,7 @@ mod tests {
     }
 
     #[test]
-    fn resolve_instrument_workflows_default_to_instrument() {
+    fn resolve_instrument_workflows_default_to_all() {
         let args = InstrumentSetupArgs {
             agent: Some(InstrumentAgentArg::Codex),
             agent_cmd: None,
@@ -3411,7 +3523,7 @@ mod tests {
 
         let selected = resolve_instrument_workflow_selection(&args, &mut false)
             .expect("resolve instrument workflows");
-        assert_eq!(selected, vec![WorkflowArg::Instrument]);
+        assert_eq!(selected, resolve_workflow_selection(&[]));
     }
 
     #[test]

--- a/src/setup/mod.rs
+++ b/src/setup/mod.rs
@@ -792,16 +792,7 @@ async fn run_setup_wizard(mut base: BaseArgs, flags: WizardFlags) -> Result<()> 
     Ok(())
 }
 
-async fn run_default_setup(mut base: BaseArgs, args: SetupArgs) -> Result<()> {
-    let login_ctx = ensure_auth(&mut base).await?;
-    let client = ApiClient::new(&login_ctx)?;
-    let org = client.org_name().to_string();
-    let project = select_project_for_setup(&client, base.project.as_deref()).await?;
-
-    if find_git_root().is_some() {
-        let _ = maybe_init(&org, &project)?;
-    }
-
+async fn run_default_setup(base: BaseArgs, args: SetupArgs) -> Result<()> {
     let scope = default_setup_scope(&args.agents);
     let home = home_dir().ok_or_else(|| anyhow!("failed to resolve HOME/USERPROFILE"))?;
     let local_root = resolve_local_root_for_scope(scope)?;
@@ -1622,8 +1613,9 @@ fn skill_config_path(
     let root = scope_root(scope, local_root, home)?;
     let path = match agent {
         Agent::Claude => root.join(".claude/skills/braintrust/SKILL.md"),
-        Agent::Codex | Agent::Opencode => root.join(".agents/skills/braintrust/SKILL.md"),
-        Agent::Cursor => root.join(".cursor/rules/braintrust.mdc"),
+        Agent::Codex | Agent::Opencode | Agent::Cursor => {
+            root.join(".agents/skills/braintrust/SKILL.md")
+        }
     };
     Ok(path)
 }
@@ -2365,32 +2357,9 @@ fn doctor_agent_status(
         .collect::<Vec<_>>();
     let detected_any = !detected_signals.is_empty();
 
-    let config_path = match (agent, scope) {
-        (Agent::Claude, InstallScope::Local) => local_root
-            .map(|root| root.join(".claude/skills/braintrust/SKILL.md"))
-            .map(|p| p.display().to_string()),
-        (Agent::Claude, InstallScope::Global) => Some(
-            home.join(".claude/skills/braintrust/SKILL.md")
-                .display()
-                .to_string(),
-        ),
-        (Agent::Codex, InstallScope::Local) | (Agent::Opencode, InstallScope::Local) => local_root
-            .map(|root| root.join(".agents/skills/braintrust/SKILL.md"))
-            .map(|p| p.display().to_string()),
-        (Agent::Codex, InstallScope::Global) | (Agent::Opencode, InstallScope::Global) => Some(
-            home.join(".agents/skills/braintrust/SKILL.md")
-                .display()
-                .to_string(),
-        ),
-        (Agent::Cursor, InstallScope::Local) => local_root
-            .map(|root| root.join(".cursor/skills/braintrust/SKILL.md"))
-            .map(|p| p.display().to_string()),
-        (Agent::Cursor, InstallScope::Global) => Some(
-            home.join(".cursor/skills/braintrust/SKILL.md")
-                .display()
-                .to_string(),
-        ),
-    };
+    let config_path = skill_config_path(agent, scope, local_root, home)
+        .ok()
+        .map(|path| path.display().to_string());
 
     let configured = config_path
         .as_deref()
@@ -3866,7 +3835,14 @@ mod tests {
         let home = std::env::temp_dir();
         let status = doctor_agent_status(Agent::Cursor, InstallScope::Global, None, &home, &[]);
         assert!(!status.configured);
-        assert!(status.config_path.is_some());
+        assert_eq!(
+            status.config_path,
+            Some(
+                home.join(".agents/skills/braintrust/SKILL.md")
+                    .display()
+                    .to_string()
+            )
+        );
         assert!(status.notes.is_empty());
     }
 

--- a/src/setup/mod.rs
+++ b/src/setup/mod.rs
@@ -784,13 +784,14 @@ async fn run_setup_wizard(mut base: BaseArgs, flags: WizardFlags) -> Result<()> 
 }
 
 async fn run_default_setup(mut base: BaseArgs, args: SetupArgs) -> Result<()> {
-    let project_flag = base.project.clone();
-    let login_ctx = ensure_auth(&mut base).await?;
-    let client = ApiClient::new(&login_ctx)?;
-    let org = client.org_name().to_string();
-    let project = select_project_with_skip(&client, project_flag.as_deref(), true).await?;
-    if let Some(ref project) = project {
-        if find_git_root().is_some() {
+    let should_prepare_project = should_prepare_project_context(args.no_instrument);
+    if should_prepare_project {
+        let project_flag = base.project.clone();
+        let login_ctx = ensure_auth(&mut base).await?;
+        let client = ApiClient::new(&login_ctx)?;
+        let org = client.org_name().to_string();
+        let project = select_project_with_skip(&client, project_flag.as_deref(), true).await?;
+        if let Some(ref project) = project {
             let _ = maybe_init(&org, project)?;
         }
     }
@@ -865,6 +866,10 @@ async fn run_default_setup(mut base: BaseArgs, args: SetupArgs) -> Result<()> {
     Ok(())
 }
 
+fn should_prepare_project_context(no_instrument: bool) -> bool {
+    !no_instrument && find_git_root().is_some()
+}
+
 async fn ensure_auth(base: &mut BaseArgs) -> Result<LoginContext> {
     if matches!(base.api_key_source, Some(ArgValueSource::CommandLine)) {
         return auth::login(base).await;
@@ -892,8 +897,9 @@ async fn login_with_existing_or_oauth(
         return auth::login(base).await;
     }
 
-    let profile_name = choose_setup_profile(base, profiles)?;
-    base.profile = Some(profile_name);
+    if let Some(profile_name) = choose_setup_profile(base, profiles)? {
+        base.profile = Some(profile_name);
+    }
     match auth::login(base).await {
         Ok(ctx) => Ok(ctx),
         Err(err) if auth::is_missing_credential_error(&err) => {
@@ -904,21 +910,26 @@ async fn login_with_existing_or_oauth(
     }
 }
 
-fn choose_setup_profile(base: &BaseArgs, profiles: &[auth::ProfileInfo]) -> Result<String> {
+fn choose_setup_profile(base: &BaseArgs, profiles: &[auth::ProfileInfo]) -> Result<Option<String>> {
     if let Some(profile_name) = base.profile.as_ref().map(|value| value.trim()) {
         if !profile_name.is_empty() {
-            return Ok(profile_name.to_string());
+            return Ok(Some(profile_name.to_string()));
         }
     }
 
     if let Some(org) = base.org_name.as_deref() {
-        return auth::resolve_org_to_profile(org, profiles);
+        return auth::resolve_org_to_profile(org, profiles).map(Some);
     }
 
-    profiles
-        .first()
-        .map(|profile| profile.name.clone())
-        .ok_or_else(|| anyhow!("no auth profiles found"))
+    if profiles.len() == 1 {
+        return Ok(profiles.first().map(|profile| profile.name.clone()));
+    }
+
+    if ui::is_interactive() {
+        return auth::select_profile_interactive(None);
+    }
+
+    bail!("multiple auth profiles found; pass --profile <NAME> or --org <ORG>, or re-run in an interactive terminal")
 }
 
 async fn select_project_for_setup(
@@ -2726,6 +2737,30 @@ fn detect_agents(local_root: Option<&Path>, home: &Path) -> Vec<DetectionSignal>
             Agent::Claude,
             true,
             "`claude` binary found in PATH",
+        );
+    }
+    if command_exists("codex") {
+        add_signal(
+            &mut by_agent,
+            Agent::Codex,
+            true,
+            "`codex` binary found in PATH",
+        );
+    }
+    if command_exists("cursor-agent") {
+        add_signal(
+            &mut by_agent,
+            Agent::Cursor,
+            true,
+            "`cursor-agent` binary found in PATH",
+        );
+    }
+    if command_exists("opencode") {
+        add_signal(
+            &mut by_agent,
+            Agent::Opencode,
+            true,
+            "`opencode` binary found in PATH",
         );
     }
 

--- a/src/setup/mod.rs
+++ b/src/setup/mod.rs
@@ -108,7 +108,7 @@ pub struct SetupArgs {
     interactive: bool,
 
     /// Show additional setup output
-    #[arg(long, short = 'v')]
+    #[arg(long, short = 'v', global = true)]
     verbose: bool,
 
     /// Deprecated: use --no-skills --no-mcp instead
@@ -190,7 +190,7 @@ struct AgentsMcpSetupArgs {
 #[derive(Debug, Clone, Args)]
 struct InstrumentSetupArgs {
     /// Agent to run for instrumentation
-    #[arg(long = "agent", value_enum)]
+    #[arg(long = "agent", alias = "agents", value_enum)]
     agent: Option<InstrumentAgentArg>,
 
     /// Command to run the selected agent (overrides built-in defaults)
@@ -201,8 +201,8 @@ struct InstrumentSetupArgs {
     #[arg(long = "workflow", value_enum)]
     workflows: Vec<WorkflowArg>,
 
-    #[arg(skip)]
-    skip_workflow_docs: bool,
+    #[arg(long = "no-workflow", conflicts_with = "workflows")]
+    no_workflow: bool,
 
     #[arg(skip)]
     yes: bool,
@@ -424,11 +424,9 @@ struct SkillsAliasResult {
 }
 
 pub async fn run_setup_top(mut base: BaseArgs, mut args: SetupArgs) -> Result<()> {
-    if args.verbose {
-        base.verbose = true;
-        crate::ui::set_quiet(false);
-        crate::ui::set_animations_enabled(true);
-    }
+    base.verbose = args.verbose;
+    crate::ui::set_quiet(!args.verbose);
+    crate::ui::set_animations_enabled(args.verbose);
     // Deprecated flag: --no-mcp-skill is equivalent to --no-skills --no-mcp
     if args.no_mcp_skill {
         args.no_skills = true;
@@ -753,7 +751,7 @@ async fn run_setup_wizard(mut base: BaseArgs, flags: WizardFlags) -> Result<()> 
                     agent: instrument_agent,
                     agent_cmd: None,
                     workflows: flag_workflows,
-                    skip_workflow_docs: flag_no_workflow,
+                    no_workflow: flag_no_workflow,
                     yes: false,
                     refresh_docs: false,
                     workers: crate::sync::default_workers(),
@@ -845,7 +843,7 @@ async fn run_default_setup(mut base: BaseArgs, args: SetupArgs) -> Result<()> {
                     agent: Some(map_agent_to_instrument_agent_arg(selected_agent)),
                     agent_cmd: None,
                     workflows: args.agents.workflows,
-                    skip_workflow_docs: args.agents.no_workflow,
+                    no_workflow: args.agents.no_workflow,
                     yes: false,
                     refresh_docs: args.agents.refresh_docs,
                     workers: args.agents.workers,
@@ -1304,7 +1302,7 @@ async fn run_instrument_setup(
             local: true,
             global: false,
             workflows: selected_workflows.clone(),
-            no_workflow: args.skip_workflow_docs,
+            no_workflow: args.no_workflow,
             yes: true,
             refresh_docs: args.refresh_docs,
             workers: args.workers,
@@ -1436,7 +1434,7 @@ fn resolve_instrument_workflow_selection(
     args: &InstrumentSetupArgs,
     _hint_pending: &mut bool,
 ) -> Result<Vec<WorkflowArg>> {
-    if args.skip_workflow_docs {
+    if args.no_workflow {
         return Ok(Vec::new());
     }
 
@@ -3593,7 +3591,7 @@ mod tests {
             agent: Some(InstrumentAgentArg::Codex),
             agent_cmd: None,
             workflows: vec![WorkflowArg::Evaluate],
-            skip_workflow_docs: false,
+            no_workflow: false,
             yes: true,
             refresh_docs: false,
             workers: crate::sync::default_workers(),
@@ -3618,7 +3616,7 @@ mod tests {
             agent: Some(InstrumentAgentArg::Codex),
             agent_cmd: None,
             workflows: Vec::new(),
-            skip_workflow_docs: false,
+            no_workflow: false,
             yes: true,
             refresh_docs: false,
             workers: crate::sync::default_workers(),
@@ -3635,12 +3633,12 @@ mod tests {
     }
 
     #[test]
-    fn resolve_instrument_workflows_honors_skip_workflow_docs() {
+    fn resolve_instrument_workflows_honors_no_workflow() {
         let args = InstrumentSetupArgs {
             agent: Some(InstrumentAgentArg::Codex),
             agent_cmd: None,
             workflows: vec![WorkflowArg::Evaluate],
-            skip_workflow_docs: true,
+            no_workflow: true,
             yes: true,
             refresh_docs: false,
             workers: crate::sync::default_workers(),

--- a/src/setup/mod.rs
+++ b/src/setup/mod.rs
@@ -111,10 +111,6 @@ pub struct SetupArgs {
     #[arg(long, short = 'v')]
     verbose: bool,
 
-    /// Deprecated: quiet is now the default; this flag is accepted as a no-op
-    #[arg(long, hide = true)]
-    quiet: bool,
-
     /// Deprecated: use --no-skills --no-mcp instead
     #[arg(long, hide = true, conflicts_with = "skills", conflicts_with = "mcp")]
     no_mcp_skill: bool,
@@ -235,7 +231,7 @@ struct InstrumentSetupArgs {
     tui: bool,
 
     /// Run the agent in background (non-interactive) mode
-    #[arg(long, conflicts_with = "tui", alias = "quiet")]
+    #[arg(long, conflicts_with = "tui")]
     background: bool,
 
     /// Grant the agent full permissions (bypass permission prompts)
@@ -3660,13 +3656,6 @@ mod tests {
         let selected = resolve_instrument_workflow_selection(&args, &mut false)
             .expect("resolve instrument workflows");
         assert!(selected.is_empty());
-    }
-
-    #[test]
-    fn setup_accepts_deprecated_quiet_flag() {
-        let parsed = SetupArgsHarness::try_parse_from(["bt", "--quiet"]).expect("parse");
-        assert!(parsed.setup.quiet);
-        assert!(!parsed.setup.verbose);
     }
 
     #[test]

--- a/src/setup/mod.rs
+++ b/src/setup/mod.rs
@@ -362,6 +362,8 @@ struct AgentInstallResult {
 #[derive(Debug, Clone, Serialize)]
 struct DetectionSignal {
     agent: Agent,
+    #[serde(default)]
+    on_path: bool,
     reason: String,
 }
 
@@ -646,24 +648,16 @@ async fn run_setup_wizard(mut base: BaseArgs, flags: WizardFlags) -> Result<()> 
         let home = home_dir().ok_or_else(|| anyhow!("failed to resolve HOME/USERPROFILE"))?;
         let local_root = resolve_local_root_for_scope(scope)?;
         let detected = detect_agents(local_root.as_deref(), &home);
-        let agents = vec![resolve_default_agent_selection(
-            flag_agent,
-            &detected,
-            "Select coding agent",
-            true,
-        )?];
+        let selected_agent =
+            resolve_default_agent_selection(flag_agent, &detected, "Select coding agent", true)?;
         if verbose && flag_agent.is_some() {
-            let agent_names: Vec<String> = agents
-                .iter()
-                .map(|a| style(a.as_str()).green().to_string())
-                .collect();
             eprintln!(
-                "{} Select agents to configure · {}",
+                "{} Select agent to configure · {}",
                 style("✔").green(),
-                agent_names.join(", ")
+                style(selected_agent.as_str()).green()
             );
         }
-        Some((scope, agents, home))
+        Some((scope, selected_agent, home))
     } else {
         None
     };
@@ -672,11 +666,11 @@ async fn run_setup_wizard(mut base: BaseArgs, flags: WizardFlags) -> Result<()> 
         if verbose {
             eprintln!("   {}", style("Skills:").bold());
         }
-        if let Some((scope, _, _)) = setup_context {
+        if let Some((scope, selected_agent, _)) = setup_context.as_ref() {
             let args = AgentsSetupArgs {
-                agent: flag_agent,
-                local: matches!(scope, InstallScope::Local),
-                global: matches!(scope, InstallScope::Global),
+                agent: Some(map_agent_to_agent_arg(*selected_agent)),
+                local: matches!(*scope, InstallScope::Local),
+                global: matches!(*scope, InstallScope::Global),
                 workflows: Vec::new(),
                 no_workflow: flag_no_workflow,
                 yes: true,
@@ -701,9 +695,10 @@ async fn run_setup_wizard(mut base: BaseArgs, flags: WizardFlags) -> Result<()> 
         if verbose {
             eprintln!("   {}", style("MCP:").bold());
         }
-        if let Some((scope, ref agents, ref home)) = setup_context {
-            let local_root = resolve_local_root_for_scope(scope)?;
-            let outcome = execute_mcp_install(scope, local_root.as_deref(), home, agents);
+        if let Some((scope, selected_agent, home)) = setup_context.as_ref() {
+            let local_root = resolve_local_root_for_scope(*scope)?;
+            let outcome =
+                execute_mcp_install(*scope, local_root.as_deref(), home, &[*selected_agent]);
             for r in &outcome.results {
                 if verbose {
                     print_wizard_agent_result(r);
@@ -712,7 +707,7 @@ async fn run_setup_wizard(mut base: BaseArgs, flags: WizardFlags) -> Result<()> 
                     had_failures = true;
                 }
             }
-            if outcome.installed_count == 0 && !agents.is_empty() {
+            if outcome.installed_count == 0 {
                 had_failures = true;
             }
         }
@@ -750,12 +745,17 @@ async fn run_setup_wizard(mut base: BaseArgs, flags: WizardFlags) -> Result<()> 
                 .interact()?
         };
         if instrument {
-            let instrument_agent = flag_agent.map(|a| match a {
-                AgentArg::Claude => InstrumentAgentArg::Claude,
-                AgentArg::Codex => InstrumentAgentArg::Codex,
-                AgentArg::Cursor => InstrumentAgentArg::Cursor,
-                AgentArg::Opencode => InstrumentAgentArg::Opencode,
-            });
+            let instrument_agent = setup_context
+                .as_ref()
+                .map(|(_, agent, _)| map_agent_to_instrument_agent_arg(*agent))
+                .or_else(|| {
+                    flag_agent.map(|a| match a {
+                        AgentArg::Claude => InstrumentAgentArg::Claude,
+                        AgentArg::Codex => InstrumentAgentArg::Codex,
+                        AgentArg::Cursor => InstrumentAgentArg::Cursor,
+                        AgentArg::Opencode => InstrumentAgentArg::Opencode,
+                    })
+                });
             run_instrument_setup(
                 base,
                 InstrumentSetupArgs {
@@ -792,7 +792,18 @@ async fn run_setup_wizard(mut base: BaseArgs, flags: WizardFlags) -> Result<()> 
     Ok(())
 }
 
-async fn run_default_setup(base: BaseArgs, args: SetupArgs) -> Result<()> {
+async fn run_default_setup(mut base: BaseArgs, args: SetupArgs) -> Result<()> {
+    let project_flag = base.project.clone();
+    let login_ctx = ensure_auth(&mut base).await?;
+    let client = ApiClient::new(&login_ctx)?;
+    let org = client.org_name().to_string();
+    let project = select_project_with_skip(&client, project_flag.as_deref(), true).await?;
+    if let Some(ref project) = project {
+        if find_git_root().is_some() {
+            let _ = maybe_init(&org, project)?;
+        }
+    }
+
     let scope = default_setup_scope(&args.agents);
     let home = home_dir().ok_or_else(|| anyhow!("failed to resolve HOME/USERPROFILE"))?;
     let local_root = resolve_local_root_for_scope(scope)?;
@@ -844,7 +855,7 @@ async fn run_default_setup(base: BaseArgs, args: SetupArgs) -> Result<()> {
                     agent_cmd: None,
                     workflows: args.agents.workflows,
                     skip_workflow_docs: args.agents.no_workflow,
-                    yes: true,
+                    yes: false,
                     refresh_docs: args.agents.refresh_docs,
                     workers: args.agents.workers,
                     languages: args.languages,
@@ -953,6 +964,10 @@ async fn select_project_for_setup(
     )
     .await?;
 
+    if projects.is_empty() {
+        bail!("no projects found in org '{}'", client.org_name());
+    }
+
     if projects.len() == 1 && projects[0].name == "My Project" {
         return create_or_fetch_project(client, &default_setup_project_name()).await;
     }
@@ -1005,9 +1020,15 @@ async fn create_or_fetch_project(
     }
     match crate::projects::api::create_project(client, name).await {
         Ok(project) => Ok(project),
-        Err(_) => crate::projects::api::get_project_by_name(client, name)
-            .await?
-            .ok_or_else(|| anyhow!("failed to create project '{name}'")),
+        Err(err) => match crate::projects::api::get_project_by_name(client, name).await {
+            Ok(Some(project)) => Ok(project),
+            Ok(None) => Err(err).context(format!(
+                "failed to create project '{name}' and project was not found afterwards"
+            )),
+            Err(fetch_err) => Err(fetch_err).context(format!(
+                "failed to create project '{name}' after initial create error: {err}"
+            )),
+        },
     }
 }
 
@@ -1313,7 +1334,7 @@ async fn run_instrument_setup(
     // --tui:        interactive TUI
     // --background: background, restricted to language package managers
     // --yes or non-interactive terminal: background, restricted to language package managers
-    // Otherwise: ask the user.
+    // Otherwise: default to interactive TUI.
     let (run_interactive, bypass_permissions) = if args.tui {
         (true, false)
     } else if args.yolo {
@@ -1357,14 +1378,14 @@ async fn run_instrument_setup(
 
     if run_interactive {
         eprintln!();
-        eprintln!("Claude Code is opening in interactive mode.");
+        eprintln!("{} is opening in interactive mode.", selected.as_str());
         eprintln!("The instrumentation task is pre-loaded. Press Enter to begin.");
         eprintln!("Task file: {}", task_path.display());
         eprintln!();
     }
 
-    let show_output = !base.json && !args.background;
-    let status = if args.background && !base.json {
+    let show_output = !base.json && run_interactive;
+    let status = if !run_interactive && !base.json {
         with_spinner(
             "Running agent instrumentation…",
             run_agent_invocation(&root, &invocation, false),
@@ -1771,39 +1792,56 @@ fn resolve_instrument_invocation(
     }
 
     let invocation = match agent {
-        Agent::Codex => InstrumentInvocation::Program {
-            program: "codex".to_string(),
-            args: vec!["exec".to_string(), "-".to_string()],
-            stdin_file: Some(task_path.to_path_buf()),
-            prompt_file_arg: None,
-            initial_prompt: None,
-            stream_json: false,
-            interactive,
-        },
+        Agent::Codex => {
+            let mut codex_args = vec![];
+            if bypass_permissions {
+                codex_args.push("--dangerously-bypass-approvals-and-sandbox".to_string());
+            }
+            if interactive {
+                InstrumentInvocation::Program {
+                    program: "codex".to_string(),
+                    args: codex_args,
+                    stdin_file: None,
+                    prompt_file_arg: Some(task_path.to_path_buf()),
+                    initial_prompt: None,
+                    stream_json: false,
+                    interactive: true,
+                }
+            } else {
+                codex_args.extend(["exec".to_string(), "-".to_string()]);
+                InstrumentInvocation::Program {
+                    program: "codex".to_string(),
+                    args: codex_args,
+                    stdin_file: Some(task_path.to_path_buf()),
+                    prompt_file_arg: None,
+                    initial_prompt: None,
+                    stream_json: false,
+                    interactive: false,
+                }
+            }
+        }
         Agent::Claude => {
             if interactive {
-                // In interactive mode the full task goes into --append-system-prompt so
-                // Claude already knows what to do.  A short initial user message is passed
-                // as the positional arg so Claude immediately starts working — the user only
-                // needs to press Enter once on a short, clear prompt rather than a wall of
-                // raw task markdown.
-                let task_content = std::fs::read_to_string(task_path)
-                    .with_context(|| format!("failed to read task file {}", task_path.display()))?;
+                let permission_mode = if bypass_permissions {
+                    "bypassPermissions"
+                } else {
+                    "acceptEdits"
+                };
                 InstrumentInvocation::Program {
                     program: "claude".to_string(),
                     args: vec![
-                        "--append-system-prompt".to_string(),
-                        task_content,
+                        "--permission-mode".to_string(),
+                        permission_mode.to_string(),
+                        "--settings".to_string(),
+                        format!(r#"{{"defaultMode": "{permission_mode}"}}"#),
                         "--disallowedTools".to_string(),
-                        "EnterPlanMode".to_string(),
+                        "ExitPlanMode,EnterPlanMode".to_string(),
                         "--name".to_string(),
                         "Braintrust: Instrument".to_string(),
                     ],
                     stdin_file: None,
-                    prompt_file_arg: None,
-                    initial_prompt: Some(
-                        "Please begin the Braintrust instrumentation task.".to_string(),
-                    ),
+                    prompt_file_arg: Some(task_path.to_path_buf()),
+                    initial_prompt: None,
                     stream_json: false,
                     interactive: true,
                 }
@@ -1848,21 +1886,39 @@ fn resolve_instrument_invocation(
             stream_json: false,
             interactive,
         },
-        Agent::Cursor => InstrumentInvocation::Program {
-            program: "cursor-agent".to_string(),
-            args: vec![
-                "-p".to_string(),
-                "-f".to_string(),
-                "--output-format".to_string(),
-                "stream-json".to_string(),
-                "--stream-partial-output".to_string(),
-            ],
-            stdin_file: None,
-            prompt_file_arg: Some(task_path.to_path_buf()),
-            initial_prompt: None,
-            stream_json: true,
-            interactive,
-        },
+        Agent::Cursor => {
+            let mut cursor_args = vec![];
+            if bypass_permissions {
+                cursor_args.push("--yolo".to_string());
+            }
+            if interactive {
+                InstrumentInvocation::Program {
+                    program: "cursor-agent".to_string(),
+                    args: cursor_args,
+                    stdin_file: None,
+                    prompt_file_arg: Some(task_path.to_path_buf()),
+                    initial_prompt: None,
+                    stream_json: false,
+                    interactive: true,
+                }
+            } else {
+                cursor_args.extend([
+                    "-p".to_string(),
+                    "--output-format".to_string(),
+                    "stream-json".to_string(),
+                    "--stream-partial-output".to_string(),
+                ]);
+                InstrumentInvocation::Program {
+                    program: "cursor-agent".to_string(),
+                    args: cursor_args,
+                    stdin_file: None,
+                    prompt_file_arg: Some(task_path.to_path_buf()),
+                    initial_prompt: None,
+                    stream_json: true,
+                    interactive: false,
+                }
+            }
+        }
     };
     Ok(invocation)
 }
@@ -2518,14 +2574,18 @@ fn resolve_default_agent_selection(
     }
 
     let path_agents = detected_agents_on_path(detected);
-    if path_agents.len() == 1 {
-        return Ok(path_agents[0]);
-    }
-
     if allow_prompt {
         let default = pick_agent_mode_target(&path_agents).unwrap_or(Agent::Codex);
         return prompt_agent_selection(prompt, default)?
             .ok_or_else(|| anyhow!("setup cancelled by user"));
+    }
+
+    if path_agents.len() == 1 {
+        return Ok(path_agents[0]);
+    }
+
+    if path_agents.is_empty() {
+        bail!("no coding agents detected on PATH; pass --agent <AGENT> to try anyway");
     }
 
     bail!("multiple coding agents available; pass --agent <AGENT> or re-run in an interactive terminal");
@@ -2576,7 +2636,7 @@ fn pick_agent_mode_target(candidates: &[Agent]) -> Option<Agent> {
 fn detected_agents_on_path(detected: &[DetectionSignal]) -> Vec<Agent> {
     let mut agents = BTreeSet::new();
     for signal in detected {
-        if signal.reason.contains("binary found in PATH") {
+        if signal.on_path {
             agents.insert(signal.agent);
         }
     }
@@ -2598,19 +2658,30 @@ fn resolve_workflow_selection(requested: &[WorkflowArg]) -> Vec<WorkflowArg> {
 }
 
 fn detect_agents(local_root: Option<&Path>, home: &Path) -> Vec<DetectionSignal> {
-    let mut by_agent: BTreeMap<Agent, BTreeSet<String>> = BTreeMap::new();
+    let mut by_agent: BTreeMap<Agent, BTreeSet<(bool, String)>> = BTreeMap::new();
 
     if let Some(root) = local_root {
         if root.join(".claude").exists() {
-            add_signal(&mut by_agent, Agent::Claude, ".claude exists in repo root");
+            add_signal(
+                &mut by_agent,
+                Agent::Claude,
+                false,
+                ".claude exists in repo root",
+            );
         }
         if root.join(".cursor").exists() {
-            add_signal(&mut by_agent, Agent::Cursor, ".cursor exists in repo root");
+            add_signal(
+                &mut by_agent,
+                Agent::Cursor,
+                false,
+                ".cursor exists in repo root",
+            );
         }
         if root.join(".opencode").exists() {
             add_signal(
                 &mut by_agent,
                 Agent::Opencode,
+                false,
                 ".opencode exists in repo root",
             );
         }
@@ -2618,36 +2689,54 @@ fn detect_agents(local_root: Option<&Path>, home: &Path) -> Vec<DetectionSignal>
             add_signal(
                 &mut by_agent,
                 Agent::Codex,
+                false,
                 ".agents/skills exists in repo root",
             );
             add_signal(
                 &mut by_agent,
                 Agent::Opencode,
+                false,
                 ".agents/skills exists in repo root",
             );
         }
         if root.join("AGENTS.md").exists() {
-            add_signal(&mut by_agent, Agent::Codex, "AGENTS.md exists in repo root");
+            add_signal(
+                &mut by_agent,
+                Agent::Codex,
+                false,
+                "AGENTS.md exists in repo root",
+            );
         }
     }
 
     if home.join(".claude").exists() {
-        add_signal(&mut by_agent, Agent::Claude, "~/.claude exists");
+        add_signal(&mut by_agent, Agent::Claude, false, "~/.claude exists");
     }
     if home.join(".cursor").exists() {
-        add_signal(&mut by_agent, Agent::Cursor, "~/.cursor exists");
+        add_signal(&mut by_agent, Agent::Cursor, false, "~/.cursor exists");
     }
     if home.join(".codex").exists() {
-        add_signal(&mut by_agent, Agent::Codex, "~/.codex exists");
+        add_signal(&mut by_agent, Agent::Codex, false, "~/.codex exists");
     }
     if home.join(".agents/skills").exists() {
-        add_signal(&mut by_agent, Agent::Codex, "~/.agents/skills exists");
-        add_signal(&mut by_agent, Agent::Opencode, "~/.agents/skills exists");
+        add_signal(
+            &mut by_agent,
+            Agent::Codex,
+            false,
+            "~/.agents/skills exists",
+        );
+        add_signal(
+            &mut by_agent,
+            Agent::Opencode,
+            false,
+            "~/.agents/skills exists",
+        );
     }
     if home.join(".opencode").exists() || home.join(".config/opencode").exists() {
         add_signal(
             &mut by_agent,
             Agent::Opencode,
+            false,
             "opencode config directory exists",
         );
     }
@@ -2656,21 +2745,33 @@ fn detect_agents(local_root: Option<&Path>, home: &Path) -> Vec<DetectionSignal>
         add_signal(
             &mut by_agent,
             Agent::Claude,
+            true,
             "`claude` binary found in PATH",
         );
     }
 
     let mut out = Vec::new();
-    for (agent, reasons) in by_agent {
-        for reason in reasons {
-            out.push(DetectionSignal { agent, reason });
+    for (agent, signals) in by_agent {
+        for (on_path, reason) in signals {
+            out.push(DetectionSignal {
+                agent,
+                on_path,
+                reason,
+            });
         }
     }
     out
 }
 
-fn add_signal(map: &mut BTreeMap<Agent, BTreeSet<String>>, agent: Agent, reason: &str) {
-    map.entry(agent).or_default().insert(reason.to_string());
+fn add_signal(
+    map: &mut BTreeMap<Agent, BTreeSet<(bool, String)>>,
+    agent: Agent,
+    on_path: bool,
+    reason: &str,
+) {
+    map.entry(agent)
+        .or_default()
+        .insert((on_path, reason.to_string()));
 }
 
 fn install_claude(
@@ -3321,6 +3422,7 @@ mod tests {
     fn single_path_agent_is_selected_by_default() {
         let detected = vec![DetectionSignal {
             agent: Agent::Codex,
+            on_path: true,
             reason: "`codex` binary found in PATH".to_string(),
         }];
         let resolved =
@@ -3334,10 +3436,12 @@ mod tests {
         let detected = vec![
             DetectionSignal {
                 agent: Agent::Codex,
+                on_path: true,
                 reason: "`codex` binary found in PATH".to_string(),
             },
             DetectionSignal {
                 agent: Agent::Claude,
+                on_path: true,
                 reason: "`claude` binary found in PATH".to_string(),
             },
         ];
@@ -3612,6 +3716,34 @@ mod tests {
     }
 
     #[test]
+    fn codex_interactive_instrument_invocation_uses_tui_prompt_arg() {
+        let task_path = PathBuf::from("/tmp/AGENT_TASK.instrument.md");
+        let invocation =
+            resolve_instrument_invocation(Agent::Codex, None, &task_path, true, false, &[])
+                .expect("resolve instrument invocation");
+
+        match invocation {
+            InstrumentInvocation::Program {
+                program,
+                args,
+                stdin_file,
+                prompt_file_arg,
+                stream_json,
+                interactive,
+                ..
+            } => {
+                assert_eq!(program, "codex");
+                assert!(args.is_empty());
+                assert_eq!(stdin_file, None);
+                assert_eq!(prompt_file_arg, Some(task_path));
+                assert!(!stream_json);
+                assert!(interactive);
+            }
+            InstrumentInvocation::Shell(_) => panic!("expected program invocation"),
+        }
+    }
+
+    #[test]
     fn claude_instrument_invocation_uses_print_with_bypass_permissions() {
         let task_path = PathBuf::from("/tmp/AGENT_TASK.instrument.md");
         let invocation =
@@ -3712,11 +3844,8 @@ mod tests {
     }
 
     #[test]
-    fn claude_interactive_instrument_invocation_uses_system_prompt_no_print_flag() {
-        let dir = tempfile::tempdir().expect("tempdir");
-        let task_path = dir.path().join("AGENT_TASK.instrument.md");
-        std::fs::write(&task_path, "## Task\nInstrument this repo.").expect("write task");
-
+    fn claude_interactive_instrument_invocation_uses_prompt_arg_no_print_flag() {
+        let task_path = PathBuf::from("/tmp/AGENT_TASK.instrument.md");
         let invocation =
             resolve_instrument_invocation(Agent::Claude, None, &task_path, true, false, &[])
                 .expect("resolve instrument invocation");
@@ -3727,30 +3856,21 @@ mod tests {
                 args,
                 stdin_file,
                 prompt_file_arg,
-                initial_prompt,
                 stream_json,
                 interactive,
+                ..
             } => {
                 assert_eq!(program, "claude");
                 assert!(
                     !args.contains(&"-p".to_string()),
                     "interactive mode must not pass -p"
                 );
-                assert!(
-                    args.contains(&"--append-system-prompt".to_string()),
-                    "task should be in system prompt"
-                );
+                assert!(args.contains(&"--permission-mode".to_string()));
+                assert!(args.contains(&"--settings".to_string()));
                 assert!(args.contains(&"--disallowedTools".to_string()));
                 assert!(args.contains(&"--name".to_string()));
                 assert_eq!(stdin_file, None);
-                assert_eq!(
-                    prompt_file_arg, None,
-                    "task is in system prompt, not prompt_file_arg"
-                );
-                assert!(
-                    initial_prompt.is_some(),
-                    "short initial message must be set to trigger Claude"
-                );
+                assert_eq!(prompt_file_arg, Some(task_path));
                 assert!(!stream_json);
                 assert!(interactive);
             }
@@ -3805,7 +3925,6 @@ mod tests {
                     args,
                     vec![
                         "-p".to_string(),
-                        "-f".to_string(),
                         "--output-format".to_string(),
                         "stream-json".to_string(),
                         "--stream-partial-output".to_string(),
@@ -3814,6 +3933,34 @@ mod tests {
                 assert_eq!(stdin_file, None);
                 assert_eq!(prompt_file_arg, Some(task_path));
                 assert!(stream_json);
+            }
+            InstrumentInvocation::Shell(_) => panic!("expected program invocation"),
+        }
+    }
+
+    #[test]
+    fn cursor_interactive_instrument_invocation_uses_tui_prompt_arg() {
+        let task_path = PathBuf::from("/tmp/AGENT_TASK.instrument.md");
+        let invocation =
+            resolve_instrument_invocation(Agent::Cursor, None, &task_path, true, false, &[])
+                .expect("resolve instrument invocation");
+
+        match invocation {
+            InstrumentInvocation::Program {
+                program,
+                args,
+                stdin_file,
+                prompt_file_arg,
+                stream_json,
+                interactive,
+                ..
+            } => {
+                assert_eq!(program, "cursor-agent");
+                assert!(args.is_empty());
+                assert_eq!(stdin_file, None);
+                assert_eq!(prompt_file_arg, Some(task_path));
+                assert!(!stream_json);
+                assert!(interactive);
             }
             InstrumentInvocation::Shell(_) => panic!("expected program invocation"),
         }

--- a/src/setup/mod.rs
+++ b/src/setup/mod.rs
@@ -106,6 +106,10 @@ pub struct SetupArgs {
     #[arg(long, short = 'v')]
     verbose: bool,
 
+    /// Deprecated: use --no-skills --no-mcp instead
+    #[arg(long, hide = true, conflicts_with = "skills", conflicts_with = "mcp")]
+    no_mcp_skill: bool,
+
     #[command(flatten)]
     agents: AgentsSetupArgs,
 }
@@ -215,11 +219,11 @@ struct InstrumentSetupArgs {
     languages: Vec<LanguageArg>,
 
     /// Run the agent in interactive TUI mode [default]
-    #[arg(long, conflicts_with = "background")]
+    #[arg(long, conflicts_with = "background", alias = "interactive")]
     tui: bool,
 
     /// Run the agent in background (non-interactive) mode
-    #[arg(long, conflicts_with = "tui")]
+    #[arg(long, conflicts_with = "tui", alias = "quiet")]
     background: bool,
 
     /// Grant the agent full permissions (bypass permission prompts)
@@ -419,8 +423,18 @@ pub async fn run_setup_top(mut base: BaseArgs, mut args: SetupArgs) -> Result<()
         crate::ui::set_quiet(false);
         crate::ui::set_animations_enabled(true);
     }
+    // Deprecated flag: --no-mcp-skill is equivalent to --no-skills --no-mcp
+    if args.no_mcp_skill {
+        args.no_skills = true;
+        args.no_mcp = true;
+    }
     if base.json && args.instrument {
         bail!("--json conflicts with --instrument: JSON mode implies --no-instrument");
+    }
+    if base.json && args.tui {
+        bail!(
+            "--json conflicts with --tui: JSON output is not compatible with interactive TUI mode"
+        );
     }
     if base.json {
         args.no_instrument = true;
@@ -1951,7 +1965,8 @@ fn resolve_setup_selection(args: &AgentsSetupArgs, home: &Path) -> Result<SetupS
     );
     let interactive = ui::is_interactive() && !args.yes;
     let mut prompted_agents: Option<Vec<Agent>> = None;
-    let mut prompted_workflows: Option<Vec<WorkflowArg>> = if args.no_fetch_docs || args.no_workflow {
+    let mut prompted_workflows: Option<Vec<WorkflowArg>> = if args.no_fetch_docs || args.no_workflow
+    {
         Some(Vec::new())
     } else {
         None
@@ -2436,7 +2451,10 @@ fn resolve_scope_from_flags(
     })
 }
 
-fn resolve_selected_agents(requested: Option<AgentArg>, detected: &[DetectionSignal]) -> Vec<Agent> {
+fn resolve_selected_agents(
+    requested: Option<AgentArg>,
+    detected: &[DetectionSignal],
+) -> Vec<Agent> {
     let Some(arg) = requested else {
         let mut inferred = BTreeSet::new();
         for signal in detected {

--- a/src/setup/mod.rs
+++ b/src/setup/mod.rs
@@ -1,5 +1,6 @@
 use std::collections::{BTreeMap, BTreeSet};
 use std::fs;
+use std::io::IsTerminal;
 use std::path::{Path, PathBuf};
 use std::process::Stdio;
 
@@ -527,7 +528,7 @@ async fn run_setup_wizard(mut base: BaseArgs, flags: WizardFlags) -> Result<()> 
         print_wizard_step(1, "Auth");
     }
     let project_flag = base.project.clone();
-    let client = ensure_setup_auth(&mut base, !flag_no_instrument).await?;
+    let client = ensure_setup_auth(&mut base, !flag_no_instrument, !flag_no_instrument).await?;
     let org = client.org_name().to_string();
 
     if verbose {
@@ -785,7 +786,7 @@ async fn run_default_setup(mut base: BaseArgs, args: SetupArgs) -> Result<()> {
     let needs_auth = !args.no_instrument;
     if needs_auth {
         let project_flag = base.project.clone();
-        let client = ensure_setup_auth(&mut base, false).await?;
+        let client = ensure_setup_auth(&mut base, false, true).await?;
         let org = client.org_name().to_string();
         let project = select_project_with_skip(&client, project_flag.as_deref(), true).await?;
         if let Some(ref project) = project {
@@ -924,13 +925,16 @@ fn resolve_profile_name_for_setup(
     }
 }
 
-async fn ensure_auth(base: &mut BaseArgs, prompt_for_profile_choice: bool) -> Result<LoginContext> {
+async fn ensure_auth(
+    base: &mut BaseArgs,
+    prompt_for_profile_choice: bool,
+) -> Result<(LoginContext, bool)> {
     if matches!(base.api_key_source, Some(ArgValueSource::CommandLine)) {
-        return auth::login(base).await;
+        return Ok((auth::login(base).await?, false));
     }
 
     if matches!(base.api_key_source, Some(ArgValueSource::EnvVariable)) && !base.prefer_profile {
-        return auth::login(base).await;
+        return Ok((auth::login(base).await?, false));
     }
 
     let profiles = auth::list_profiles()?;
@@ -945,7 +949,10 @@ async fn ensure_auth(base: &mut BaseArgs, prompt_for_profile_choice: bool) -> Re
         base.profile = Some(profile_name.clone());
 
         match auth::login(base).await {
-            Ok(ctx) => return Ok(ctx),
+            Ok(ctx) => {
+                let is_oauth = auth::resolve_auth(base).await?.is_oauth;
+                return Ok((ctx, is_oauth));
+            }
             Err(err) if auth::is_missing_credential_error(&err) => {
                 if base.verbose {
                     eprintln!(
@@ -954,7 +961,7 @@ async fn ensure_auth(base: &mut BaseArgs, prompt_for_profile_choice: bool) -> Re
                     );
                 }
                 auth::login_interactive_oauth(base).await?;
-                return auth::login(base).await;
+                return Ok((auth::login(base).await?, true));
             }
             Err(err) => return Err(err),
         }
@@ -964,15 +971,99 @@ async fn ensure_auth(base: &mut BaseArgs, prompt_for_profile_choice: bool) -> Re
         eprintln!("No auth profiles found. Starting OAuth login.\n");
     }
     auth::login_interactive_oauth(base).await?;
-    auth::login(base).await
+    Ok((auth::login(base).await?, true))
 }
 
 async fn ensure_setup_auth(
     base: &mut BaseArgs,
     prompt_for_profile_choice: bool,
+    will_instrument: bool,
 ) -> Result<ApiClient> {
-    let login_ctx = ensure_auth(base, prompt_for_profile_choice).await?;
-    ApiClient::new(&login_ctx)
+    let (login_ctx, is_oauth) = ensure_auth(base, prompt_for_profile_choice).await?;
+    let client = ApiClient::new(&login_ctx)?;
+    if should_create_api_key_for_instrumentation(is_oauth, base, will_instrument) {
+        maybe_create_api_key_for_instrumentation(base, &client).await?;
+    }
+    Ok(client)
+}
+
+fn should_create_api_key_for_instrumentation(
+    is_oauth: bool,
+    base: &BaseArgs,
+    will_instrument: bool,
+) -> bool {
+    will_instrument
+        && is_oauth
+        && !matches!(
+            base.api_key_source,
+            Some(ArgValueSource::CommandLine | ArgValueSource::EnvVariable)
+        )
+}
+
+async fn maybe_create_api_key_for_instrumentation(
+    base: &BaseArgs,
+    client: &ApiClient,
+) -> Result<()> {
+    let username = std::process::Command::new("whoami")
+        .output()
+        .ok()
+        .and_then(|o| String::from_utf8(o.stdout).ok())
+        .map(|s| s.trim().to_string())
+        .filter(|s| !s.is_empty())
+        .unwrap_or_else(|| "user".to_string());
+    let base_name = format!("{username}-created-by-bt-setup");
+
+    #[derive(serde::Deserialize)]
+    struct ApiKeyEntry {
+        name: String,
+    }
+    #[derive(serde::Deserialize)]
+    struct ApiKeyList {
+        objects: Vec<ApiKeyEntry>,
+    }
+    #[derive(serde::Deserialize)]
+    struct CreatedKey {
+        key: String,
+    }
+
+    let existing: Vec<String> = client
+        .get::<ApiKeyList>("/v1/api_key")
+        .await
+        .map(|r| r.objects.into_iter().map(|k| k.name).collect())
+        .unwrap_or_default();
+
+    let name = if !existing.iter().any(|n| n == &base_name) {
+        base_name
+    } else {
+        (1u32..)
+            .map(|i| format!("{base_name}{i}"))
+            .find(|candidate| !existing.iter().any(|n| n == candidate))
+            .expect("name sequence is infinite")
+    };
+
+    let body = serde_json::json!({ "name": name, "org_name": client.org_name() });
+    let created: CreatedKey = client.post("/v1/api_key", &body).await?;
+    std::env::set_var("BRAINTRUST_API_KEY", &created.key);
+
+    if !base.quiet && std::io::stderr().is_terminal() {
+        eprintln!();
+        eprintln!(
+            "{} Created Braintrust API key '{}' for instrumentation and exported it to this setup process:",
+            style("!").yellow().bold(),
+            name,
+        );
+        eprintln!();
+        eprintln!("   {}", style(&created.key).bold());
+        eprintln!();
+        eprintln!("   To reuse it later in your shell, run:");
+        eprintln!(
+            "   {}",
+            style(format!("export BRAINTRUST_API_KEY={}", created.key)).dim()
+        );
+        eprintln!();
+    }
+
+    Ok(())
 }
 
 async fn select_project_for_setup(
@@ -3572,6 +3663,26 @@ mod tests {
         let resolved =
             resolve_profile_name_for_setup(&base, &profiles, false).expect("resolve profile");
         assert_eq!(resolved, "alpha");
+    }
+
+    #[test]
+    fn oauth_instrumentation_creates_api_key_when_no_env_key_exists() {
+        let base = make_base_args();
+        assert!(should_create_api_key_for_instrumentation(true, &base, true));
+    }
+
+    #[test]
+    fn oauth_non_instrumentation_does_not_create_api_key() {
+        let base = make_base_args();
+        assert!(!should_create_api_key_for_instrumentation(true, &base, false));
+    }
+
+    #[test]
+    fn oauth_instrumentation_skips_api_key_creation_when_env_key_exists() {
+        let mut base = make_base_args();
+        base.api_key = Some("env-key".to_string());
+        base.api_key_source = Some(ArgValueSource::EnvVariable);
+        assert!(!should_create_api_key_for_instrumentation(true, &base, true));
     }
 
     #[test]

--- a/src/setup/mod.rs
+++ b/src/setup/mod.rs
@@ -108,10 +108,6 @@ pub struct SetupArgs {
     #[arg(long, short = 'i')]
     interactive: bool,
 
-    /// Show additional setup output
-    #[arg(long, short = 'v', global = true)]
-    verbose: bool,
-
     /// Deprecated: use --no-skills --no-mcp instead
     #[arg(long, hide = true, conflicts_with = "skills", conflicts_with = "mcp")]
     no_mcp_skill: bool,
@@ -419,10 +415,7 @@ struct SkillsAliasResult {
     path: PathBuf,
 }
 
-pub async fn run_setup_top(mut base: BaseArgs, mut args: SetupArgs) -> Result<()> {
-    base.verbose = args.verbose;
-    crate::ui::set_quiet(!args.verbose);
-    crate::ui::set_animations_enabled(args.verbose);
+pub async fn run_setup_top(base: BaseArgs, mut args: SetupArgs) -> Result<()> {
     // Deprecated flag: --no-mcp-skill is equivalent to --no-skills --no-mcp
     if args.no_mcp_skill {
         args.no_skills = true;
@@ -1663,7 +1656,7 @@ async fn run_setup(base: BaseArgs, args: AgentsSetupArgs) -> Result<()> {
             "{}",
             serde_json::to_string_pretty(&report).context("failed to serialize setup report")?
         );
-    } else {
+    } else if base.verbose {
         print_human_report(
             false,
             outcome.scope,
@@ -1696,7 +1689,7 @@ async fn execute_skills_setup(
     let mut warnings = Vec::new();
     let mut notes = Vec::new();
     let mut results = Vec::new();
-    let show_progress = !base.json && !quiet;
+    let show_progress = !base.json && !quiet && base.verbose;
 
     if show_progress {
         println!("Configuring coding agents for Braintrust");
@@ -1938,7 +1931,7 @@ async fn run_instrument_setup(
         &selected_languages,
     )?;
 
-    if run_interactive {
+    if run_interactive && base.verbose {
         eprintln!();
         eprintln!("{} is opening in interactive mode.", selected.as_str());
         eprintln!("The instrumentation task is pre-loaded. Press Enter to begin.");
@@ -1985,7 +1978,7 @@ async fn run_instrument_setup(
             "{}",
             serde_json::to_string_pretty(&report).context("failed to serialize setup report")?
         );
-    } else {
+    } else if base.verbose {
         eprintln!();
         for result in &results {
             print_wizard_agent_result(result);
@@ -2626,7 +2619,7 @@ fn run_mcp_setup(base: BaseArgs, args: AgentsMcpSetupArgs) -> Result<()> {
             serde_json::to_string_pretty(&report)
                 .context("failed to serialize MCP setup report")?
         );
-    } else {
+    } else if base.verbose {
         print_mcp_human_report(scope, &selected_agents, &outcome.results, &outcome.warnings);
     }
 
@@ -3918,6 +3911,7 @@ mod tests {
             json: false,
             verbose: false,
             quiet: false,
+            quiet_source: None,
             no_color: false,
             no_input: false,
             profile: None,

--- a/src/setup/mod.rs
+++ b/src/setup/mod.rs
@@ -156,12 +156,8 @@ struct AgentsSetupArgs {
     #[arg(skip)]
     yes: bool,
 
-    /// Do not auto-fetch workflow docs during setup
-    #[arg(long)]
-    no_fetch_docs: bool,
-
     /// Refresh prefetched docs by clearing existing output before download
-    #[arg(long, conflicts_with = "no_fetch_docs")]
+    #[arg(long, conflicts_with = "no_workflow")]
     refresh_docs: bool,
 
     /// Number of concurrent workers for docs prefetch/download.
@@ -668,9 +664,8 @@ async fn run_setup_wizard(mut base: BaseArgs, flags: WizardFlags) -> Result<()> 
                 local: matches!(*scope, InstallScope::Local),
                 global: matches!(*scope, InstallScope::Global),
                 workflows: Vec::new(),
-                no_workflow: flag_no_workflow,
+                no_workflow: true,
                 yes: true,
-                no_fetch_docs: true,
                 refresh_docs: false,
                 workers: crate::sync::default_workers(),
                 yolo: false,
@@ -821,7 +816,6 @@ async fn run_default_setup(mut base: BaseArgs, args: SetupArgs) -> Result<()> {
                 workflows: args.agents.workflows.clone(),
                 no_workflow: args.agents.no_workflow,
                 yes: true,
-                no_fetch_docs: args.agents.no_fetch_docs,
                 refresh_docs: args.agents.refresh_docs,
                 workers: args.agents.workers,
                 yolo: args.agents.yolo,
@@ -1169,8 +1163,6 @@ async fn execute_skills_setup(
         notes.push(
             "Skipped workflow docs prefetch (no agents configured successfully).".to_string(),
         );
-    } else if args.no_fetch_docs {
-        notes.push("Skipped workflow docs prefetch (`--no-fetch-docs`).".to_string());
     } else if selected_workflows.is_empty() {
         notes.push("Skipped workflow docs prefetch (no workflows selected).".to_string());
     } else {
@@ -1303,7 +1295,6 @@ async fn run_instrument_setup(
             workflows: selected_workflows.clone(),
             no_workflow: args.skip_workflow_docs,
             yes: true,
-            no_fetch_docs: args.skip_workflow_docs,
             refresh_docs: args.refresh_docs,
             workers: args.workers,
             yolo: false,
@@ -2143,8 +2134,7 @@ fn run_mcp_setup(base: BaseArgs, args: AgentsMcpSetupArgs) -> Result<()> {
 fn resolve_setup_selection(args: &AgentsSetupArgs, home: &Path) -> Result<SetupSelection> {
     let mut scope = initial_scope(args.local, args.global, args.yes, YesScopeDefault::Global);
     let interactive = ui::is_interactive() && !args.yes;
-    let mut prompted_workflows: Option<Vec<WorkflowArg>> = if args.no_fetch_docs || args.no_workflow
-    {
+    let mut prompted_workflows: Option<Vec<WorkflowArg>> = if args.no_workflow {
         Some(Vec::new())
     } else {
         None
@@ -2161,7 +2151,7 @@ fn resolve_setup_selection(args: &AgentsSetupArgs, home: &Path) -> Result<SetupS
         if scope.is_none() {
             steps.push(SetupWizardStep::Scope);
         }
-        if !args.no_fetch_docs && args.workflows.is_empty() {
+        if !args.no_workflow && args.workflows.is_empty() {
             steps.push(SetupWizardStep::Workflows);
         }
 
@@ -2219,7 +2209,7 @@ fn resolve_setup_selection(args: &AgentsSetupArgs, home: &Path) -> Result<SetupS
     )?;
     let selected_agents = vec![selected_agent];
 
-    let selected_workflows = if args.no_fetch_docs {
+    let selected_workflows = if args.no_workflow {
         Vec::new()
     } else if let Some(value) = prompted_workflows {
         value
@@ -3535,25 +3525,6 @@ mod tests {
     }
 
     #[test]
-    fn resolve_setup_selection_honors_no_fetch_docs() {
-        let args = AgentsSetupArgs {
-            agent: Some(AgentArg::Codex),
-            local: false,
-            global: true,
-            workflows: vec![WorkflowArg::Evaluate],
-            no_workflow: false,
-            yes: true,
-            no_fetch_docs: true,
-            refresh_docs: false,
-            workers: crate::sync::default_workers(),
-            yolo: false,
-        };
-        let home = std::env::temp_dir();
-        let selection = resolve_setup_selection(&args, &home).expect("resolve setup selection");
-        assert!(selection.selected_workflows.is_empty());
-    }
-
-    #[test]
     fn resolve_setup_selection_honors_no_workflow() {
         let args = AgentsSetupArgs {
             agent: Some(AgentArg::Codex),
@@ -3562,7 +3533,6 @@ mod tests {
             workflows: vec![WorkflowArg::Evaluate],
             no_workflow: true,
             yes: true,
-            no_fetch_docs: false,
             refresh_docs: false,
             workers: crate::sync::default_workers(),
             yolo: false,

--- a/src/setup/mod.rs
+++ b/src/setup/mod.rs
@@ -528,17 +528,8 @@ async fn run_setup_wizard(mut base: BaseArgs, flags: WizardFlags) -> Result<()> 
         print_wizard_step(1, "Auth");
     }
     let project_flag = base.project.clone();
-    let login_ctx = ensure_auth(&mut base).await?;
-    let client = ApiClient::new(&login_ctx)?;
+    let (_login_ctx, client) = ensure_setup_auth(&mut base).await?;
     let org = client.org_name().to_string();
-
-    // After OAuth login, create a permanent API key so the user has one for external tooling.
-    let resolved = auth::resolve_auth(&base).await.ok();
-    let is_oauth = resolved.map(|r| r.is_oauth).unwrap_or(false);
-    let has_explicit_key = base.api_key.is_some() || std::env::var("BRAINTRUST_API_KEY").is_ok();
-    if is_oauth && !has_explicit_key {
-        maybe_create_api_key_for_oauth(&client).await?;
-    }
 
     if verbose {
         eprintln!("   {} Using org '{}'", style("✓").green(), org);
@@ -792,15 +783,16 @@ async fn run_setup_wizard(mut base: BaseArgs, flags: WizardFlags) -> Result<()> 
 }
 
 async fn run_default_setup(mut base: BaseArgs, args: SetupArgs) -> Result<()> {
-    let should_prepare_project = should_prepare_project_context(args.no_instrument);
-    if should_prepare_project {
+    let needs_auth = !args.no_instrument || (args.mcp && !args.no_mcp);
+    if needs_auth {
         let project_flag = base.project.clone();
-        let login_ctx = ensure_auth(&mut base).await?;
-        let client = ApiClient::new(&login_ctx)?;
+        let (_login_ctx, client) = ensure_setup_auth(&mut base).await?;
         let org = client.org_name().to_string();
         let project = select_project_with_skip(&client, project_flag.as_deref(), true).await?;
         if let Some(ref project) = project {
-            let _ = maybe_init(&org, project)?;
+            if find_git_root().is_some() {
+                let _ = maybe_init(&org, project)?;
+            }
         }
     }
 
@@ -847,9 +839,6 @@ async fn run_default_setup(mut base: BaseArgs, args: SetupArgs) -> Result<()> {
 
     if !args.no_instrument {
         if find_git_root().is_some() {
-            let home = home_dir().ok_or_else(|| anyhow!("failed to resolve HOME/USERPROFILE"))?;
-            let root = find_git_root().expect("git root already checked");
-            ensure_instrumentation_skill_prereq(selected_agent, &root, &home, args.no_skills)?;
             run_instrument_setup(
                 base,
                 InstrumentSetupArgs {
@@ -877,49 +866,85 @@ async fn run_default_setup(mut base: BaseArgs, args: SetupArgs) -> Result<()> {
     Ok(())
 }
 
-fn should_prepare_project_context(no_instrument: bool) -> bool {
-    !no_instrument && find_git_root().is_some()
-}
-
-async fn ensure_auth(base: &mut BaseArgs) -> Result<LoginContext> {
+async fn ensure_auth(base: &mut BaseArgs) -> Result<(LoginContext, bool)> {
     if matches!(base.api_key_source, Some(ArgValueSource::CommandLine)) {
-        return auth::login(base).await;
+        return Ok((auth::login(base).await?, false));
+    }
+
+    if matches!(base.api_key_source, Some(ArgValueSource::EnvVariable)) && !base.prefer_profile {
+        return Ok((auth::login(base).await?, false));
     }
 
     let profiles = auth::list_profiles()?;
-    if base.prefer_profile {
-        return login_with_existing_or_oauth(base, &profiles).await;
+    if !profiles.is_empty() {
+        let profile_name = if let Some(profile_name) =
+            base.profile.as_ref().map(|value| value.trim())
+        {
+            if !profile_name.is_empty() {
+                profile_name.to_string()
+            } else if let Some(org) = base.org_name.as_deref() {
+                auth::resolve_org_to_profile(org, &profiles)?
+            } else if profiles.len() == 1 {
+                profiles[0].name.clone()
+            } else if !ui::is_interactive() {
+                bail!("multiple auth profiles found; pass --profile <NAME> or --org <ORG>, or re-run in an interactive terminal")
+            } else {
+                auth::select_profile_interactive(None)?
+                    .ok_or_else(|| anyhow!("no profile selected"))?
+            }
+        } else if let Some(org) = base.org_name.as_deref() {
+            auth::resolve_org_to_profile(org, &profiles)?
+        } else if profiles.len() == 1 {
+            profiles[0].name.clone()
+        } else if !ui::is_interactive() {
+            bail!("multiple auth profiles found; pass --profile <NAME> or --org <ORG>, or re-run in an interactive terminal")
+        } else {
+            auth::select_profile_interactive(None)?.ok_or_else(|| anyhow!("no profile selected"))?
+        };
+        base.profile = Some(profile_name.clone());
+
+        match auth::login(base).await {
+            Ok(ctx) => {
+                let is_oauth = profiles
+                    .iter()
+                    .find(|p| p.name == profile_name)
+                    .is_some_and(|p| p.is_oauth);
+                return Ok((ctx, is_oauth));
+            }
+            Err(err) if auth::is_missing_credential_error(&err) => {
+                if base.verbose {
+                    eprintln!(
+                        "   Profile '{}' credentials inaccessible ({}). Re-authenticating via OAuth...",
+                        profile_name, err
+                    );
+                }
+                base.profile = None;
+                auth::login_interactive_oauth(base).await?;
+                return Ok((auth::login(base).await?, true));
+            }
+            Err(err) => return Err(err),
+        }
     }
 
-    if matches!(base.api_key_source, Some(ArgValueSource::EnvVariable)) {
-        return auth::login(base).await;
+    if base.verbose {
+        eprintln!("No auth profiles found. Starting OAuth login.\n");
     }
-
-    login_with_existing_or_oauth(base, &profiles).await
+    auth::login_interactive_oauth(base).await?;
+    Ok((auth::login(base).await?, true))
 }
 
-async fn login_with_existing_or_oauth(
-    base: &mut BaseArgs,
-    profiles: &[auth::ProfileInfo],
-) -> Result<LoginContext> {
-    if profiles.is_empty() {
-        eprintln!("No auth profiles found. Let's set one up.\n");
-        auth::login_interactive_oauth(base).await?;
-        return auth::login(base).await;
+async fn ensure_setup_auth(base: &mut BaseArgs) -> Result<(LoginContext, ApiClient)> {
+    let (login_ctx, is_oauth) = ensure_auth(base).await?;
+    let client = ApiClient::new(&login_ctx)?;
+    if is_oauth
+        && !matches!(
+            base.api_key_source,
+            Some(ArgValueSource::CommandLine | ArgValueSource::EnvVariable)
+        )
+    {
+        maybe_create_api_key_for_oauth(&client).await?;
     }
-
-    let cfg_org = config::load().ok().and_then(|cfg| cfg.org);
-    if let Some(profile_name) = choose_setup_profile(base, profiles, cfg_org.as_deref())? {
-        base.profile = Some(profile_name);
-    }
-    match auth::login(base).await {
-        Ok(ctx) => Ok(ctx),
-        Err(err) if auth::is_missing_credential_error(&err) => {
-            auth::login_interactive_oauth(base).await?;
-            auth::login(base).await
-        }
-        Err(err) => Err(err),
-    }
+    Ok((login_ctx, client))
 }
 
 /// After an OAuth login in `bt setup`, create a permanent Braintrust API key so the user
@@ -997,59 +1022,6 @@ async fn maybe_create_api_key_for_oauth(client: &ApiClient) -> Result<()> {
     }
 
     Ok(())
-}
-
-fn choose_setup_profile(
-    base: &BaseArgs,
-    profiles: &[auth::ProfileInfo],
-    cfg_org: Option<&str>,
-) -> Result<Option<String>> {
-    if let Some(profile_name) = base.profile.as_ref().map(|value| value.trim()) {
-        if !profile_name.is_empty() {
-            return Ok(Some(profile_name.to_string()));
-        }
-    }
-
-    if let Some(org) = base.org_name.as_deref() {
-        return auth::resolve_org_to_profile(org, profiles).map(Some);
-    }
-
-    if let Some(org) = cfg_org {
-        return auth::resolve_org_to_profile(org, profiles).map(Some);
-    }
-
-    if profiles.len() == 1 {
-        return Ok(profiles.first().map(|profile| profile.name.clone()));
-    }
-
-    if ui::is_interactive() {
-        return auth::select_profile_interactive(None);
-    }
-
-    bail!("multiple auth profiles found; pass --profile <NAME> or --org <ORG>, or re-run in an interactive terminal")
-}
-
-fn ensure_instrumentation_skill_prereq(
-    agent: Agent,
-    root: &Path,
-    home: &Path,
-    no_skills: bool,
-) -> Result<()> {
-    if !no_skills {
-        return Ok(());
-    }
-
-    let skill_path = skill_config_path(agent, InstallScope::Local, Some(root), home)?;
-    if skill_path.exists() {
-        return Ok(());
-    }
-
-    bail!(
-        "--no-skills prevents automatic skill installation, but instrumentation requires a local {} skill at {}. Re-run without --no-skills, run `bt setup skills --local --agent {}` first, or add --no-instrument.",
-        agent.as_str(),
-        skill_path.display(),
-        agent.as_str(),
-    )
 }
 
 async fn select_project_for_setup(
@@ -3543,14 +3515,25 @@ fn print_mcp_human_report(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use clap::Parser;
-    use std::fs;
     use std::time::{SystemTime, UNIX_EPOCH};
 
-    #[derive(Parser)]
-    struct SetupArgsHarness {
-        #[command(flatten)]
-        setup: SetupArgs,
+    fn make_base_args() -> BaseArgs {
+        BaseArgs {
+            json: false,
+            verbose: false,
+            quiet: false,
+            no_color: false,
+            no_input: false,
+            profile: None,
+            org_name: None,
+            project: None,
+            api_key: None,
+            api_key_source: None,
+            prefer_profile: false,
+            api_url: None,
+            app_url: None,
+            env_file: None,
+        }
     }
 
     #[test]
@@ -3585,73 +3568,26 @@ mod tests {
         assert!(err.to_string().contains("pass --agent"));
     }
 
-    #[test]
-    fn choose_setup_profile_uses_configured_org_when_multiple_profiles_exist() {
-        let base = BaseArgs {
-            json: false,
-            verbose: false,
-            quiet: false,
-            no_color: false,
-            no_input: true,
-            profile: None,
-            org_name: None,
-            project: None,
-            api_key: None,
-            api_key_source: None,
-            prefer_profile: false,
-            api_url: None,
-            app_url: None,
-            env_file: None,
-        };
-        let profiles = vec![
-            auth::ProfileInfo {
-                name: "alpha".to_string(),
-                org_name: Some("alpha-org".to_string()),
-                user_name: None,
-                email: None,
-                api_key_hint: None,
-            },
-            auth::ProfileInfo {
-                name: "beta".to_string(),
-                org_name: Some("beta-org".to_string()),
-                user_name: None,
-                email: None,
-                api_key_hint: None,
-            },
-        ];
-
-        let selected = choose_setup_profile(&base, &profiles, Some("alpha-org"))
-            .expect("resolve profile from config org");
-
-        assert_eq!(selected, Some("alpha".to_string()));
+    fn should_create_api_key(is_oauth: bool, base: &BaseArgs) -> bool {
+        is_oauth
+            && !matches!(
+                base.api_key_source,
+                Some(ArgValueSource::CommandLine | ArgValueSource::EnvVariable)
+            )
     }
 
     #[test]
-    fn no_skills_blocks_instrumentation_when_local_skill_is_missing() {
-        let root = tempfile::tempdir().expect("tempdir");
-        let home = tempfile::tempdir().expect("home tempdir");
-
-        let err = ensure_instrumentation_skill_prereq(Agent::Codex, root.path(), home.path(), true)
-            .expect_err("missing local skill should fail when --no-skills is set");
-
-        assert!(err
-            .to_string()
-            .contains("--no-skills prevents automatic skill installation"));
-        assert!(err
-            .to_string()
-            .contains("bt setup skills --local --agent codex"));
+    fn setup_creates_api_key_for_oauth_without_explicit_key() {
+        let base = make_base_args();
+        assert!(should_create_api_key(true, &base));
     }
 
     #[test]
-    fn no_skills_allows_instrumentation_when_local_skill_exists() {
-        let root = tempfile::tempdir().expect("tempdir");
-        let home = tempfile::tempdir().expect("home tempdir");
-        let skill_path = root.path().join(".agents/skills/braintrust/SKILL.md");
-        fs::create_dir_all(skill_path.parent().expect("skill dir")).expect("create skill dir");
-        fs::write(&skill_path, "skill").expect("write skill");
-
-        ensure_instrumentation_skill_prereq(Agent::Codex, root.path(), home.path(), true)
-            .expect("existing local skill should satisfy --no-skills instrumentation prereq");
+    fn setup_does_not_create_api_key_when_env_key_is_present() {
+        let mut base = make_base_args();
+        base.api_key = Some("env-key".to_string());
+        base.api_key_source = Some(ArgValueSource::EnvVariable);
+        assert!(!should_create_api_key(true, &base));
     }
 
     #[test]

--- a/src/setup/mod.rs
+++ b/src/setup/mod.rs
@@ -837,6 +837,9 @@ async fn run_default_setup(mut base: BaseArgs, args: SetupArgs) -> Result<()> {
 
     if !args.no_instrument {
         if find_git_root().is_some() {
+            let home = home_dir().ok_or_else(|| anyhow!("failed to resolve HOME/USERPROFILE"))?;
+            let root = find_git_root().expect("git root already checked");
+            ensure_instrumentation_skill_prereq(selected_agent, &root, &home, args.no_skills)?;
             run_instrument_setup(
                 base,
                 InstrumentSetupArgs {
@@ -895,7 +898,8 @@ async fn login_with_existing_or_oauth(
         return auth::login(base).await;
     }
 
-    if let Some(profile_name) = choose_setup_profile(base, profiles)? {
+    let cfg_org = config::load().ok().and_then(|cfg| cfg.org);
+    if let Some(profile_name) = choose_setup_profile(base, profiles, cfg_org.as_deref())? {
         base.profile = Some(profile_name);
     }
     match auth::login(base).await {
@@ -908,7 +912,11 @@ async fn login_with_existing_or_oauth(
     }
 }
 
-fn choose_setup_profile(base: &BaseArgs, profiles: &[auth::ProfileInfo]) -> Result<Option<String>> {
+fn choose_setup_profile(
+    base: &BaseArgs,
+    profiles: &[auth::ProfileInfo],
+    cfg_org: Option<&str>,
+) -> Result<Option<String>> {
     if let Some(profile_name) = base.profile.as_ref().map(|value| value.trim()) {
         if !profile_name.is_empty() {
             return Ok(Some(profile_name.to_string()));
@@ -916,6 +924,10 @@ fn choose_setup_profile(base: &BaseArgs, profiles: &[auth::ProfileInfo]) -> Resu
     }
 
     if let Some(org) = base.org_name.as_deref() {
+        return auth::resolve_org_to_profile(org, profiles).map(Some);
+    }
+
+    if let Some(org) = cfg_org {
         return auth::resolve_org_to_profile(org, profiles).map(Some);
     }
 
@@ -928,6 +940,29 @@ fn choose_setup_profile(base: &BaseArgs, profiles: &[auth::ProfileInfo]) -> Resu
     }
 
     bail!("multiple auth profiles found; pass --profile <NAME> or --org <ORG>, or re-run in an interactive terminal")
+}
+
+fn ensure_instrumentation_skill_prereq(
+    agent: Agent,
+    root: &Path,
+    home: &Path,
+    no_skills: bool,
+) -> Result<()> {
+    if !no_skills {
+        return Ok(());
+    }
+
+    let skill_path = skill_config_path(agent, InstallScope::Local, Some(root), home)?;
+    if skill_path.exists() {
+        return Ok(());
+    }
+
+    bail!(
+        "--no-skills prevents automatic skill installation, but instrumentation requires a local {} skill at {}. Re-run without --no-skills, run `bt setup skills --local --agent {}` first, or add --no-instrument.",
+        agent.as_str(),
+        skill_path.display(),
+        agent.as_str(),
+    )
 }
 
 async fn select_project_for_setup(
@@ -3422,6 +3457,7 @@ fn print_mcp_human_report(
 mod tests {
     use super::*;
     use clap::Parser;
+    use std::fs;
     use std::time::{SystemTime, UNIX_EPOCH};
 
     #[derive(Parser)]
@@ -3460,6 +3496,75 @@ mod tests {
         let err = resolve_default_agent_selection(None, &detected, "Select coding agent", false)
             .expect_err("ambiguous path detection should fail");
         assert!(err.to_string().contains("pass --agent"));
+    }
+
+    #[test]
+    fn choose_setup_profile_uses_configured_org_when_multiple_profiles_exist() {
+        let base = BaseArgs {
+            json: false,
+            verbose: false,
+            quiet: false,
+            no_color: false,
+            no_input: true,
+            profile: None,
+            org_name: None,
+            project: None,
+            api_key: None,
+            api_key_source: None,
+            prefer_profile: false,
+            api_url: None,
+            app_url: None,
+            env_file: None,
+        };
+        let profiles = vec![
+            auth::ProfileInfo {
+                name: "alpha".to_string(),
+                org_name: Some("alpha-org".to_string()),
+                user_name: None,
+                email: None,
+                api_key_hint: None,
+            },
+            auth::ProfileInfo {
+                name: "beta".to_string(),
+                org_name: Some("beta-org".to_string()),
+                user_name: None,
+                email: None,
+                api_key_hint: None,
+            },
+        ];
+
+        let selected = choose_setup_profile(&base, &profiles, Some("alpha-org"))
+            .expect("resolve profile from config org");
+
+        assert_eq!(selected, Some("alpha".to_string()));
+    }
+
+    #[test]
+    fn no_skills_blocks_instrumentation_when_local_skill_is_missing() {
+        let root = tempfile::tempdir().expect("tempdir");
+        let home = tempfile::tempdir().expect("home tempdir");
+
+        let err = ensure_instrumentation_skill_prereq(Agent::Codex, root.path(), home.path(), true)
+            .expect_err("missing local skill should fail when --no-skills is set");
+
+        assert!(err
+            .to_string()
+            .contains("--no-skills prevents automatic skill installation"));
+        assert!(err
+            .to_string()
+            .contains("bt setup skills --local --agent codex"));
+    }
+
+    #[test]
+    fn no_skills_allows_instrumentation_when_local_skill_exists() {
+        let root = tempfile::tempdir().expect("tempdir");
+        let home = tempfile::tempdir().expect("home tempdir");
+        let skill_path = root.path().join(".agents/skills/braintrust/SKILL.md");
+        fs::create_dir_all(skill_path.parent().expect("skill dir")).expect("create skill dir");
+        fs::write(&skill_path, "skill").expect("write skill");
+
+        ensure_instrumentation_skill_prereq(Agent::Codex, root.path(), home.path(), true)
+            .expect("existing local skill should satisfy --no-skills instrumentation prereq");
     }
 
     #[test]

--- a/src/setup/mod.rs
+++ b/src/setup/mod.rs
@@ -1,5 +1,6 @@
 use std::collections::{BTreeMap, BTreeSet};
 use std::fs;
+use std::io::IsTerminal;
 use std::path::{Path, PathBuf};
 use std::process::Stdio;
 
@@ -530,6 +531,15 @@ async fn run_setup_wizard(mut base: BaseArgs, flags: WizardFlags) -> Result<()> 
     let login_ctx = ensure_auth(&mut base).await?;
     let client = ApiClient::new(&login_ctx)?;
     let org = client.org_name().to_string();
+
+    // After OAuth login, create a permanent API key so the user has one for external tooling.
+    let resolved = auth::resolve_auth(&base).await.ok();
+    let is_oauth = resolved.map(|r| r.is_oauth).unwrap_or(false);
+    let has_explicit_key = base.api_key.is_some() || std::env::var("BRAINTRUST_API_KEY").is_ok();
+    if is_oauth && !has_explicit_key {
+        maybe_create_api_key_for_oauth(&client).await?;
+    }
+
     if verbose {
         eprintln!("   {} Using org '{}'", style("✓").green(), org);
     }
@@ -894,7 +904,7 @@ async fn login_with_existing_or_oauth(
 ) -> Result<LoginContext> {
     if profiles.is_empty() {
         eprintln!("No auth profiles found. Let's set one up.\n");
-        auth::login_setup_oauth(base).await?;
+        auth::login_interactive_oauth(base).await?;
         return auth::login(base).await;
     }
 
@@ -905,11 +915,88 @@ async fn login_with_existing_or_oauth(
     match auth::login(base).await {
         Ok(ctx) => Ok(ctx),
         Err(err) if auth::is_missing_credential_error(&err) => {
-            auth::login_setup_oauth(base).await?;
+            auth::login_interactive_oauth(base).await?;
             auth::login(base).await
         }
         Err(err) => Err(err),
     }
+}
+
+/// After an OAuth login in `bt setup`, create a permanent Braintrust API key so the user
+/// has a key they can use outside this session.
+///
+/// The key is stored in `BRAINTRUST_API_KEY` for the rest of the current process and printed
+/// once to stderr (it is never retrievable again).
+async fn maybe_create_api_key_for_oauth(client: &ApiClient) -> Result<()> {
+    let username = std::process::Command::new("whoami")
+        .output()
+        .ok()
+        .and_then(|o| String::from_utf8(o.stdout).ok())
+        .map(|s| s.trim().to_string())
+        .filter(|s| !s.is_empty())
+        .unwrap_or_else(|| "user".to_string());
+    let base_name = format!("{username}-created-by-bt-setup");
+
+    #[derive(serde::Deserialize)]
+    struct ApiKeyEntry {
+        name: String,
+    }
+    #[derive(serde::Deserialize)]
+    struct ApiKeyList {
+        objects: Vec<ApiKeyEntry>,
+    }
+
+    let existing: Vec<String> = client
+        .get::<ApiKeyList>("/v1/api_key")
+        .await
+        .map(|r| r.objects.into_iter().map(|k| k.name).collect())
+        .unwrap_or_default();
+
+    let name = if !existing.iter().any(|n| n == &base_name) {
+        base_name
+    } else {
+        (1u32..)
+            .map(|i| format!("{base_name}{i}"))
+            .find(|candidate| !existing.iter().any(|n| n == candidate))
+            .expect("name sequence is infinite")
+    };
+
+    #[derive(serde::Deserialize)]
+    struct CreatedKey {
+        key: String,
+    }
+
+    let body = serde_json::json!({ "name": name, "org_name": client.org_name() });
+    let created: CreatedKey = client.post("/v1/api_key", &body).await?;
+
+    // Expose the key in the current process so later steps can use it.
+    std::env::set_var("BRAINTRUST_API_KEY", &created.key);
+
+    // Print once to stderr — the raw key is never retrievable again.
+    eprintln!();
+    eprintln!(
+        "{} New API key '{}' created — displayed only once:",
+        style("!").yellow().bold(),
+        name,
+    );
+    eprintln!();
+    eprintln!("   {}", style(&created.key).bold());
+    eprintln!();
+    eprintln!("   To export it in your shell, run:");
+    eprintln!(
+        "   {}",
+        style(format!("export BRAINTRUST_API_KEY={}", created.key)).dim()
+    );
+    eprintln!(
+        "   It is safe to cancel the setup now, export the key and restart the setup (with bt setup)."
+    );
+    eprintln!();
+    if std::io::stdin().is_terminal() {
+        eprint!("   Press Enter to continue...");
+        let _ = std::io::BufRead::read_line(&mut std::io::stdin().lock(), &mut String::new());
+    }
+
+    Ok(())
 }
 
 fn choose_setup_profile(

--- a/src/setup/mod.rs
+++ b/src/setup/mod.rs
@@ -902,7 +902,7 @@ async fn login_with_existing_or_oauth(
     base.profile = Some(profile_name);
     match auth::login(base).await {
         Ok(ctx) => Ok(ctx),
-        Err(err) if should_force_reauth(&err) => {
+        Err(err) if auth::is_missing_credential_error(&err) => {
             auth::login_setup_oauth(base).await?;
             auth::login(base).await
         }
@@ -925,13 +925,6 @@ fn choose_setup_profile(base: &BaseArgs, profiles: &[auth::ProfileInfo]) -> Resu
         .first()
         .map(|profile| profile.name.clone())
         .ok_or_else(|| anyhow!("no auth profiles found"))
-}
-
-fn should_force_reauth(err: &anyhow::Error) -> bool {
-    let msg = err.to_string();
-    msg.contains("oauth refresh token missing")
-        || msg.contains("oauth profile requested but none selected")
-        || msg.contains("re-run `bt auth login --oauth")
 }
 
 async fn select_project_for_setup(

--- a/src/setup/mod.rs
+++ b/src/setup/mod.rs
@@ -1,6 +1,5 @@
 use std::collections::{BTreeMap, BTreeSet};
 use std::fs;
-use std::io::IsTerminal;
 use std::path::{Path, PathBuf};
 use std::process::Stdio;
 
@@ -59,7 +58,7 @@ pub struct SetupArgs {
     skills: bool,
 
     /// Do not set up coding-agent skills
-    #[arg(long, conflicts_with = "skills")]
+    #[arg(long, visible_alias = "no-skill", conflicts_with = "skills")]
     no_skills: bool,
 
     /// Set up MCP server
@@ -528,7 +527,7 @@ async fn run_setup_wizard(mut base: BaseArgs, flags: WizardFlags) -> Result<()> 
         print_wizard_step(1, "Auth");
     }
     let project_flag = base.project.clone();
-    let (_login_ctx, client) = ensure_setup_auth(&mut base).await?;
+    let client = ensure_setup_auth(&mut base, !flag_no_instrument).await?;
     let org = client.org_name().to_string();
 
     if verbose {
@@ -783,10 +782,10 @@ async fn run_setup_wizard(mut base: BaseArgs, flags: WizardFlags) -> Result<()> 
 }
 
 async fn run_default_setup(mut base: BaseArgs, args: SetupArgs) -> Result<()> {
-    let needs_auth = !args.no_instrument || (args.mcp && !args.no_mcp);
+    let needs_auth = !args.no_instrument;
     if needs_auth {
         let project_flag = base.project.clone();
-        let (_login_ctx, client) = ensure_setup_auth(&mut base).await?;
+        let client = ensure_setup_auth(&mut base, false).await?;
         let org = client.org_name().to_string();
         let project = select_project_with_skip(&client, project_flag.as_deref(), true).await?;
         if let Some(ref project) = project {
@@ -866,51 +865,87 @@ async fn run_default_setup(mut base: BaseArgs, args: SetupArgs) -> Result<()> {
     Ok(())
 }
 
-async fn ensure_auth(base: &mut BaseArgs) -> Result<(LoginContext, bool)> {
+fn in_ci() -> bool {
+    std::env::var_os("CI").is_some()
+}
+
+fn resolve_profile_name_for_setup(
+    base: &BaseArgs,
+    profiles: &[auth::ProfileInfo],
+    prompt_for_choice: bool,
+) -> Result<String> {
+    if let Some(profile_name) = base
+        .profile
+        .as_deref()
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+    {
+        return Ok(profile_name.to_string());
+    }
+
+    if let Some(org_name) = base.org_name.as_deref() {
+        if let Some(profile_name) = profiles
+            .iter()
+            .find(|profile| profile.name == org_name)
+            .map(|profile| profile.name.clone())
+        {
+            return Ok(profile_name);
+        }
+
+        let mut matches = profiles
+            .iter()
+            .filter(|profile| profile.org_name.as_deref() == Some(org_name))
+            .map(|profile| profile.name.clone())
+            .collect::<Vec<_>>();
+        matches.sort();
+
+        return match matches.len() {
+            0 => auth::resolve_org_to_profile(org_name, profiles),
+            1 => Ok(matches.remove(0)),
+            _ if prompt_for_choice => auth::select_profile_interactive(Some(org_name))?
+                .ok_or_else(|| anyhow!("no profile selected")),
+            _ => Ok(matches.remove(0)),
+        };
+    }
+
+    if profiles.len() == 1 {
+        return Ok(profiles[0].name.clone());
+    }
+
+    if prompt_for_choice {
+        auth::select_profile_interactive(None)?.ok_or_else(|| anyhow!("no profile selected"))
+    } else {
+        let mut names = profiles
+            .iter()
+            .map(|profile| profile.name.clone())
+            .collect::<Vec<_>>();
+        names.sort();
+        Ok(names.remove(0))
+    }
+}
+
+async fn ensure_auth(base: &mut BaseArgs, prompt_for_profile_choice: bool) -> Result<LoginContext> {
     if matches!(base.api_key_source, Some(ArgValueSource::CommandLine)) {
-        return Ok((auth::login(base).await?, false));
+        return auth::login(base).await;
     }
 
     if matches!(base.api_key_source, Some(ArgValueSource::EnvVariable)) && !base.prefer_profile {
-        return Ok((auth::login(base).await?, false));
+        return auth::login(base).await;
     }
 
     let profiles = auth::list_profiles()?;
     if !profiles.is_empty() {
-        let profile_name = if let Some(profile_name) =
-            base.profile.as_ref().map(|value| value.trim())
-        {
-            if !profile_name.is_empty() {
-                profile_name.to_string()
-            } else if let Some(org) = base.org_name.as_deref() {
-                auth::resolve_org_to_profile(org, &profiles)?
-            } else if profiles.len() == 1 {
-                profiles[0].name.clone()
-            } else if !ui::is_interactive() {
-                bail!("multiple auth profiles found; pass --profile <NAME> or --org <ORG>, or re-run in an interactive terminal")
-            } else {
-                auth::select_profile_interactive(None)?
-                    .ok_or_else(|| anyhow!("no profile selected"))?
-            }
-        } else if let Some(org) = base.org_name.as_deref() {
-            auth::resolve_org_to_profile(org, &profiles)?
-        } else if profiles.len() == 1 {
-            profiles[0].name.clone()
-        } else if !ui::is_interactive() {
-            bail!("multiple auth profiles found; pass --profile <NAME> or --org <ORG>, or re-run in an interactive terminal")
-        } else {
-            auth::select_profile_interactive(None)?.ok_or_else(|| anyhow!("no profile selected"))?
-        };
+        let should_prompt_for_profile_choice = prompt_for_profile_choice
+            && !base.json
+            && !base.no_input
+            && !in_ci()
+            && ui::is_interactive();
+        let profile_name =
+            resolve_profile_name_for_setup(base, &profiles, should_prompt_for_profile_choice)?;
         base.profile = Some(profile_name.clone());
 
         match auth::login(base).await {
-            Ok(ctx) => {
-                let is_oauth = profiles
-                    .iter()
-                    .find(|p| p.name == profile_name)
-                    .is_some_and(|p| p.is_oauth);
-                return Ok((ctx, is_oauth));
-            }
+            Ok(ctx) => return Ok(ctx),
             Err(err) if auth::is_missing_credential_error(&err) => {
                 if base.verbose {
                     eprintln!(
@@ -918,9 +953,8 @@ async fn ensure_auth(base: &mut BaseArgs) -> Result<(LoginContext, bool)> {
                         profile_name, err
                     );
                 }
-                base.profile = None;
                 auth::login_interactive_oauth(base).await?;
-                return Ok((auth::login(base).await?, true));
+                return auth::login(base).await;
             }
             Err(err) => return Err(err),
         }
@@ -930,98 +964,15 @@ async fn ensure_auth(base: &mut BaseArgs) -> Result<(LoginContext, bool)> {
         eprintln!("No auth profiles found. Starting OAuth login.\n");
     }
     auth::login_interactive_oauth(base).await?;
-    Ok((auth::login(base).await?, true))
+    auth::login(base).await
 }
 
-async fn ensure_setup_auth(base: &mut BaseArgs) -> Result<(LoginContext, ApiClient)> {
-    let (login_ctx, is_oauth) = ensure_auth(base).await?;
-    let client = ApiClient::new(&login_ctx)?;
-    if is_oauth
-        && !matches!(
-            base.api_key_source,
-            Some(ArgValueSource::CommandLine | ArgValueSource::EnvVariable)
-        )
-    {
-        maybe_create_api_key_for_oauth(&client).await?;
-    }
-    Ok((login_ctx, client))
-}
-
-/// After an OAuth login in `bt setup`, create a permanent Braintrust API key so the user
-/// has a key they can use outside this session.
-///
-/// The key is stored in `BRAINTRUST_API_KEY` for the rest of the current process and printed
-/// once to stderr (it is never retrievable again).
-async fn maybe_create_api_key_for_oauth(client: &ApiClient) -> Result<()> {
-    let username = std::process::Command::new("whoami")
-        .output()
-        .ok()
-        .and_then(|o| String::from_utf8(o.stdout).ok())
-        .map(|s| s.trim().to_string())
-        .filter(|s| !s.is_empty())
-        .unwrap_or_else(|| "user".to_string());
-    let base_name = format!("{username}-created-by-bt-setup");
-
-    #[derive(serde::Deserialize)]
-    struct ApiKeyEntry {
-        name: String,
-    }
-    #[derive(serde::Deserialize)]
-    struct ApiKeyList {
-        objects: Vec<ApiKeyEntry>,
-    }
-
-    let existing: Vec<String> = client
-        .get::<ApiKeyList>("/v1/api_key")
-        .await
-        .map(|r| r.objects.into_iter().map(|k| k.name).collect())
-        .unwrap_or_default();
-
-    let name = if !existing.iter().any(|n| n == &base_name) {
-        base_name
-    } else {
-        (1u32..)
-            .map(|i| format!("{base_name}{i}"))
-            .find(|candidate| !existing.iter().any(|n| n == candidate))
-            .expect("name sequence is infinite")
-    };
-
-    #[derive(serde::Deserialize)]
-    struct CreatedKey {
-        key: String,
-    }
-
-    let body = serde_json::json!({ "name": name, "org_name": client.org_name() });
-    let created: CreatedKey = client.post("/v1/api_key", &body).await?;
-
-    // Expose the key in the current process so later steps can use it.
-    std::env::set_var("BRAINTRUST_API_KEY", &created.key);
-
-    // Print once to stderr — the raw key is never retrievable again.
-    eprintln!();
-    eprintln!(
-        "{} New API key '{}' created — displayed only once:",
-        style("!").yellow().bold(),
-        name,
-    );
-    eprintln!();
-    eprintln!("   {}", style(&created.key).bold());
-    eprintln!();
-    eprintln!("   To export it in your shell, run:");
-    eprintln!(
-        "   {}",
-        style(format!("export BRAINTRUST_API_KEY={}", created.key)).dim()
-    );
-    eprintln!(
-        "   It is safe to cancel the setup now, export the key and restart the setup (with bt setup)."
-    );
-    eprintln!();
-    if std::io::stdin().is_terminal() {
-        eprint!("   Press Enter to continue...");
-        let _ = std::io::BufRead::read_line(&mut std::io::stdin().lock(), &mut String::new());
-    }
-
-    Ok(())
+async fn ensure_setup_auth(
+    base: &mut BaseArgs,
+    prompt_for_profile_choice: bool,
+) -> Result<ApiClient> {
+    let login_ctx = ensure_auth(base, prompt_for_profile_choice).await?;
+    ApiClient::new(&login_ctx)
 }
 
 async fn select_project_for_setup(
@@ -1050,18 +1001,10 @@ async fn select_project_for_setup(
     )
     .await?;
 
-    if projects.is_empty() {
-        bail!("no projects found in org '{}'", client.org_name());
-    }
-
-    if projects.len() == 1 && projects[0].name == "My Project" {
-        return create_or_fetch_project(client, &default_setup_project_name()).await;
-    }
-
     projects.sort_by(|a, b| a.name.cmp(&b.name));
     if !ui::is_interactive() {
         bail!(
-            "multiple project choices available; pass --project <NAME> or run `bt setup` in an interactive terminal"
+            "project choice required in non-interactive mode; pass --project <NAME> or set BRAINTRUST_DEFAULT_PROJECT"
         );
     }
 
@@ -1362,7 +1305,16 @@ async fn run_instrument_setup(
     let mut hint_pending = print_hint && base.verbose;
     let selected_workflows = resolve_instrument_workflow_selection(&args, &mut hint_pending)?;
 
-    let selected_languages: Vec<LanguageArg> = args.languages.clone();
+    let detected_languages = if args.languages.is_empty() {
+        detect_languages_from_dir(&root)
+    } else {
+        Vec::new()
+    };
+    let selected_languages: Vec<LanguageArg> = if args.languages.is_empty() {
+        detected_languages.clone()
+    } else {
+        args.languages.clone()
+    };
 
     let show_progress = !base.json;
     let mut warnings = Vec::new();
@@ -1416,17 +1368,23 @@ async fn run_instrument_setup(
     // --yolo:       background, full bypassPermissions (no restrictions)
     // --tui:        interactive TUI
     // --background: background, restricted to language package managers
-    // --yes or non-interactive terminal: background, restricted to language package managers
-    // Otherwise: default to interactive TUI.
-    let (run_interactive, bypass_permissions) = if args.tui {
+    // Otherwise: default to interactive TUI when supported.
+    let requested_interactive = if args.tui {
         (true, false)
     } else if args.yolo {
         (false, true)
-    } else if args.background || args.yes || !ui::is_interactive() {
+    } else if args.background || !ui::is_interactive() {
         (false, false)
     } else {
         (true, false)
     };
+    let (mut run_interactive, bypass_permissions) = requested_interactive;
+    if run_interactive && matches!(selected, Agent::Opencode) {
+        run_interactive = false;
+        warnings.push(
+            "Opencode does not reliably support starting with a preloaded prompt in TUI mode; launching it in background mode instead.".to_string(),
+        );
+    }
 
     let docs_output_dir = root.join(".bt").join("skills").join("docs");
     sdk_install_docs::write_sdk_install_docs(&docs_output_dir)?;
@@ -1442,6 +1400,7 @@ async fn run_instrument_setup(
             &selected_workflows,
             &selected_languages,
             run_interactive,
+            detected_languages.is_empty(),
         ),
     )?;
 
@@ -2092,6 +2051,7 @@ fn render_instrument_task(
     workflows: &[WorkflowArg],
     languages: &[LanguageArg],
     interactive: bool,
+    needs_language_detection: bool,
 ) -> String {
     use std::collections::BTreeSet;
     let sdk_install_dir = docs_output_dir.join("sdk-install");
@@ -2099,7 +2059,15 @@ fn render_instrument_task(
     // Deduplicate languages (TypeScript and JavaScript both map to the same variant).
     let unique_langs: BTreeSet<LanguageArg> = languages.iter().copied().collect();
     let language_context = if unique_langs.is_empty() {
-        String::new()
+        if needs_language_detection {
+            "### Language Discovery\n\n\
+             No language override was provided and no supported language markers were detected \
+             in the repo root or its immediate subdirectories. Determine which language(s) to \
+             instrument before you make code changes.\n"
+                .to_string()
+        } else {
+            String::new()
+        }
     } else {
         let names: Vec<String> = unique_langs
             .iter()
@@ -2656,14 +2624,14 @@ fn resolve_default_agent_selection(
     }
 
     let path_agents = detected_agents_on_path(detected);
+    if path_agents.len() == 1 {
+        return Ok(path_agents[0]);
+    }
+
     if allow_prompt {
         let default = pick_agent_mode_target(&path_agents).unwrap_or(Agent::Codex);
         return prompt_agent_selection(prompt, default)?
             .ok_or_else(|| anyhow!("setup cancelled by user"));
-    }
-
-    if path_agents.len() == 1 {
-        return Ok(path_agents[0]);
     }
 
     if path_agents.is_empty() {
@@ -3568,26 +3536,42 @@ mod tests {
         assert!(err.to_string().contains("pass --agent"));
     }
 
-    fn should_create_api_key(is_oauth: bool, base: &BaseArgs) -> bool {
-        is_oauth
-            && !matches!(
-                base.api_key_source,
-                Some(ArgValueSource::CommandLine | ArgValueSource::EnvVariable)
-            )
+    #[test]
+    fn default_agent_selection_uses_single_path_agent_without_prompt() {
+        let detected = vec![DetectionSignal {
+            agent: Agent::Cursor,
+            on_path: true,
+            reason: "`cursor-agent` binary found in PATH".to_string(),
+        }];
+        let resolved =
+            resolve_default_agent_selection(None, &detected, "Select coding agent", true)
+                .expect("resolve default agent");
+        assert_eq!(resolved, Agent::Cursor);
     }
 
     #[test]
-    fn setup_creates_api_key_for_oauth_without_explicit_key() {
+    fn resolve_profile_name_for_setup_uses_first_alphabetical_profile_without_prompt() {
         let base = make_base_args();
-        assert!(should_create_api_key(true, &base));
-    }
+        let profiles = vec![
+            auth::ProfileInfo {
+                name: "zeta".to_string(),
+                org_name: Some("Zeta Org".to_string()),
+                user_name: None,
+                email: None,
+                api_key_hint: None,
+            },
+            auth::ProfileInfo {
+                name: "alpha".to_string(),
+                org_name: Some("Alpha Org".to_string()),
+                user_name: None,
+                email: None,
+                api_key_hint: None,
+            },
+        ];
 
-    #[test]
-    fn setup_does_not_create_api_key_when_env_key_is_present() {
-        let mut base = make_base_args();
-        base.api_key = Some("env-key".to_string());
-        base.api_key_source = Some(ArgValueSource::EnvVariable);
-        assert!(!should_create_api_key(true, &base));
+        let resolved =
+            resolve_profile_name_for_setup(&base, &profiles, false).expect("resolve profile");
+        assert_eq!(resolved, "alpha");
     }
 
     #[test]
@@ -3790,10 +3774,19 @@ mod tests {
             &[WorkflowArg::Instrument, WorkflowArg::Observe],
             &[],
             false,
+            false,
         );
         assert!(task.contains("Use the installed Braintrust agent skills"));
         assert!(task.contains("prefer local `bt` CLI commands"));
         assert!(task.contains("Do not rely on the Braintrust MCP server"));
+    }
+
+    #[test]
+    fn render_instrument_task_includes_language_discovery_guidance_when_needed() {
+        let root = PathBuf::from("/tmp/repo");
+        let task = render_instrument_task(&root, &[WorkflowArg::Instrument], &[], false, true);
+        assert!(task.contains("Language Discovery"));
+        assert!(task.contains("Determine which language"));
     }
 
     #[test]

--- a/src/setup/mod.rs
+++ b/src/setup/mod.rs
@@ -111,6 +111,10 @@ pub struct SetupArgs {
     #[arg(long, short = 'v')]
     verbose: bool,
 
+    /// Deprecated: quiet is now the default; this flag is accepted as a no-op
+    #[arg(long, hide = true)]
+    quiet: bool,
+
     /// Deprecated: use --no-skills --no-mcp instead
     #[arg(long, hide = true, conflicts_with = "skills", conflicts_with = "mcp")]
     no_mcp_skill: bool,
@@ -204,6 +208,9 @@ struct InstrumentSetupArgs {
     /// Workflow docs to prefetch alongside instrument (repeatable; always includes instrument) [default: all]
     #[arg(long = "workflow", value_enum)]
     workflows: Vec<WorkflowArg>,
+
+    #[arg(skip)]
+    skip_workflow_docs: bool,
 
     #[arg(skip)]
     yes: bool,
@@ -517,7 +524,7 @@ async fn run_setup_wizard(mut base: BaseArgs, flags: WizardFlags) -> Result<()> 
         background: flag_background,
         agent: flag_agent,
         workflows: flag_workflows,
-        no_workflow: _,
+        no_workflow: flag_no_workflow,
         languages: flag_languages,
     } = flags;
     let mut had_failures = false;
@@ -671,7 +678,7 @@ async fn run_setup_wizard(mut base: BaseArgs, flags: WizardFlags) -> Result<()> 
                 local: matches!(scope, InstallScope::Local),
                 global: matches!(scope, InstallScope::Global),
                 workflows: Vec::new(),
-                no_workflow: false,
+                no_workflow: flag_no_workflow,
                 yes: true,
                 no_fetch_docs: true,
                 refresh_docs: false,
@@ -755,6 +762,7 @@ async fn run_setup_wizard(mut base: BaseArgs, flags: WizardFlags) -> Result<()> 
                     agent: instrument_agent,
                     agent_cmd: None,
                     workflows: flag_workflows,
+                    skip_workflow_docs: flag_no_workflow,
                     yes: false,
                     refresh_docs: false,
                     workers: crate::sync::default_workers(),
@@ -844,6 +852,7 @@ async fn run_default_setup(mut base: BaseArgs, args: SetupArgs) -> Result<()> {
                     agent: Some(map_agent_to_instrument_agent_arg(selected_agent)),
                     agent_cmd: None,
                     workflows: args.agents.workflows,
+                    skip_workflow_docs: args.agents.no_workflow,
                     yes: true,
                     refresh_docs: args.agents.refresh_docs,
                     workers: args.agents.workers,
@@ -1291,9 +1300,9 @@ async fn run_instrument_setup(
             local: true,
             global: false,
             workflows: selected_workflows.clone(),
-            no_workflow: false,
+            no_workflow: args.skip_workflow_docs,
             yes: true,
-            no_fetch_docs: false,
+            no_fetch_docs: args.skip_workflow_docs,
             refresh_docs: args.refresh_docs,
             workers: args.workers,
             yolo: false,
@@ -1424,6 +1433,10 @@ fn resolve_instrument_workflow_selection(
     args: &InstrumentSetupArgs,
     _hint_pending: &mut bool,
 ) -> Result<Vec<WorkflowArg>> {
+    if args.skip_workflow_docs {
+        return Ok(Vec::new());
+    }
+
     if !args.workflows.is_empty() {
         let mut selected = resolve_workflow_selection(&args.workflows);
         if !selected.contains(&WorkflowArg::Instrument) {
@@ -3326,7 +3339,14 @@ fn print_mcp_human_report(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use clap::Parser;
     use std::time::{SystemTime, UNIX_EPOCH};
+
+    #[derive(Parser)]
+    struct SetupArgsHarness {
+        #[command(flatten)]
+        setup: SetupArgs,
+    }
 
     #[test]
     fn single_path_agent_is_selected_by_default() {
@@ -3472,6 +3492,25 @@ mod tests {
     }
 
     #[test]
+    fn resolve_setup_selection_honors_no_workflow() {
+        let args = AgentsSetupArgs {
+            agent: Some(AgentArg::Codex),
+            local: false,
+            global: true,
+            workflows: vec![WorkflowArg::Evaluate],
+            no_workflow: true,
+            yes: true,
+            no_fetch_docs: false,
+            refresh_docs: false,
+            workers: crate::sync::default_workers(),
+            yolo: false,
+        };
+        let home = std::env::temp_dir();
+        let selection = resolve_setup_selection(&args, &home).expect("resolve setup selection");
+        assert!(selection.selected_workflows.is_empty());
+    }
+
+    #[test]
     fn resolve_workflow_selection_resolves_explicit_values() {
         let selected =
             resolve_workflow_selection(&[WorkflowArg::Evaluate, WorkflowArg::Instrument]);
@@ -3487,6 +3526,7 @@ mod tests {
             agent: Some(InstrumentAgentArg::Codex),
             agent_cmd: None,
             workflows: vec![WorkflowArg::Evaluate],
+            skip_workflow_docs: false,
             yes: true,
             refresh_docs: false,
             workers: crate::sync::default_workers(),
@@ -3511,6 +3551,7 @@ mod tests {
             agent: Some(InstrumentAgentArg::Codex),
             agent_cmd: None,
             workflows: Vec::new(),
+            skip_workflow_docs: false,
             yes: true,
             refresh_docs: false,
             workers: crate::sync::default_workers(),
@@ -3524,6 +3565,35 @@ mod tests {
         let selected = resolve_instrument_workflow_selection(&args, &mut false)
             .expect("resolve instrument workflows");
         assert_eq!(selected, resolve_workflow_selection(&[]));
+    }
+
+    #[test]
+    fn resolve_instrument_workflows_honors_skip_workflow_docs() {
+        let args = InstrumentSetupArgs {
+            agent: Some(InstrumentAgentArg::Codex),
+            agent_cmd: None,
+            workflows: vec![WorkflowArg::Evaluate],
+            skip_workflow_docs: true,
+            yes: true,
+            refresh_docs: false,
+            workers: crate::sync::default_workers(),
+            languages: Vec::new(),
+            tui: false,
+            background: false,
+            yolo: false,
+            skip_launch: false,
+        };
+
+        let selected = resolve_instrument_workflow_selection(&args, &mut false)
+            .expect("resolve instrument workflows");
+        assert!(selected.is_empty());
+    }
+
+    #[test]
+    fn setup_accepts_deprecated_quiet_flag() {
+        let parsed = SetupArgsHarness::try_parse_from(["bt", "--quiet"]).expect("parse");
+        assert!(parsed.setup.quiet);
+        assert!(!parsed.setup.verbose);
     }
 
     #[test]

--- a/src/setup/mod.rs
+++ b/src/setup/mod.rs
@@ -234,11 +234,6 @@ struct InstrumentSetupArgs {
     /// Grant the agent full permissions (bypass permission prompts)
     #[arg(long)]
     yolo: bool,
-
-    /// Set up skills and write the task file but do not launch the agent.
-    #[arg(skip)]
-    #[allow(dead_code)]
-    skip_launch: bool,
 }
 
 #[derive(Debug, Clone, Args)]
@@ -453,7 +448,6 @@ pub async fn run_setup_top(mut base: BaseArgs, mut args: SetupArgs) -> Result<()
         Some(SetupSubcommand::Doctor(doctor)) => run_doctor(base, doctor),
         None => {
             let wizard_flags = WizardFlags {
-                interactive: args.interactive,
                 yolo: args.agents.yolo,
                 skills: args.skills,
                 no_skills: args.no_skills,
@@ -481,9 +475,7 @@ pub async fn run_setup_top(mut base: BaseArgs, mut args: SetupArgs) -> Result<()
 
 pub use docs::run_docs_top;
 
-#[allow(dead_code)]
 struct WizardFlags {
-    interactive: bool,
     yolo: bool,
     skills: bool,
     no_skills: bool,
@@ -503,7 +495,6 @@ struct WizardFlags {
 
 async fn run_setup_wizard(mut base: BaseArgs, flags: WizardFlags) -> Result<()> {
     let WizardFlags {
-        interactive: _,
         yolo,
         skills: flag_skills,
         no_skills: flag_no_skills,
@@ -605,11 +596,12 @@ async fn run_setup_wizard(mut base: BaseArgs, flags: WizardFlags) -> Result<()> 
         }
         let choices = ["Skills", "MCP"];
         let defaults = [true, false];
+        let term = ui::prompt_term().ok_or_else(|| anyhow!("interactive mode requires TTY"))?;
         let selected = MultiSelect::with_theme(&ColorfulTheme::default())
             .with_prompt("What would you like to set up?")
             .items(&choices)
             .defaults(&defaults)
-            .interact()?;
+            .interact_on(&term)?;
         (selected.contains(&0), selected.contains(&1))
     };
 
@@ -729,10 +721,11 @@ async fn run_setup_wizard(mut base: BaseArgs, flags: WizardFlags) -> Result<()> 
             }
             true
         } else {
+            let term = ui::prompt_term().ok_or_else(|| anyhow!("interactive mode requires TTY"))?;
             Confirm::with_theme(&ColorfulTheme::default())
                 .with_prompt("Run instrumentation agent to set up tracing in this repo?")
                 .default(true)
-                .interact()?
+                .interact_on(&term)?
         };
         if instrument {
             let instrument_agent = setup_context
@@ -760,7 +753,6 @@ async fn run_setup_wizard(mut base: BaseArgs, flags: WizardFlags) -> Result<()> 
                     tui: flag_tui,
                     background: flag_background,
                     yolo,
-                    skip_launch: false,
                 },
                 !multiselect_hint_shown,
             )
@@ -804,7 +796,7 @@ async fn run_default_setup(mut base: BaseArgs, args: SetupArgs) -> Result<()> {
         args.agents.agent,
         &detected,
         "Select coding agent",
-        ui::is_interactive(),
+        ui::can_prompt(),
     )?;
 
     if args.skills || !args.no_skills {
@@ -853,7 +845,6 @@ async fn run_default_setup(mut base: BaseArgs, args: SetupArgs) -> Result<()> {
                     tui: args.tui,
                     background: args.background,
                     yolo: args.agents.yolo,
-                    skip_launch: false,
                 },
                 false,
             )
@@ -943,7 +934,7 @@ async fn ensure_auth(
             && !base.json
             && !base.no_input
             && !in_ci()
-            && ui::is_interactive();
+            && ui::can_prompt();
         let profile_name =
             resolve_profile_name_for_setup(base, &profiles, should_prompt_for_profile_choice)?;
         base.profile = Some(profile_name.clone());
@@ -1093,7 +1084,7 @@ async fn select_project_for_setup(
     .await?;
 
     projects.sort_by(|a, b| a.name.cmp(&b.name));
-    if !ui::is_interactive() {
+    if !ui::can_prompt() {
         bail!(
             "project choice required in non-interactive mode; pass --project <NAME> or set BRAINTRUST_DEFAULT_PROJECT"
         );
@@ -1108,7 +1099,9 @@ async fn select_project_for_setup(
         let name: String = dialoguer::Input::with_theme(&ColorfulTheme::default())
             .with_prompt("Project name")
             .default(default_name)
-            .interact_text()?;
+            .interact_text_on(
+                &ui::prompt_term().ok_or_else(|| anyhow!("interactive mode requires TTY"))?,
+            )?;
         let trimmed = name.trim();
         if trimmed.is_empty() {
             bail!("project name cannot be empty");
@@ -1185,7 +1178,9 @@ fn maybe_init(org: &str, project: &crate::projects::api::Project) -> Result<bool
         let update = Confirm::new()
             .with_prompt(format!("Update .bt/config.json to {org}/{}?", project.name))
             .default(true)
-            .interact()?;
+            .interact_on(
+                &ui::prompt_term().ok_or_else(|| anyhow!("interactive mode requires TTY"))?,
+            )?;
         if !update {
             return Ok(false);
         }
@@ -1382,7 +1377,7 @@ async fn run_instrument_setup(
         args.agent.map(map_instrument_agent_arg_to_agent_arg),
         &detected,
         "Select agent to instrument this repo",
-        ui::is_interactive() && !args.yes,
+        ui::can_prompt() && !args.yes,
     )?;
 
     if args.agent.is_some() && base.verbose {
@@ -1456,19 +1451,9 @@ async fn run_instrument_setup(
     }
 
     // Determine run mode: interactive TUI vs background (autonomous).
-    // --yolo:       background, full bypassPermissions (no restrictions)
-    // --tui:        interactive TUI
-    // --background: background, restricted to language package managers
-    // Otherwise: default to interactive TUI when supported.
-    let requested_interactive = if args.tui {
-        (true, false)
-    } else if args.yolo {
-        (false, true)
-    } else if args.background || !ui::is_interactive() {
-        (false, false)
-    } else {
-        (true, false)
-    };
+    // Use prompt availability rather than stdin TTY state so `/dev/tty`
+    // fallbacks still allow TUI launch when bt is invoked via a shell script.
+    let requested_interactive = resolve_instrument_run_mode(&args, ui::can_prompt());
     let (mut run_interactive, bypass_permissions) = requested_interactive;
     if run_interactive && matches!(selected, Agent::Opencode) {
         run_interactive = false;
@@ -1595,31 +1580,6 @@ fn resolve_instrument_workflow_selection(
     Ok(resolve_workflow_selection(&[]))
 }
 
-#[allow(dead_code)]
-fn prompt_instrument_workflow_selection() -> Result<Option<Vec<WorkflowArg>>> {
-    let choices = ["observe", "annotate", "evaluate", "deploy"];
-    let defaults = [true, false, true, false];
-    let selected = MultiSelect::with_theme(&ColorfulTheme::default())
-        .with_prompt("Select additional workflow docs to prefetch (instrument is always included)")
-        .items(&choices)
-        .defaults(&defaults)
-        .interact_opt()?;
-    Ok(selected.map(|indexes| {
-        let mut workflows = vec![WorkflowArg::Instrument];
-        for index in indexes {
-            match index {
-                0 => workflows.push(WorkflowArg::Observe),
-                1 => workflows.push(WorkflowArg::Annotate),
-                2 => workflows.push(WorkflowArg::Evaluate),
-                3 => workflows.push(WorkflowArg::Deploy),
-                _ => {}
-            }
-        }
-        workflows
-    }))
-}
-
-#[allow(dead_code)]
 fn detect_languages_from_dir(dir: &std::path::Path) -> Vec<LanguageArg> {
     // (indicator filename suffix, language)
     let indicators: &[(&str, LanguageArg)] = &[
@@ -1683,61 +1643,6 @@ fn detect_languages_from_dir(dir: &std::path::Path) -> Vec<LanguageArg> {
     }
 
     found.into_iter().collect()
-}
-
-#[allow(dead_code)]
-fn prompt_instrument_language_selection(
-    detected: &[LanguageArg],
-) -> Result<Option<Vec<LanguageArg>>> {
-    // Index 0 = "All / auto-detect".  Indices 1-6 map to specific languages.
-    let choices = [
-        "All languages (auto-detect)",
-        "Python",
-        "TypeScript / JavaScript",
-        "Go",
-        "Java",
-        "Ruby",
-        "C#",
-    ];
-    // Map detected languages to their choice indices (1-based)
-    let lang_to_idx = |lang: LanguageArg| match lang {
-        LanguageArg::Python => 1usize,
-        LanguageArg::TypeScript => 2,
-        LanguageArg::Go => 3,
-        LanguageArg::Java => 4,
-        LanguageArg::Ruby => 5,
-        LanguageArg::CSharp => 6,
-    };
-    let defaults = if detected.len() != 1 {
-        // Zero or multiple detected → pre-select "All languages (auto-detect)"
-        [true, false, false, false, false, false, false]
-    } else {
-        let mut d = [false; 7];
-        d[lang_to_idx(detected[0])] = true;
-        d
-    };
-    let selected = MultiSelect::with_theme(&ColorfulTheme::default())
-        .with_prompt("Which language(s) to instrument?")
-        .items(&choices)
-        .defaults(&defaults)
-        .interact_opt()?;
-    Ok(selected.map(|indices| {
-        if indices.is_empty() || indices.contains(&0) {
-            return Vec::new(); // auto-detect
-        }
-        indices
-            .iter()
-            .filter_map(|&i| match i {
-                1 => Some(LanguageArg::Python),
-                2 => Some(LanguageArg::TypeScript),
-                3 => Some(LanguageArg::Go),
-                4 => Some(LanguageArg::Java),
-                5 => Some(LanguageArg::Ruby),
-                6 => Some(LanguageArg::CSharp),
-                _ => None,
-            })
-            .collect()
-    }))
 }
 
 fn map_agent_to_agent_arg(agent: Agent) -> AgentArg {
@@ -1832,27 +1737,6 @@ async fn prefetch_workflow_docs(
     }
 
     Ok(())
-}
-
-#[allow(dead_code)]
-fn prompt_instrument_agent(default_agent: Agent) -> Result<Agent> {
-    let choices = ALL_AGENTS
-        .iter()
-        .map(|agent| agent.as_str())
-        .collect::<Vec<_>>();
-    let default_index = ALL_AGENTS
-        .iter()
-        .position(|agent| *agent == default_agent)
-        .unwrap_or(0);
-    let selection = FuzzySelect::with_theme(&ColorfulTheme::default())
-        .with_prompt("Select agent to instrument this repo")
-        .items(&choices)
-        .default(default_index)
-        .interact_opt()?;
-    let Some(index) = selection else {
-        bail!("instrument setup cancelled by user");
-    };
-    Ok(ALL_AGENTS[index])
 }
 
 /// Returns the package-manager command names allowed in background (non-yolo) mode.
@@ -2107,6 +1991,12 @@ async fn run_agent_invocation(
 
             if *interactive {
                 // Inherit all streams so the user can interact with the agent directly.
+                #[cfg(unix)]
+                if !ui::is_interactive() {
+                    if let Ok(tty) = fs::File::open("/dev/tty") {
+                        command.stdin(Stdio::from(tty));
+                    }
+                }
                 return command
                     .status()
                     .await
@@ -2134,6 +2024,16 @@ async fn run_agent_invocation(
                     .with_context(|| format!("failed to run agent command in {}", root.display()))
             }
         }
+    }
+}
+
+fn resolve_instrument_run_mode(args: &InstrumentSetupArgs, prompt_available: bool) -> (bool, bool) {
+    if args.tui {
+        (true, args.yolo)
+    } else if args.background || !prompt_available {
+        (false, args.yolo)
+    } else {
+        (true, args.yolo)
     }
 }
 
@@ -2295,7 +2195,7 @@ fn run_mcp_setup(base: BaseArgs, args: AgentsMcpSetupArgs) -> Result<()> {
 
 fn resolve_setup_selection(args: &AgentsSetupArgs, home: &Path) -> Result<SetupSelection> {
     let mut scope = initial_scope(args.local, args.global, args.yes, YesScopeDefault::Global);
-    let interactive = ui::is_interactive() && !args.yes;
+    let interactive = ui::can_prompt() && !args.yes;
     let mut prompted_workflows: Option<Vec<WorkflowArg>> = if args.no_workflow {
         Some(Vec::new())
     } else {
@@ -2390,7 +2290,7 @@ fn resolve_setup_selection(args: &AgentsSetupArgs, home: &Path) -> Result<SetupS
 
 fn resolve_mcp_selection(args: &AgentsMcpSetupArgs, home: &Path) -> Result<McpSelection> {
     let mut scope = initial_scope(args.local, args.global, args.yes, YesScopeDefault::Global);
-    let interactive = ui::is_interactive() && !args.yes;
+    let interactive = ui::can_prompt() && !args.yes;
 
     if interactive {
         #[derive(Clone, Copy)]
@@ -2616,11 +2516,12 @@ fn resolve_local_root_for_scope(scope: InstallScope) -> Result<Option<PathBuf>> 
 
 fn prompt_scope_selection(prompt: &str) -> Result<Option<InstallScope>> {
     let choices = ["local (current git repo)", "global (user-wide)"];
+    let term = ui::prompt_term().ok_or_else(|| anyhow!("interactive mode requires TTY"))?;
     let idx = Select::with_theme(&ColorfulTheme::default())
         .with_prompt(prompt)
         .items(&choices)
         .default(1)
-        .interact_opt()?;
+        .interact_on_opt(&term)?;
     Ok(idx.map(|i| {
         if i == 0 {
             InstallScope::Local
@@ -2639,11 +2540,12 @@ fn prompt_agent_selection(prompt: &str, default: Agent) -> Result<Option<Agent>>
         .iter()
         .position(|agent| *agent == default)
         .unwrap_or(0);
+    let term = ui::prompt_term().ok_or_else(|| anyhow!("interactive mode requires TTY"))?;
     let selected = FuzzySelect::with_theme(&ColorfulTheme::default())
         .with_prompt(prompt)
         .items(&labels)
         .default(default_index)
-        .interact_opt()?;
+        .interact_on_opt(&term)?;
     Ok(selected.map(|index| ALL_AGENTS[index]))
 }
 
@@ -2658,13 +2560,14 @@ fn prompt_workflows_selection(defaults: &[WorkflowArg]) -> Result<Option<Vec<Wor
         .map(|workflow| default_set.contains(workflow))
         .collect::<Vec<_>>();
 
+    let term = ui::prompt_term().ok_or_else(|| anyhow!("interactive mode requires TTY"))?;
     let selected = MultiSelect::with_theme(&ColorfulTheme::default())
         .with_prompt(
             "Select the workflows you are interested in (will prefetch docs for them) (Esc: back)",
         )
         .items(&labels)
         .defaults(&default_flags)
-        .interact_opt()?;
+        .interact_on_opt(&term)?;
 
     Ok(selected.map(|indexes| {
         indexes
@@ -2691,7 +2594,7 @@ fn resolve_scope_from_flags(
         return Ok(resolve_yes_scope(yes_scope_default));
     }
 
-    if !ui::is_interactive() {
+    if !ui::can_prompt() {
         bail!("scope required in non-interactive mode: pass --local or --global");
     }
 
@@ -2730,16 +2633,6 @@ fn resolve_default_agent_selection(
     }
 
     bail!("multiple coding agents available; pass --agent <AGENT> or re-run in an interactive terminal");
-}
-
-#[allow(dead_code)]
-fn map_instrument_agent_arg(agent: InstrumentAgentArg) -> Agent {
-    match agent {
-        InstrumentAgentArg::Claude => Agent::Claude,
-        InstrumentAgentArg::Codex => Agent::Codex,
-        InstrumentAgentArg::Cursor => Agent::Cursor,
-        InstrumentAgentArg::Opencode => Agent::Opencode,
-    }
 }
 
 fn map_instrument_agent_arg_to_agent_arg(agent: InstrumentAgentArg) -> AgentArg {
@@ -3674,7 +3567,9 @@ mod tests {
     #[test]
     fn oauth_non_instrumentation_does_not_create_api_key() {
         let base = make_base_args();
-        assert!(!should_create_api_key_for_instrumentation(true, &base, false));
+        assert!(!should_create_api_key_for_instrumentation(
+            true, &base, false
+        ));
     }
 
     #[test]
@@ -3682,7 +3577,9 @@ mod tests {
         let mut base = make_base_args();
         base.api_key = Some("env-key".to_string());
         base.api_key_source = Some(ArgValueSource::EnvVariable);
-        assert!(!should_create_api_key_for_instrumentation(true, &base, true));
+        assert!(!should_create_api_key_for_instrumentation(
+            true, &base, true
+        ));
     }
 
     #[test]
@@ -3822,7 +3719,6 @@ mod tests {
             tui: false,
             background: false,
             yolo: false,
-            skip_launch: false,
         };
 
         let selected = resolve_instrument_workflow_selection(&args, &mut false)
@@ -3847,7 +3743,6 @@ mod tests {
             tui: false,
             background: false,
             yolo: false,
-            skip_launch: false,
         };
 
         let selected = resolve_instrument_workflow_selection(&args, &mut false)
@@ -3869,12 +3764,87 @@ mod tests {
             tui: false,
             background: false,
             yolo: false,
-            skip_launch: false,
         };
 
         let selected = resolve_instrument_workflow_selection(&args, &mut false)
             .expect("resolve instrument workflows");
         assert!(selected.is_empty());
+    }
+
+    #[test]
+    fn instrument_run_mode_prefers_tui_when_prompt_is_available() {
+        let args = InstrumentSetupArgs {
+            agent: Some(InstrumentAgentArg::Codex),
+            agent_cmd: None,
+            workflows: Vec::new(),
+            no_workflow: false,
+            yes: false,
+            refresh_docs: false,
+            workers: crate::sync::default_workers(),
+            languages: Vec::new(),
+            tui: false,
+            background: false,
+            yolo: false,
+        };
+
+        assert_eq!(resolve_instrument_run_mode(&args, true), (true, false));
+    }
+
+    #[test]
+    fn instrument_run_mode_falls_back_to_background_without_prompt() {
+        let args = InstrumentSetupArgs {
+            agent: Some(InstrumentAgentArg::Codex),
+            agent_cmd: None,
+            workflows: Vec::new(),
+            no_workflow: false,
+            yes: false,
+            refresh_docs: false,
+            workers: crate::sync::default_workers(),
+            languages: Vec::new(),
+            tui: false,
+            background: false,
+            yolo: false,
+        };
+
+        assert_eq!(resolve_instrument_run_mode(&args, false), (false, false));
+    }
+
+    #[test]
+    fn instrument_run_mode_keeps_tui_when_yolo_and_prompt_available() {
+        let args = InstrumentSetupArgs {
+            agent: Some(InstrumentAgentArg::Codex),
+            agent_cmd: None,
+            workflows: Vec::new(),
+            no_workflow: false,
+            yes: false,
+            refresh_docs: false,
+            workers: crate::sync::default_workers(),
+            languages: Vec::new(),
+            tui: false,
+            background: false,
+            yolo: true,
+        };
+
+        assert_eq!(resolve_instrument_run_mode(&args, true), (true, true));
+    }
+
+    #[test]
+    fn instrument_run_mode_keeps_background_when_requested_with_yolo() {
+        let args = InstrumentSetupArgs {
+            agent: Some(InstrumentAgentArg::Codex),
+            agent_cmd: None,
+            workflows: Vec::new(),
+            no_workflow: false,
+            yes: false,
+            refresh_docs: false,
+            workers: crate::sync::default_workers(),
+            languages: Vec::new(),
+            tui: false,
+            background: true,
+            yolo: true,
+        };
+
+        assert_eq!(resolve_instrument_run_mode(&args, true), (false, true));
     }
 
     #[test]

--- a/src/status.rs
+++ b/src/status.rs
@@ -342,7 +342,6 @@ mod tests {
             user_name: user_name.map(Into::into),
             email: email.map(Into::into),
             api_key_hint: api_key_hint.map(Into::into),
-            is_oauth: false,
         }
     }
 

--- a/src/status.rs
+++ b/src/status.rs
@@ -13,11 +13,7 @@ Examples:
   bt status --json
   bt status --verbose
 ")]
-pub struct StatusArgs {
-    /// Output verbose status
-    #[arg(long)]
-    pub verbose: bool,
-}
+pub struct StatusArgs {}
 
 #[derive(Serialize)]
 struct StatusOutput {
@@ -44,7 +40,7 @@ fn format_identity(p: &auth::ProfileInfo) -> Option<String> {
     }
 }
 
-pub async fn run(base: BaseArgs, args: StatusArgs) -> Result<()> {
+pub async fn run(base: BaseArgs, _args: StatusArgs) -> Result<()> {
     let global_path = config::global_path().ok();
     let global_cfg = config::load_global().unwrap_or_default();
     let local_path = config::local_path();
@@ -79,7 +75,7 @@ pub async fn run(base: BaseArgs, args: StatusArgs) -> Result<()> {
         return Ok(());
     }
 
-    if args.verbose {
+    if base.verbose {
         println!("org: {}", org.as_deref().unwrap_or("(unset)"));
         println!("project: {}", project.as_deref().unwrap_or("(unset)"));
         if let Some(ref p) = profile_info {

--- a/src/status.rs
+++ b/src/status.rs
@@ -342,6 +342,7 @@ mod tests {
             user_name: user_name.map(Into::into),
             email: email.map(Into::into),
             api_key_hint: api_key_hint.map(Into::into),
+            is_oauth: false,
         }
     }
 

--- a/src/switch.rs
+++ b/src/switch.rs
@@ -276,7 +276,6 @@ mod tests {
             user_name: None,
             email: None,
             api_key_hint: None,
-            is_oauth: false,
         }
     }
 

--- a/src/switch.rs
+++ b/src/switch.rs
@@ -259,6 +259,7 @@ mod tests {
             org_name: org.map(String::from),
             project: project.map(String::from),
             api_key: None,
+            api_key_source: None,
             prefer_profile: false,
             api_url: None,
             app_url: None,

--- a/src/switch.rs
+++ b/src/switch.rs
@@ -254,6 +254,7 @@ mod tests {
         BaseArgs {
             json: false,
             verbose: false,
+            quiet: false,
             no_color: false,
             no_input: false,
             profile: None,

--- a/src/switch.rs
+++ b/src/switch.rs
@@ -25,9 +25,6 @@ pub struct SwitchArgs {
     /// Force set local config value
     #[arg(long, short = 'l')]
     local: bool,
-    /// Output verbose response
-    #[arg(long)]
-    verbose: bool,
     /// Target: project name or org/project
     #[arg(value_name = "TARGET")]
     target: Option<String>,
@@ -151,7 +148,7 @@ pub async fn run(base: BaseArgs, args: SwitchArgs) -> Result<()> {
 
     let display = format!("{org_name}/{}", project.name);
     print_command_status(CommandStatus::Success, &format!("Switched to {display}"));
-    if args.verbose {
+    if base.verbose {
         eprintln!("Wrote to {}", path.display());
     }
 
@@ -245,7 +242,6 @@ mod tests {
         SwitchArgs {
             global: false,
             local: false,
-            verbose: false,
             target: target.map(String::from),
         }
     }
@@ -255,6 +251,7 @@ mod tests {
             json: false,
             verbose: false,
             quiet: false,
+            quiet_source: None,
             no_color: false,
             no_input: false,
             profile: None,

--- a/src/switch.rs
+++ b/src/switch.rs
@@ -253,14 +253,13 @@ mod tests {
     fn base_args(org: Option<&str>, project: Option<&str>) -> BaseArgs {
         BaseArgs {
             json: false,
-            quiet: false,
+            verbose: false,
             no_color: false,
             profile: None,
             org_name: org.map(String::from),
             project: project.map(String::from),
             api_key: None,
             prefer_profile: false,
-            no_input: false,
             api_url: None,
             app_url: None,
             env_file: None,

--- a/src/switch.rs
+++ b/src/switch.rs
@@ -255,6 +255,7 @@ mod tests {
             json: false,
             verbose: false,
             no_color: false,
+            no_input: false,
             profile: None,
             org_name: org.map(String::from),
             project: project.map(String::from),

--- a/src/switch.rs
+++ b/src/switch.rs
@@ -276,6 +276,7 @@ mod tests {
             user_name: None,
             email: None,
             api_key_hint: None,
+            is_oauth: false,
         }
     }
 

--- a/src/sync.rs
+++ b/src/sync.rs
@@ -115,10 +115,6 @@ struct PullArgs {
     /// Include stored vectors in pulled rows so a subsequent push can re-ingest them.
     #[arg(long)]
     include_vectors: bool,
-
-    /// Print each BTQL query and timing information.
-    #[arg(long, env = "BT_SYNC_VERBOSE")]
-    verbose: bool,
 }
 
 #[derive(Debug, Clone, Args)]
@@ -544,7 +540,15 @@ pub async fn run(base: BaseArgs, args: SyncArgs) -> Result<()> {
         SyncCommand::Pull(pull) => {
             let ctx = login(&base).await?;
             let client = ApiClient::new(&ctx)?;
-            run_pull(base.json, &ctx, &client, project.as_deref(), pull).await
+            run_pull(
+                base.json,
+                base.verbose,
+                &ctx,
+                &client,
+                project.as_deref(),
+                pull,
+            )
+            .await
         }
         SyncCommand::Push(push) => {
             let ctx = login(&base).await?;
@@ -557,6 +561,7 @@ pub async fn run(base: BaseArgs, args: SyncArgs) -> Result<()> {
 
 async fn run_pull(
     json_output: bool,
+    verbose: bool,
     ctx: &LoginContext,
     client: &ApiClient,
     project_selector: Option<&str>,
@@ -705,7 +710,6 @@ async fn run_pull(
         Some(RunStatus::Running),
     )?;
     let btql_retry_tracker = Arc::new(BtqlRetryTracker::default());
-    let verbose = args.verbose;
 
     match scope {
         ScopeArg::Spans => {

--- a/src/traces.rs
+++ b/src/traces.rs
@@ -6059,6 +6059,7 @@ mod tests {
         BaseArgs {
             json: false,
             verbose: false,
+            quiet: false,
             no_color: false,
             no_input: false,
             profile: None,

--- a/src/traces.rs
+++ b/src/traces.rs
@@ -6060,6 +6060,7 @@ mod tests {
             json: false,
             verbose: false,
             quiet: false,
+            quiet_source: None,
             no_color: false,
             no_input: false,
             profile: None,

--- a/src/traces.rs
+++ b/src/traces.rs
@@ -6064,6 +6064,7 @@ mod tests {
             org_name: None,
             project: None,
             api_key: None,
+            api_key_source: None,
             prefer_profile: false,
             api_url: None,
             app_url: None,

--- a/src/traces.rs
+++ b/src/traces.rs
@@ -6060,6 +6060,7 @@ mod tests {
             json: false,
             verbose: false,
             no_color: false,
+            no_input: false,
             profile: None,
             org_name: None,
             project: None,

--- a/src/traces.rs
+++ b/src/traces.rs
@@ -6058,14 +6058,13 @@ mod tests {
     fn base_args() -> BaseArgs {
         BaseArgs {
             json: false,
-            quiet: false,
+            verbose: false,
             no_color: false,
             profile: None,
             org_name: None,
             project: None,
             api_key: None,
             prefer_profile: false,
-            no_input: false,
             api_url: None,
             app_url: None,
             env_file: None,

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -1,6 +1,8 @@
 use std::io::IsTerminal;
 use std::sync::atomic::{AtomicBool, Ordering};
 
+use dialoguer::console::Term;
+
 mod pager;
 pub mod prompt_render;
 mod select;
@@ -30,6 +32,33 @@ pub fn set_animations_enabled(val: bool) {
 
 pub fn animations_enabled() -> bool {
     ANIMATIONS_ENABLED.load(Ordering::Relaxed)
+}
+
+pub fn prompt_term() -> Option<Term> {
+    if NO_INPUT.load(Ordering::Relaxed) {
+        return None;
+    }
+
+    if std::io::stderr().is_terminal() {
+        return Some(Term::stderr());
+    }
+
+    #[cfg(unix)]
+    {
+        use std::fs::OpenOptions;
+
+        if let Ok(tty) = OpenOptions::new().read(true).write(true).open("/dev/tty") {
+            if let Ok(tty2) = tty.try_clone() {
+                return Some(Term::read_write_pair(tty, tty2));
+            }
+        }
+    }
+
+    None
+}
+
+pub fn can_prompt() -> bool {
+    prompt_term().is_some()
 }
 
 pub fn is_interactive() -> bool {

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -12,7 +12,6 @@ static NO_INPUT: AtomicBool = AtomicBool::new(false);
 static QUIET: AtomicBool = AtomicBool::new(false);
 static ANIMATIONS_ENABLED: AtomicBool = AtomicBool::new(true);
 
-#[allow(dead_code)]
 pub fn set_no_input(val: bool) {
     NO_INPUT.store(val, Ordering::Relaxed);
 }

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -12,6 +12,7 @@ static NO_INPUT: AtomicBool = AtomicBool::new(false);
 static QUIET: AtomicBool = AtomicBool::new(false);
 static ANIMATIONS_ENABLED: AtomicBool = AtomicBool::new(true);
 
+#[allow(dead_code)]
 pub fn set_no_input(val: bool) {
     NO_INPUT.store(val, Ordering::Relaxed);
 }

--- a/src/ui/select.rs
+++ b/src/ui/select.rs
@@ -5,9 +5,9 @@ use crate::{http::ApiClient, projects::api, ui::with_spinner};
 
 /// Fuzzy select from a list of items. Requires TTY.
 pub fn fuzzy_select<T: ToString>(prompt: &str, items: &[T], default: usize) -> Result<usize> {
-    if !super::is_interactive() {
+    let Some(term) = super::prompt_term() else {
         bail!("interactive mode requires TTY");
-    }
+    };
 
     if items.is_empty() {
         bail!("no items to select from");
@@ -20,7 +20,7 @@ pub fn fuzzy_select<T: ToString>(prompt: &str, items: &[T], default: usize) -> R
         .items(&labels)
         .default(default)
         .max_length(12)
-        .interact()?;
+        .interact_on(&term)?;
 
     Ok(selection)
 }

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -40,12 +40,12 @@ fn write_auth_store(config_home: &Path, profiles: &[(&str, &str)]) {
 }
 
 #[test]
-fn deprecated_global_quiet_flag_still_parses_for_other_commands() {
+fn global_quiet_flag_still_parses_for_other_commands() {
     bt_command().args(["status", "--quiet"]).assert().success();
 }
 
 #[test]
-fn deprecated_global_quiet_flag_still_parses_for_setup_subcommands() {
+fn quiet_flag_still_parses_for_setup_subcommands() {
     bt_command()
         .args(["setup", "skills", "--quiet", "--help"])
         .assert()
@@ -56,6 +56,30 @@ fn deprecated_global_quiet_flag_still_parses_for_setup_subcommands() {
 fn setup_instrument_quiet_no_longer_aliases_background() {
     bt_command()
         .args(["setup", "instrument", "--quiet", "--tui", "--help"])
+        .assert()
+        .success();
+}
+
+#[test]
+fn setup_verbose_is_accepted_after_subcommand() {
+    bt_command()
+        .args(["setup", "skills", "--verbose", "--help"])
+        .assert()
+        .success();
+}
+
+#[test]
+fn setup_instrument_accepts_no_workflow_flag() {
+    bt_command()
+        .args(["setup", "instrument", "--no-workflow", "--help"])
+        .assert()
+        .success();
+}
+
+#[test]
+fn setup_instrument_accepts_deprecated_agents_alias() {
+    bt_command()
+        .args(["setup", "instrument", "--agents", "codex", "--help"])
         .assert()
         .success();
 }

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -12,6 +12,7 @@ fn clear_braintrust_auth_env(cmd: &mut Command) {
         "BRAINTRUST_API_KEY",
         "BRAINTRUST_PROFILE",
         "BRAINTRUST_ORG_NAME",
+        "BRAINTRUST_DEFAULT_PROJECT",
     ] {
         cmd.env_remove(key);
     }
@@ -154,11 +155,20 @@ fn setup_no_instrument_does_not_require_auth_in_git_repo() {
 }
 
 #[test]
-fn setup_requires_profile_disambiguation_when_multiple_profiles_exist() {
+fn setup_accepts_no_skill_alias() {
+    bt_command()
+        .args(["setup", "--no-skill", "--help"])
+        .assert()
+        .success();
+}
+
+#[test]
+fn setup_mcp_only_no_instrument_does_not_require_project_or_auth() {
     let repo = make_git_repo();
     let home = tempfile::tempdir().expect("home tempdir");
     let config_home = tempfile::tempdir().expect("config tempdir");
     let bin_dir = tempfile::tempdir().expect("bin tempdir");
+    write_executable(&bin_dir.path().join("codex"));
     write_auth_store(
         config_home.path(),
         &[("alpha", "alpha-org"), ("beta", "beta-org")],
@@ -170,9 +180,15 @@ fn setup_requires_profile_disambiguation_when_multiple_profiles_exist() {
         .env("HOME", home.path())
         .env("XDG_CONFIG_HOME", config_home.path())
         .env("PATH", bin_dir.path())
-        .args(["setup", "--global", "--no-input"])
+        .args([
+            "setup",
+            "--global",
+            "--mcp",
+            "--no-skills",
+            "--no-instrument",
+            "--no-input",
+        ])
         .assert()
-        .failure()
-        .stderr(predicate::str::contains("multiple auth profiles found"))
-        .stderr(predicate::str::contains("pass --profile"));
+        .success()
+        .stdout(predicate::str::contains("Configuring MCP for Braintrust"));
 }

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -80,6 +80,32 @@ fn setup_verbose_is_accepted_after_subcommand() {
 }
 
 #[test]
+fn status_quiet_and_verbose_conflict() {
+    bt_command()
+        .args(["status", "--quiet", "--verbose"])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("cannot be used with"));
+}
+
+#[test]
+fn setup_quiet_and_verbose_conflict() {
+    bt_command()
+        .args([
+            "setup",
+            "--quiet",
+            "--verbose",
+            "--no-instrument",
+            "--global",
+            "--agent",
+            "codex",
+        ])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("cannot be used with"));
+}
+
+#[test]
 fn setup_instrument_accepts_no_workflow_flag() {
     bt_command()
         .args(["setup", "instrument", "--no-workflow", "--help"])
@@ -118,12 +144,39 @@ fn setup_uses_codex_detected_on_path_without_explicit_agent() {
         ])
         .assert()
         .success()
-        .stdout(predicate::str::contains("Selected agents: codex"));
+        .stdout(predicate::str::contains("Selected agents: codex").not());
 
     assert!(home
         .path()
         .join(".agents/skills/braintrust/SKILL.md")
         .exists());
+}
+
+#[test]
+fn setup_verbose_prints_agent_summary() {
+    let repo = make_git_repo();
+    let home = tempfile::tempdir().expect("home tempdir");
+    let config_home = tempfile::tempdir().expect("config tempdir");
+    let bin_dir = tempfile::tempdir().expect("bin tempdir");
+    write_executable(&bin_dir.path().join("codex"));
+
+    let mut cmd = bt_command();
+    clear_braintrust_auth_env(&mut cmd);
+    cmd.current_dir(repo.path())
+        .env("HOME", home.path())
+        .env("XDG_CONFIG_HOME", config_home.path())
+        .env("PATH", bin_dir.path())
+        .args([
+            "setup",
+            "--verbose",
+            "--global",
+            "--no-instrument",
+            "--no-workflow",
+            "--no-input",
+        ])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Selected agents: codex"));
 }
 
 #[test]
@@ -222,5 +275,5 @@ fn setup_mcp_only_no_instrument_does_not_require_project_or_auth() {
         ])
         .assert()
         .success()
-        .stdout(predicate::str::contains("Configuring MCP for Braintrust"));
+        .stdout(predicate::str::contains("Configuring MCP for Braintrust").not());
 }

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -1,0 +1,141 @@
+use assert_cmd::Command;
+use predicates::prelude::*;
+use std::fs;
+use std::path::Path;
+
+fn bt_command() -> Command {
+    Command::cargo_bin("bt").expect("bt binary")
+}
+
+fn write_executable(path: &Path) {
+    fs::write(path, "#!/bin/sh\nexit 0\n").expect("write executable");
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let mut perms = fs::metadata(path).expect("metadata").permissions();
+        perms.set_mode(0o755);
+        fs::set_permissions(path, perms).expect("chmod");
+    }
+}
+
+fn make_git_repo() -> tempfile::TempDir {
+    let dir = tempfile::tempdir().expect("tempdir");
+    fs::write(dir.path().join(".git"), "gitdir: /tmp/fake").expect("write .git");
+    dir
+}
+
+fn write_auth_store(config_home: &Path, profiles: &[(&str, &str)]) {
+    let auth_dir = config_home.join("bt");
+    fs::create_dir_all(&auth_dir).expect("create auth dir");
+
+    let mut entries = Vec::new();
+    for (profile, org) in profiles {
+        entries.push(format!(
+            "\"{profile}\":{{\"auth_kind\":\"api_key\",\"org_name\":\"{org}\"}}"
+        ));
+    }
+
+    let body = format!("{{\"profiles\":{{{}}}}}", entries.join(","));
+    fs::write(auth_dir.join("auth.json"), body).expect("write auth store");
+}
+
+#[test]
+fn deprecated_global_quiet_flag_still_parses_for_other_commands() {
+    bt_command().args(["status", "--quiet"]).assert().success();
+}
+
+#[test]
+fn deprecated_global_quiet_flag_still_parses_for_setup_subcommands() {
+    bt_command()
+        .args(["setup", "skills", "--quiet", "--help"])
+        .assert()
+        .success();
+}
+
+#[test]
+fn setup_instrument_quiet_no_longer_aliases_background() {
+    bt_command()
+        .args(["setup", "instrument", "--quiet", "--tui", "--help"])
+        .assert()
+        .success();
+}
+
+#[test]
+fn setup_uses_codex_detected_on_path_without_explicit_agent() {
+    let repo = make_git_repo();
+    let home = tempfile::tempdir().expect("home tempdir");
+    let config_home = tempfile::tempdir().expect("config tempdir");
+    let bin_dir = tempfile::tempdir().expect("bin tempdir");
+    write_executable(&bin_dir.path().join("codex"));
+
+    bt_command()
+        .current_dir(repo.path())
+        .env("HOME", home.path())
+        .env("XDG_CONFIG_HOME", config_home.path())
+        .env("PATH", bin_dir.path())
+        .args([
+            "setup",
+            "--global",
+            "--no-instrument",
+            "--no-workflow",
+            "--no-input",
+        ])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Selected agents: codex"));
+
+    assert!(home
+        .path()
+        .join(".agents/skills/braintrust/SKILL.md")
+        .exists());
+}
+
+#[test]
+fn setup_no_instrument_does_not_require_auth_in_git_repo() {
+    let repo = make_git_repo();
+    let nested = repo.path().join("nested");
+    fs::create_dir_all(&nested).expect("create nested");
+
+    let home = tempfile::tempdir().expect("home tempdir");
+    let config_home = tempfile::tempdir().expect("config tempdir");
+    let bin_dir = tempfile::tempdir().expect("bin tempdir");
+    write_executable(&bin_dir.path().join("codex"));
+
+    bt_command()
+        .current_dir(&nested)
+        .env("HOME", home.path())
+        .env("XDG_CONFIG_HOME", config_home.path())
+        .env("PATH", bin_dir.path())
+        .args([
+            "setup",
+            "--global",
+            "--no-instrument",
+            "--no-workflow",
+            "--no-input",
+        ])
+        .assert()
+        .success();
+}
+
+#[test]
+fn setup_requires_profile_disambiguation_when_multiple_profiles_exist() {
+    let repo = make_git_repo();
+    let home = tempfile::tempdir().expect("home tempdir");
+    let config_home = tempfile::tempdir().expect("config tempdir");
+    let bin_dir = tempfile::tempdir().expect("bin tempdir");
+    write_auth_store(
+        config_home.path(),
+        &[("alpha", "alpha-org"), ("beta", "beta-org")],
+    );
+
+    bt_command()
+        .current_dir(repo.path())
+        .env("HOME", home.path())
+        .env("XDG_CONFIG_HOME", config_home.path())
+        .env("PATH", bin_dir.path())
+        .args(["setup", "--global", "--no-input"])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("multiple auth profiles found"))
+        .stderr(predicate::str::contains("pass --profile"));
+}

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -7,6 +7,16 @@ fn bt_command() -> Command {
     Command::cargo_bin("bt").expect("bt binary")
 }
 
+fn clear_braintrust_auth_env(cmd: &mut Command) {
+    for key in [
+        "BRAINTRUST_API_KEY",
+        "BRAINTRUST_PROFILE",
+        "BRAINTRUST_ORG_NAME",
+    ] {
+        cmd.env_remove(key);
+    }
+}
+
 fn write_executable(path: &Path) {
     fs::write(path, "#!/bin/sh\nexit 0\n").expect("write executable");
     #[cfg(unix)]
@@ -92,8 +102,9 @@ fn setup_uses_codex_detected_on_path_without_explicit_agent() {
     let bin_dir = tempfile::tempdir().expect("bin tempdir");
     write_executable(&bin_dir.path().join("codex"));
 
-    bt_command()
-        .current_dir(repo.path())
+    let mut cmd = bt_command();
+    clear_braintrust_auth_env(&mut cmd);
+    cmd.current_dir(repo.path())
         .env("HOME", home.path())
         .env("XDG_CONFIG_HOME", config_home.path())
         .env("PATH", bin_dir.path())
@@ -125,8 +136,9 @@ fn setup_no_instrument_does_not_require_auth_in_git_repo() {
     let bin_dir = tempfile::tempdir().expect("bin tempdir");
     write_executable(&bin_dir.path().join("codex"));
 
-    bt_command()
-        .current_dir(&nested)
+    let mut cmd = bt_command();
+    clear_braintrust_auth_env(&mut cmd);
+    cmd.current_dir(&nested)
         .env("HOME", home.path())
         .env("XDG_CONFIG_HOME", config_home.path())
         .env("PATH", bin_dir.path())
@@ -152,8 +164,9 @@ fn setup_requires_profile_disambiguation_when_multiple_profiles_exist() {
         &[("alpha", "alpha-org"), ("beta", "beta-org")],
     );
 
-    bt_command()
-        .current_dir(repo.path())
+    let mut cmd = bt_command();
+    clear_braintrust_auth_env(&mut cmd);
+    cmd.current_dir(repo.path())
         .env("HOME", home.path())
         .env("XDG_CONFIG_HOME", config_home.path())
         .env("PATH", bin_dir.path())

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -155,6 +155,38 @@ fn setup_no_instrument_does_not_require_auth_in_git_repo() {
 }
 
 #[test]
+fn setup_interactive_no_instrument_does_not_require_auth_in_git_repo() {
+    let repo = make_git_repo();
+    let nested = repo.path().join("nested");
+    fs::create_dir_all(&nested).expect("create nested");
+
+    let home = tempfile::tempdir().expect("home tempdir");
+    let config_home = tempfile::tempdir().expect("config tempdir");
+    let bin_dir = tempfile::tempdir().expect("bin tempdir");
+    write_executable(&bin_dir.path().join("codex"));
+
+    let mut cmd = bt_command();
+    clear_braintrust_auth_env(&mut cmd);
+    cmd.current_dir(&nested)
+        .env("HOME", home.path())
+        .env("XDG_CONFIG_HOME", config_home.path())
+        .env("PATH", bin_dir.path())
+        .args([
+            "setup",
+            "--interactive",
+            "--global",
+            "--agent",
+            "codex",
+            "--skills",
+            "--no-mcp",
+            "--no-instrument",
+            "--no-input",
+        ])
+        .assert()
+        .success();
+}
+
+#[test]
 fn setup_accepts_no_skill_alias() {
     bt_command()
         .args(["setup", "--no-skill", "--help"])

--- a/tests/eval_dev_server.rs
+++ b/tests/eval_dev_server.rs
@@ -123,10 +123,10 @@ fn parse_sse_events(body: &str) -> Vec<SseEvent> {
     let mut current_data = Vec::<String>::new();
 
     for line in body.lines() {
-        if line.starts_with("event: ") {
-            current_event = line["event: ".len()..].to_string();
-        } else if line.starts_with("data: ") {
-            current_data.push(line["data: ".len()..].to_string());
+        if let Some(stripped) = line.strip_prefix("event: ") {
+            current_event = stripped.to_string();
+        } else if let Some(stripped) = line.strip_prefix("data: ") {
+            current_data.push(stripped.to_string());
         } else if line.is_empty() && !current_event.is_empty() {
             events.push(SseEvent {
                 event: std::mem::take(&mut current_event),
@@ -518,10 +518,10 @@ fn streaming_eval_post(
             Ok(l) => l,
             Err(_) => break,
         };
-        if line.starts_with("event: ") {
-            current_event = line["event: ".len()..].to_string();
-        } else if line.starts_with("data: ") {
-            current_data.push(line["data: ".len()..].to_string());
+        if let Some(stripped) = line.strip_prefix("event: ") {
+            current_event = stripped.to_string();
+        } else if let Some(stripped) = line.strip_prefix("data: ") {
+            current_data.push(stripped.to_string());
         } else if line.is_empty() && !current_event.is_empty() {
             let event = SseEvent {
                 event: std::mem::take(&mut current_event),

--- a/tests/setup_cli.rs
+++ b/tests/setup_cli.rs
@@ -1,0 +1,12 @@
+use assert_cmd::prelude::*;
+use predicates::str::contains;
+use std::process::Command;
+
+#[test]
+fn setup_accepts_deprecated_quiet_flag() {
+    let mut cmd = Command::cargo_bin("bt").expect("bt binary");
+    cmd.args(["setup", "--quiet", "--help"]);
+    cmd.assert()
+        .success()
+        .stdout(contains("Configure Braintrust setup flows"));
+}


### PR DESCRIPTION
The OAuth-related changes, isolated from the wizard.
- `ensure_auth` rewrite (credential recovery flow, `is_missing_credential_error`)
- `maybe_create_api_key_for_oauth` (auto-create key, print-once)
- `login_interactive_oauth` made `pub(crate)`
- `#[allow(dead_code)]` on `login_interactive_api_key` (or just remove it)
- Remove `login_interactive` (the old method-chooser)
- Auth output tweaks (warning→info, spacing)

Part 3 of https://github.com/braintrustdata/bt/pull/94