### PR TITLE
Add custom CA bundle support across bt HTTP flows

### DIFF
--- a/src/args.rs
+++ b/src/args.rs
@@ -66,6 +66,16 @@ pub struct BaseArgs {
     )]
     pub app_url: Option<String>,
 
+    /// PEM CA bundle used for bt HTTPS requests
+    #[arg(
+        long = "ca-cert",
+        env = "BRAINTRUST_CA_CERT",
+        hide_env_values = true,
+        global = true,
+        value_name = "PATH"
+    )]
+    pub ca_cert: Option<PathBuf>,
+
     /// Path to a .env file to load before running commands.
     #[arg(
         long,

--- a/src/auth.rs
+++ b/src/auth.rs
@@ -8,18 +8,14 @@ use std::time::Duration;
 
 use anyhow::{bail, Context, Result};
 use base64::Engine as _;
-use braintrust_sdk_rust::{BraintrustClient, LoginState};
+use braintrust_sdk_rust::LoginState;
 use clap::{Args, Subcommand};
 use crossterm::event::{self, Event, KeyCode, KeyEventKind};
 use dialoguer::{Confirm, Input, Password};
-use oauth2::basic::{BasicClient, BasicTokenType};
-use oauth2::reqwest::async_http_client;
+use oauth2::basic::BasicClient;
 use oauth2::{
-    AuthUrl, AuthorizationCode, ClientId, CsrfToken, EmptyExtraTokenFields, PkceCodeChallenge,
-    PkceCodeVerifier, RedirectUrl, RefreshToken, Scope, StandardTokenResponse, TokenResponse,
-    TokenUrl,
+    AuthUrl, ClientId, CsrfToken, PkceCodeChallenge, PkceCodeVerifier, RedirectUrl, Scope, TokenUrl,
 };
-use reqwest::Client;
 use serde::{Deserialize, Serialize};
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::net::TcpListener;
@@ -172,7 +168,7 @@ pub async fn list_available_orgs(base: &BaseArgs) -> Result<Vec<AvailableOrg>> {
         None => login(base).await?.login.api_key,
     };
 
-    let mut orgs = fetch_login_orgs(&api_key, &app_url).await?;
+    let mut orgs = fetch_login_orgs(base, &api_key, &app_url).await?;
     orgs.sort_by(|a, b| {
         a.name
             .to_ascii_lowercase()
@@ -378,42 +374,22 @@ pub async fn login(base: &BaseArgs) -> Result<LoginContext> {
         )
     })?;
 
-    let mut builder = BraintrustClient::builder()
-        .blocking_login(true)
-        .api_key(api_key.clone());
-
-    if let Some(api_url) = &auth.api_url {
-        builder = builder.api_url(api_url);
-    }
-    if let Some(app_url) = &auth.app_url {
-        builder = builder.app_url(app_url);
-    }
-    if let Some(org_name) = &auth.org_name {
-        builder = builder.org_name(org_name);
-    }
-    let project = base
-        .project
+    let configured_api_url = auth
+        .api_url
         .clone()
-        .or_else(|| crate::config::load().ok().and_then(|c| c.project));
-    if let Some(project) = &project {
-        builder = builder.default_project(project);
-    }
+        .unwrap_or_else(|| DEFAULT_API_URL.to_string());
+    reqwest::Url::parse(&configured_api_url).context("invalid api_url")?;
 
-    let login = match builder.build().await {
-        Ok(client) => client.wait_for_login().await?,
-        Err(err) if auth.is_oauth => {
-            let org_name = auth
-                .org_name
-                .clone()
-                .ok_or_else(|| anyhow::anyhow!("oauth profile is missing org_name: {err}"))?;
-            LoginState {
-                api_key: api_key.clone(),
-                org_id: String::new(),
-                org_name,
-                api_url: auth.api_url.clone(),
-            }
-        }
-        Err(err) => return Err(err.into()),
+    let app_url = auth
+        .app_url
+        .clone()
+        .unwrap_or_else(|| DEFAULT_APP_URL.to_string());
+    let login = match fetch_login_orgs(base, &api_key, &app_url).await {
+        Ok(login_orgs) => login_state_from_orgs(&auth, api_key.clone(), login_orgs)?,
+        Err(err) => match oauth_login_state_fallback(&auth, api_key.clone()) {
+            Some(login) => login,
+            None => return Err(err),
+        },
     };
 
     let api_url = login
@@ -422,15 +398,48 @@ pub async fn login(base: &BaseArgs) -> Result<LoginContext> {
         .or(auth.api_url.clone())
         .unwrap_or_else(|| DEFAULT_API_URL.to_string());
 
-    let app_url = auth
-        .app_url
-        .clone()
-        .unwrap_or_else(|| DEFAULT_APP_URL.to_string());
-
     Ok(LoginContext {
         login,
         api_url,
         app_url,
+    })
+}
+
+fn login_state_from_orgs(
+    auth: &ResolvedAuth,
+    api_key: String,
+    login_orgs: Vec<LoginOrgInfo>,
+) -> Result<LoginState> {
+    let org = if let Some(org_name) = auth.org_name.as_deref() {
+        login_orgs
+            .into_iter()
+            .find(|org| org.name == org_name)
+            .ok_or_else(|| anyhow::anyhow!("organization '{org_name}' not found"))?
+    } else {
+        login_orgs
+            .into_iter()
+            .next()
+            .ok_or_else(|| anyhow::anyhow!("no organizations found for this credential"))?
+    };
+
+    Ok(LoginState {
+        api_key,
+        org_id: org.id,
+        org_name: org.name,
+        api_url: org.api_url.clone().or(auth.api_url.clone()),
+    })
+}
+
+fn oauth_login_state_fallback(auth: &ResolvedAuth, api_key: String) -> Option<LoginState> {
+    if !auth.is_oauth {
+        return None;
+    }
+
+    Some(LoginState {
+        api_key,
+        org_id: String::new(),
+        org_name: auth.org_name.clone()?,
+        api_url: auth.api_url.clone(),
     })
 }
 
@@ -523,7 +532,7 @@ pub async fn resolve_auth(base: &BaseArgs) -> Result<ResolvedAuth> {
             "oauth refresh token missing for profile '{profile_name}'; re-run `bt auth login --oauth --profile {profile_name}`"
         )
     })?;
-    let refreshed = refresh_oauth_access_token(&api_url, &refresh_token, client_id).await?;
+    let refreshed = refresh_oauth_access_token(base, &api_url, &refresh_token, client_id).await?;
     save_profile_oauth_access_token(&profile_name, &refreshed.access_token)?;
     if let Some(next_refresh_token) = refreshed.refresh_token.as_ref() {
         if next_refresh_token != &refresh_token {
@@ -691,7 +700,7 @@ async fn run_login_set(base: &BaseArgs, args: AuthLoginArgs) -> Result<()> {
         .app_url
         .clone()
         .unwrap_or_else(|| DEFAULT_APP_URL.to_string());
-    let login_orgs = fetch_login_orgs(&api_key, &login_app_url).await?;
+    let login_orgs = fetch_login_orgs(base, &api_key, &login_app_url).await?;
     let selected_org = select_login_org(
         login_orgs.clone(),
         base.org_name.as_deref(),
@@ -791,6 +800,7 @@ async fn run_login_oauth(base: &BaseArgs, args: AuthLoginArgs) -> Result<()> {
     }
 
     let oauth_tokens = exchange_oauth_authorization_code(
+        base,
         &api_url,
         &client_id,
         &redirect_uri,
@@ -798,7 +808,7 @@ async fn run_login_oauth(base: &BaseArgs, args: AuthLoginArgs) -> Result<()> {
         pkce_verifier,
     )
     .await?;
-    let login_orgs = fetch_login_orgs(&oauth_tokens.access_token, &app_url).await?;
+    let login_orgs = fetch_login_orgs(base, &oauth_tokens.access_token, &app_url).await?;
     let selected_org = select_login_org(
         login_orgs.clone(),
         base.org_name.as_deref(),
@@ -849,7 +859,7 @@ async fn login_interactive_api_key(base: &mut BaseArgs) -> Result<String> {
         .app_url
         .clone()
         .unwrap_or_else(|| DEFAULT_APP_URL.to_string());
-    let login_orgs = fetch_login_orgs(&api_key, &login_app_url).await?;
+    let login_orgs = fetch_login_orgs(base, &api_key, &login_app_url).await?;
     let selected_org = select_login_org(
         login_orgs.clone(),
         base.org_name.as_deref(),
@@ -932,6 +942,7 @@ async fn login_interactive_oauth(base: &mut BaseArgs) -> Result<String> {
     }
 
     let oauth_tokens = exchange_oauth_authorization_code(
+        base,
         &api_url,
         &client_id,
         &redirect_uri,
@@ -940,7 +951,7 @@ async fn login_interactive_oauth(base: &mut BaseArgs) -> Result<String> {
     )
     .await?;
 
-    let login_orgs = fetch_login_orgs(&oauth_tokens.access_token, &app_url).await?;
+    let login_orgs = fetch_login_orgs(base, &oauth_tokens.access_token, &app_url).await?;
     let selected_org = select_login_org(
         login_orgs.clone(),
         base.org_name.as_deref(),
@@ -1091,7 +1102,7 @@ async fn run_login_refresh(base: &BaseArgs) -> Result<()> {
         println!("Cached access token expiry before refresh: unknown");
     }
 
-    let refreshed = refresh_oauth_access_token(&api_url, &refresh_token, &client_id).await?;
+    let refreshed = refresh_oauth_access_token(base, &api_url, &refresh_token, &client_id).await?;
     save_profile_oauth_access_token(profile_name.as_str(), &refreshed.access_token)?;
     let mut refresh_rotated = false;
     if let Some(next_refresh_token) = refreshed.refresh_token.as_ref() {
@@ -1221,7 +1232,7 @@ async fn run_profiles(base: &BaseArgs, args: AuthProfilesArgs) -> Result<()> {
         return Ok(());
     }
 
-    let verifications = verify_all_profiles_from_store(&store).await;
+    let verifications = verify_all_profiles_from_store(base, &store).await;
     let all_network_errors = verifications
         .iter()
         .all(|v| v.status == "error" && !v.error.as_deref().unwrap_or("").contains("invalid"));
@@ -1402,7 +1413,11 @@ fn build_verification(
     }
 }
 
-async fn verify_profile_full(name: &str, profile: &AuthProfile) -> ProfileVerification {
+async fn verify_profile_full(
+    base: &BaseArgs,
+    name: &str,
+    profile: &AuthProfile,
+) -> ProfileVerification {
     let app_url = profile.app_url.as_deref().unwrap_or(DEFAULT_APP_URL);
     let auth_kind = match profile.auth_kind {
         AuthKind::ApiKey => "api_key",
@@ -1431,7 +1446,7 @@ async fn verify_profile_full(name: &str, profile: &AuthProfile) -> ProfileVerifi
         AuthKind::ApiKey => (None, profile.api_key_hint.clone()),
     };
 
-    match fetch_login_orgs(&credential, app_url).await {
+    match fetch_login_orgs(base, &credential, app_url).await {
         Ok(_) => mk(ProfileStatus::Ok, jwt_id, hint),
         Err(e) => {
             let msg = e.to_string();
@@ -1449,12 +1464,16 @@ async fn verify_profile_full(name: &str, profile: &AuthProfile) -> ProfileVerifi
     }
 }
 
-async fn verify_all_profiles_from_store(store: &AuthStore) -> Vec<ProfileVerification> {
+async fn verify_all_profiles_from_store(
+    base: &BaseArgs,
+    store: &AuthStore,
+) -> Vec<ProfileVerification> {
     let mut set = tokio::task::JoinSet::new();
     for (name, profile) in store.profiles.iter() {
+        let base = base.clone();
         let name = name.clone();
         let profile = profile.clone();
-        set.spawn(async move { verify_profile_full(&name, &profile).await });
+        set.spawn(async move { verify_profile_full(&base, &name, &profile).await });
     }
 
     let mut results = Vec::new();
@@ -1538,10 +1557,13 @@ fn print_saved_profiles(store: &AuthStore, json: bool) -> Result<()> {
     Ok(())
 }
 
-async fn fetch_login_orgs(api_key: &str, app_url: &str) -> Result<Vec<LoginOrgInfo>> {
+async fn fetch_login_orgs(
+    base: &BaseArgs,
+    api_key: &str,
+    app_url: &str,
+) -> Result<Vec<LoginOrgInfo>> {
     let login_url = format!("{}/api/apikey/login", app_url.trim_end_matches('/'));
-    let client = Client::builder()
-        .timeout(crate::http::DEFAULT_HTTP_TIMEOUT)
+    let client = crate::http::client_builder(base, crate::http::DEFAULT_HTTP_TIMEOUT)?
         .build()
         .context("failed to initialize HTTP client")?;
     let response = client
@@ -1550,7 +1572,9 @@ async fn fetch_login_orgs(api_key: &str, app_url: &str) -> Result<Vec<LoginOrgIn
         .header("Content-Type", "application/json")
         .send()
         .await
-        .with_context(|| format!("failed to call login endpoint {login_url}"))?;
+        .map_err(|err| {
+            anyhow::Error::new(err).context(format!("failed to call login endpoint {login_url}"))
+        })?;
 
     if !response.status().is_success() {
         let status = response.status();
@@ -1931,47 +1955,76 @@ fn is_ssh_session() -> bool {
 }
 
 async fn exchange_oauth_authorization_code(
+    base: &BaseArgs,
     api_url: &str,
     client_id: &str,
     redirect_uri: &str,
     code: &str,
     code_verifier: PkceCodeVerifier,
 ) -> Result<OAuthTokenResponse> {
-    let oauth_client = build_oauth_client(api_url, client_id, Some(redirect_uri))?;
-    let token_response = oauth_client
-        .exchange_code(AuthorizationCode::new(code.to_string()))
-        .set_pkce_verifier(code_verifier)
-        .request_async(async_http_client)
+    let token_url = format!("{}/oauth/token", api_url.trim_end_matches('/'));
+    let client = crate::http::client_builder(base, crate::http::DEFAULT_HTTP_TIMEOUT)?
+        .build()
+        .context("failed to initialize HTTP client")?;
+    let token_response = client
+        .post(&token_url)
+        .form(&[
+            ("grant_type", "authorization_code"),
+            ("client_id", client_id),
+            ("redirect_uri", redirect_uri),
+            ("code", code),
+            ("code_verifier", code_verifier.secret()),
+        ])
+        .send()
         .await
-        .with_context(|| {
-            format!(
-                "failed to call oauth token endpoint {}/oauth/token",
-                api_url.trim_end_matches('/')
-            )
+        .map_err(|err| {
+            anyhow::Error::new(err)
+                .context(format!("failed to call oauth token endpoint {token_url}"))
         })?;
-    Ok(to_oauth_token_response(token_response))
+    if !token_response.status().is_success() {
+        let status = token_response.status();
+        let body = token_response.text().await.unwrap_or_default();
+        return Err(crate::http::HttpError { status, body }.into());
+    }
+    token_response
+        .json()
+        .await
+        .context("failed to parse oauth token response")
 }
 
 async fn refresh_oauth_access_token(
+    base: &BaseArgs,
     api_url: &str,
     refresh_token: &str,
     client_id: &str,
 ) -> Result<OAuthTokenResponse> {
-    let oauth_client = build_oauth_client(api_url, client_id, None)?;
-    let token_response = oauth_client
-        .exchange_refresh_token(&RefreshToken::new(refresh_token.to_string()))
-        .request_async(async_http_client)
+    let token_url = format!("{}/oauth/token", api_url.trim_end_matches('/'));
+    let client = crate::http::client_builder(base, crate::http::DEFAULT_HTTP_TIMEOUT)?
+        .build()
+        .context("failed to initialize HTTP client")?;
+    let token_response = client
+        .post(&token_url)
+        .form(&[
+            ("grant_type", "refresh_token"),
+            ("client_id", client_id),
+            ("refresh_token", refresh_token),
+        ])
+        .send()
         .await
-        .with_context(|| {
-            format!(
-                "failed to call oauth token endpoint {}/oauth/token",
-                api_url.trim_end_matches('/')
-            )
+        .map_err(|err| {
+            anyhow::Error::new(err)
+                .context(format!("failed to call oauth token endpoint {token_url}"))
         })?;
-    Ok(to_oauth_token_response(token_response))
+    if !token_response.status().is_success() {
+        let status = token_response.status();
+        let body = token_response.text().await.unwrap_or_default();
+        return Err(crate::http::HttpError { status, body }.into());
+    }
+    token_response
+        .json()
+        .await
+        .context("failed to parse oauth token response")
 }
-
-type OAuth2StdTokenResponse = StandardTokenResponse<EmptyExtraTokenFields, BasicTokenType>;
 
 fn build_oauth_client(
     api_url: &str,
@@ -1995,16 +2048,6 @@ fn build_oauth_client(
         Ok(client.set_redirect_uri(redirect_url))
     } else {
         Ok(client)
-    }
-}
-
-fn to_oauth_token_response(tokens: OAuth2StdTokenResponse) -> OAuthTokenResponse {
-    OAuthTokenResponse {
-        access_token: tokens.access_token().secret().to_string(),
-        refresh_token: tokens
-            .refresh_token()
-            .map(|token| token.secret().to_string()),
-        expires_in: tokens.expires_in().map(|duration| duration.as_secs()),
     }
 }
 
@@ -2652,6 +2695,7 @@ mod tests {
             no_input: false,
             api_url: None,
             app_url: None,
+            ca_cert: None,
             env_file: None,
         }
     }
@@ -2944,6 +2988,38 @@ mod tests {
         assert!(resolved.is_oauth);
         assert_eq!(resolved.api_key, None);
         assert_eq!(resolved.org_name.as_deref(), Some("Example Org"));
+    }
+
+    #[test]
+    fn oauth_login_state_fallback_uses_stored_profile_context() {
+        let auth = ResolvedAuth {
+            api_key: Some("oauth-token".to_string()),
+            api_url: Some("https://api.example.com".to_string()),
+            app_url: Some("https://app.example.com".to_string()),
+            org_name: Some("Example Org".to_string()),
+            is_oauth: true,
+        };
+
+        let login = oauth_login_state_fallback(&auth, "oauth-token".to_string())
+            .expect("oauth fallback should be available");
+
+        assert_eq!(login.api_key, "oauth-token");
+        assert_eq!(login.org_id, "");
+        assert_eq!(login.org_name, "Example Org");
+        assert_eq!(login.api_url.as_deref(), Some("https://api.example.com"));
+    }
+
+    #[test]
+    fn oauth_login_state_fallback_requires_org_name() {
+        let auth = ResolvedAuth {
+            api_key: Some("oauth-token".to_string()),
+            api_url: Some("https://api.example.com".to_string()),
+            app_url: Some("https://app.example.com".to_string()),
+            org_name: None,
+            is_oauth: true,
+        };
+
+        assert!(oauth_login_state_fallback(&auth, "oauth-token".to_string()).is_none());
     }
 
     #[test]

--- a/src/eval.rs
+++ b/src/eval.rs
@@ -404,8 +404,7 @@ pub async fn run(base: BaseArgs, args: EvalArgs) -> Result<()> {
             allowed_org_name: args.dev_org_name.clone(),
             allowed_origins: collect_allowed_dev_origins(&args.dev_allowed_origin, &app_url),
             app_url,
-            http_client: Client::builder()
-                .timeout(crate::http::DEFAULT_HTTP_TIMEOUT)
+            http_client: crate::http::client_builder(&base, crate::http::DEFAULT_HTTP_TIMEOUT)?
                 .build()
                 .context("failed to create dev server HTTP client")?,
         };

--- a/src/functions/api.rs
+++ b/src/functions/api.rs
@@ -3,6 +3,7 @@ use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use urlencoding::encode;
 
+use crate::args::BaseArgs;
 use crate::http::ApiClient;
 
 fn escape_sql(s: &str) -> String {
@@ -210,11 +211,12 @@ pub async fn request_code_upload_slot(
 }
 
 pub async fn upload_bundle(
+    base: &BaseArgs,
     url: &str,
     bundle_bytes: Vec<u8>,
     content_encoding: Option<&str>,
 ) -> Result<()> {
-    crate::http::put_signed_url(url, bundle_bytes, content_encoding)
+    crate::http::put_signed_url(base, url, bundle_bytes, content_encoding)
         .await
         .context("failed to upload code bundle to signed URL")
 }

--- a/src/functions/mod.rs
+++ b/src/functions/mod.rs
@@ -464,7 +464,7 @@ pub(crate) struct ResolvedContext {
 
 pub(crate) async fn resolve_auth_context(base: &BaseArgs) -> Result<AuthContext> {
     let ctx = login(base).await?;
-    let client = ApiClient::new(&ctx)?;
+    let client = ApiClient::new(base, &ctx)?;
     Ok(AuthContext {
         client,
         app_url: ctx.app_url,

--- a/src/functions/push.rs
+++ b/src/functions/push.rs
@@ -599,6 +599,7 @@ pub async fn run(base: BaseArgs, args: PushArgs) -> Result<()> {
 
         let source_path = PathBuf::from(&file.source_file);
         let file_result = push_file(
+            &base,
             &auth_ctx,
             default_project_id.as_deref(),
             &manifest.runtime_context,
@@ -727,6 +728,7 @@ fn build_code_function_data(
 
 #[allow(clippy::too_many_arguments)]
 async fn push_file(
+    base: &BaseArgs,
     auth_ctx: &super::AuthContext,
     default_project_id: Option<&str>,
     runtime_context: &RuntimeContext,
@@ -810,7 +812,7 @@ async fn push_file(
             message: format!("{err:#}"),
         })?;
 
-        api::upload_bundle(&slot.url, upload_bytes, content_encoding)
+        api::upload_bundle(base, &slot.url, upload_bytes, content_encoding)
             .await
             .map_err(|err| FileFailure {
                 reason: HardFailureReason::BundleUploadFailed,
@@ -3443,6 +3445,7 @@ mod tests {
             no_input: false,
             api_url: None,
             app_url: None,
+            ca_cert: None,
             env_file: None,
         }
     }

--- a/src/http.rs
+++ b/src/http.rs
@@ -5,6 +5,7 @@ use serde::de::DeserializeOwned;
 use serde::{Deserialize, Serialize};
 use serde_json::json;
 
+use crate::args::BaseArgs;
 use crate::auth::LoginContext;
 
 pub const DEFAULT_HTTP_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(30);
@@ -37,9 +38,8 @@ pub struct BtqlResponse<T> {
 }
 
 impl ApiClient {
-    pub fn new(ctx: &LoginContext) -> Result<Self> {
-        let http = Client::builder()
-            .timeout(DEFAULT_HTTP_TIMEOUT)
+    pub fn new(base: &BaseArgs, ctx: &LoginContext) -> Result<Self> {
+        let http = client_builder(base, DEFAULT_HTTP_TIMEOUT)?
             .build()
             .context("failed to build HTTP client")?;
 
@@ -207,12 +207,12 @@ impl ApiClient {
 const UPLOAD_HTTP_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(120);
 
 pub async fn put_signed_url(
+    base: &BaseArgs,
     url: &str,
     body: Vec<u8>,
     content_encoding: Option<&str>,
 ) -> Result<()> {
-    let client = Client::builder()
-        .timeout(UPLOAD_HTTP_TIMEOUT)
+    let client = client_builder(base, UPLOAD_HTTP_TIMEOUT)?
         .build()
         .context("failed to build signed-url HTTP client")?;
 
@@ -234,4 +234,131 @@ pub async fn put_signed_url(
         return Err(HttpError { status, body }.into());
     }
     Ok(())
+}
+
+pub fn resolved_ca_cert_path(base: &BaseArgs) -> Option<std::path::PathBuf> {
+    base.ca_cert.clone().or_else(|| {
+        // Compatibility exception: `SSL_CERT_FILE` is a widely-used TLS env var and needs to
+        // remain available even though bt's primary configuration surface is clap args/env.
+        std::env::var_os("SSL_CERT_FILE")
+            .filter(|value| !value.is_empty())
+            .map(std::path::PathBuf::from)
+    })
+}
+
+pub fn client_builder(
+    base: &BaseArgs,
+    timeout: std::time::Duration,
+) -> Result<reqwest::ClientBuilder> {
+    let mut builder = Client::builder().timeout(timeout);
+
+    if let Some(ca_cert) = resolved_ca_cert_path(base) {
+        let pem = std::fs::read(&ca_cert)
+            .with_context(|| format!("failed to read CA bundle {}", ca_cert.display()))?;
+        let certs = reqwest::Certificate::from_pem_bundle(&pem).with_context(|| {
+            format!(
+                "failed to parse PEM certificates from CA bundle {}",
+                ca_cert.display()
+            )
+        })?;
+        if certs.is_empty() {
+            anyhow::bail!(
+                "CA bundle {} did not contain any PEM certificates",
+                ca_cert.display()
+            );
+        }
+        for cert in certs {
+            builder = builder.add_root_certificate(cert);
+        }
+    }
+
+    Ok(builder)
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::{Mutex, OnceLock};
+
+    use super::*;
+
+    const VALID_TEST_CERT_PEM: &str = r#"-----BEGIN CERTIFICATE-----
+MIICpDCCAYwCCQDtlc4RX+IuODANBgkqhkiG9w0BAQsFADAUMRIwEAYDVQQDDAls
+b2NhbGhvc3QwHhcNMjYwMzE3MTY1MzAyWhcNMjYwMzE4MTY1MzAyWjAUMRIwEAYD
+VQQDDAlsb2NhbGhvc3QwggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDX
+K/y/7AlhzPBkIbiEiCt/l1Qfa99h8FdblOe8BCeJkpoW4Fw10mZnWBgX6peZMF7j
+p4rjtIJTWkfl8eNoTPdOkYfmi6B3AwAZzl7VQCMgE0gCFkIrgXrkeLqP+q231UxE
+wKgilRG3DWFfELZCQeFtq0jSBcnyWybw+o9SgajaQ+SJg7lbgT6o+8AwHQ54HBo+
+VVZJ2CybZvmijQXGiVCMpZ34nxJVW/i6AbsFwp+CLMHOFjrpLuZpv61EnZaGsqsF
+RG/VPiNca769Dr8YG4RtPRBKvyDMnUqEDkGwYXrhAVxvI3kKlQq3MHppGCSsjnVl
+oqhWm//sE7znMJtuzIf7AgMBAAEwDQYJKoZIhvcNAQELBQADggEBAD1zS7eOkfU2
+IzxjW7MAJce5JrAcRWWe3L2ORx+y+PS4uI0ms1FM4AopZ2FxXdbSSXLf5bqC2f2i
+qy+8YbVdZacFtFLmnZicCXP86Na5JUYxZERDyqKN4GFwSrfELwLsuv9TWpir+p/H
+3XxQ/8/eJdTHOunNtl4BVUefjGp9PVNb6NFvLDkSkNN37KcjNpB9jPVK970uZ5lb
+kOx6ulbMXpNH73h5rwzgs6FbVbcAavPJKYGr170rDRxidpfRz3ex+RBQvcfFQeRx
+NP64Q8OosOHraKRn7bvST7bXvGFZUp06aIFrlwdmSQPXU/6o4zYNmkR4RVv4VvQ7
+cb0bfZ7fHHs=
+-----END CERTIFICATE-----
+"#;
+
+    fn env_lock() -> &'static Mutex<()> {
+        static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+        LOCK.get_or_init(|| Mutex::new(()))
+    }
+
+    fn base_args() -> BaseArgs {
+        BaseArgs {
+            json: false,
+            quiet: false,
+            no_color: false,
+            profile: None,
+            org_name: None,
+            project: None,
+            api_key: None,
+            prefer_profile: false,
+            no_input: false,
+            api_url: None,
+            app_url: None,
+            ca_cert: None,
+            env_file: None,
+        }
+    }
+
+    #[test]
+    fn resolved_ca_cert_prefers_base_arg_over_ssl_cert_file() {
+        let _guard = env_lock().lock().expect("lock env");
+        let ssl_path = std::env::temp_dir().join("ssl-cert-file.pem");
+        std::env::set_var("SSL_CERT_FILE", &ssl_path);
+
+        let explicit = std::env::temp_dir().join("explicit-ca.pem");
+        let mut base = base_args();
+        base.ca_cert = Some(explicit.clone());
+
+        assert_eq!(resolved_ca_cert_path(&base), Some(explicit));
+        std::env::remove_var("SSL_CERT_FILE");
+    }
+
+    #[test]
+    fn resolved_ca_cert_uses_ssl_cert_file_when_flag_missing() {
+        let _guard = env_lock().lock().expect("lock env");
+        let ssl_path = std::env::temp_dir().join("ssl-cert-file-only.pem");
+        std::env::set_var("SSL_CERT_FILE", &ssl_path);
+
+        assert_eq!(resolved_ca_cert_path(&base_args()), Some(ssl_path));
+        std::env::remove_var("SSL_CERT_FILE");
+    }
+
+    #[test]
+    fn client_builder_accepts_valid_ca_bundle() {
+        let path = std::env::temp_dir().join(format!("bt-ca-bundle-{}.pem", std::process::id()));
+        std::fs::write(&path, VALID_TEST_CERT_PEM).expect("write temp bundle");
+
+        let mut base = base_args();
+        base.ca_cert = Some(path.clone());
+        let client = client_builder(&base, DEFAULT_HTTP_TIMEOUT)
+            .expect("build client builder")
+            .build();
+
+        std::fs::remove_file(&path).expect("remove temp bundle");
+        assert!(client.is_ok());
+    }
 }

--- a/src/init.rs
+++ b/src/init.rs
@@ -38,7 +38,7 @@ pub async fn run(base: BaseArgs, _args: InitArgs) -> Result<()> {
             }
         }
         let ctx = login(&login_base).await?;
-        let client = ApiClient::new(&ctx)?;
+        let client = ApiClient::new(&login_base, &ctx)?;
 
         let org = client.org_name().to_string();
         let project = select_project_interactive(&client, Some("Link to project"), None).await?;

--- a/src/logs3_uploader.rs
+++ b/src/logs3_uploader.rs
@@ -1,0 +1,551 @@
+use std::collections::HashMap;
+use std::time::Duration;
+
+use anyhow::{anyhow, Context, Result};
+use backoff::backoff::Backoff;
+use backoff::ExponentialBackoffBuilder;
+use reqwest::header::{HeaderMap, HeaderName, HeaderValue};
+use reqwest::{multipart, Client, Url};
+use serde::{Deserialize, Serialize};
+use serde_json::{json, Map, Value};
+use tokio::time::sleep;
+
+use crate::args::BaseArgs;
+
+const DEFAULT_MAX_REQUEST_SIZE: usize = 6 * 1024 * 1024;
+const LOGS_API_VERSION: u8 = 2;
+const LOGS3_OVERFLOW_REFERENCE_TYPE: &str = "logs3_overflow";
+const MAX_ATTEMPTS: usize = 5;
+const BASE_BACKOFF_MS: u64 = 300;
+const MAX_BACKOFF_MS: u64 = 8_000;
+const REQUEST_TIMEOUT: Duration = Duration::from_secs(30);
+const OBJECT_ID_KEYS: [&str; 6] = [
+    "experiment_id",
+    "dataset_id",
+    "prompt_session_id",
+    "project_id",
+    "log_id",
+    "function_data",
+];
+
+#[derive(Debug, Clone, Default)]
+pub struct Logs3UploadResult {
+    pub rows_uploaded: usize,
+    pub bytes_processed: usize,
+    pub requests_sent: usize,
+}
+
+#[derive(Debug, Clone)]
+pub struct Logs3BatchUploader {
+    client: Client,
+    api_url: Url,
+    api_key: String,
+    org_name: Option<String>,
+    payload_limits: Option<PayloadLimits>,
+}
+
+#[derive(Debug, Clone)]
+struct PayloadLimits {
+    max_request_size: usize,
+    can_use_overflow: bool,
+}
+
+#[derive(Debug, Clone)]
+struct RowPayload {
+    row_json: String,
+    row_bytes: usize,
+    overflow_meta: Logs3OverflowInputRow,
+}
+
+#[derive(Debug, Clone, Serialize)]
+struct Logs3OverflowInputRow {
+    object_ids: Map<String, Value>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    is_delete: Option<bool>,
+    input_row: OverflowInputRowInfo,
+}
+
+#[derive(Debug, Clone, Serialize)]
+struct OverflowInputRowInfo {
+    byte_size: usize,
+}
+
+#[derive(Debug, Deserialize)]
+struct VersionInfo {
+    #[serde(default)]
+    logs3_payload_max_bytes: Option<usize>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "UPPERCASE")]
+enum OverflowMethod {
+    Put,
+    Post,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct Logs3OverflowUpload {
+    method: OverflowMethod,
+    signed_url: String,
+    headers: Option<HashMap<String, String>>,
+    fields: Option<HashMap<String, String>>,
+    key: String,
+}
+
+#[derive(Debug)]
+struct UploadApiError {
+    status: u16,
+    body: String,
+}
+
+impl std::fmt::Display for UploadApiError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "request failed ({}): {}", self.status, self.body)
+    }
+}
+
+impl std::error::Error for UploadApiError {}
+
+impl Logs3BatchUploader {
+    pub fn new(
+        base: &BaseArgs,
+        api_url: impl AsRef<str>,
+        api_key: impl Into<String>,
+        org_name: Option<String>,
+    ) -> Result<Self> {
+        let api_url =
+            Url::parse(api_url.as_ref()).map_err(|err| anyhow!("invalid api_url: {err}"))?;
+        let client = crate::http::client_builder(base, REQUEST_TIMEOUT)?
+            .build()
+            .context("failed to build logs3 HTTP client")?;
+        Ok(Self {
+            client,
+            api_url,
+            api_key: api_key.into(),
+            org_name: org_name.filter(|name| !name.trim().is_empty()),
+            payload_limits: None,
+        })
+    }
+
+    pub async fn upload_rows(
+        &mut self,
+        rows: &[Map<String, Value>],
+        batch_max_num_items: usize,
+    ) -> Result<Logs3UploadResult> {
+        if rows.is_empty() {
+            return Ok(Logs3UploadResult::default());
+        }
+
+        let limits = self.get_payload_limits().await;
+        let mut row_payloads = Vec::with_capacity(rows.len());
+        for row in rows {
+            row_payloads.push(RowPayload::from_row(row)?);
+        }
+
+        let batch_limit_rows = batch_max_num_items.max(1);
+        let batch_limit_bytes = (limits.max_request_size / 2).max(1);
+        let batches = batch_items(row_payloads, batch_limit_rows, batch_limit_bytes, |item| {
+            item.row_bytes
+        });
+
+        let mut result = Logs3UploadResult::default();
+        for batch in batches {
+            let batch_result = self.submit_row_batch(&batch, &limits).await?;
+            result.bytes_processed += batch_result.bytes_processed;
+            result.requests_sent += batch_result.requests_sent;
+            result.rows_uploaded += batch_result.rows_uploaded;
+        }
+        Ok(result)
+    }
+
+    async fn get_payload_limits(&mut self) -> PayloadLimits {
+        if let Some(existing) = &self.payload_limits {
+            return existing.clone();
+        }
+
+        let fetched = self.fetch_payload_limits().await;
+        self.payload_limits = Some(fetched.clone());
+        fetched
+    }
+
+    async fn fetch_payload_limits(&self) -> PayloadLimits {
+        let mut server_limit = None;
+        if let Ok(url) = self.api_url.join("version") {
+            let mut request = self.client.get(url).bearer_auth(&self.api_key);
+            if let Some(org_name) = &self.org_name {
+                request = request.header("x-bt-org-name", org_name);
+            }
+            if let Ok(response) = request.send().await {
+                if response.status().is_success() {
+                    if let Ok(version) = response.json::<VersionInfo>().await {
+                        server_limit = version.logs3_payload_max_bytes.filter(|limit| *limit > 0);
+                    }
+                }
+            }
+        }
+
+        PayloadLimits {
+            max_request_size: server_limit.unwrap_or(DEFAULT_MAX_REQUEST_SIZE).max(1),
+            can_use_overflow: server_limit.is_some(),
+        }
+    }
+
+    async fn submit_row_batch(
+        &self,
+        items: &[RowPayload],
+        limits: &PayloadLimits,
+    ) -> Result<Logs3UploadResult> {
+        if items.is_empty() {
+            return Ok(Logs3UploadResult::default());
+        }
+
+        let mut pending = vec![items.to_vec()];
+        let mut result = Logs3UploadResult::default();
+
+        while let Some(chunk) = pending.pop() {
+            if chunk.is_empty() {
+                continue;
+            }
+            let payload = construct_logs3_payload(&chunk);
+            let payload_bytes = payload.len();
+
+            if limits.can_use_overflow && payload_bytes > limits.max_request_size {
+                let overflow_result = self.submit_overflow(&chunk, payload, payload_bytes).await?;
+                result.rows_uploaded += overflow_result.rows_uploaded;
+                result.bytes_processed += overflow_result.bytes_processed;
+                result.requests_sent += overflow_result.requests_sent;
+                continue;
+            }
+
+            let (post_result, post_attempts) =
+                run_with_backoff(|| self.post_logs3_raw(&payload)).await;
+            result.requests_sent += post_attempts;
+            match post_result {
+                Ok(()) => {
+                    result.rows_uploaded += chunk.len();
+                    result.bytes_processed += payload_bytes;
+                }
+                Err(err) if upload_api_status(&err) == Some(413) => {
+                    if limits.can_use_overflow {
+                        let overflow_result = self
+                            .submit_overflow(&chunk, payload.clone(), payload_bytes)
+                            .await?;
+                        result.rows_uploaded += overflow_result.rows_uploaded;
+                        result.bytes_processed += overflow_result.bytes_processed;
+                        result.requests_sent += overflow_result.requests_sent;
+                    } else if chunk.len() > 1 {
+                        let mid = chunk.len() / 2;
+                        pending.push(chunk[mid..].to_vec());
+                        pending.push(chunk[..mid].to_vec());
+                    } else {
+                        return Err(anyhow!(
+                            "single row exceeds server payload limit and overflow is unavailable"
+                        ));
+                    }
+                }
+                Err(err) => return Err(err),
+            }
+        }
+
+        Ok(result)
+    }
+
+    async fn submit_overflow(
+        &self,
+        items: &[RowPayload],
+        payload: String,
+        payload_bytes: usize,
+    ) -> Result<Logs3UploadResult> {
+        let overflow_rows = items
+            .iter()
+            .map(|item| item.overflow_meta.clone())
+            .collect::<Vec<_>>();
+        let mut requests_sent = 0usize;
+
+        let (upload_result, upload_attempts) =
+            run_with_backoff(|| self.request_overflow_upload(&overflow_rows, payload_bytes)).await;
+        requests_sent += upload_attempts;
+        let upload = upload_result?;
+
+        let (payload_result, payload_attempts) =
+            run_with_backoff(|| self.upload_overflow_payload(&upload, &payload)).await;
+        requests_sent += payload_attempts;
+        payload_result?;
+
+        let overflow_reference = json!({
+            "rows": {
+                "type": LOGS3_OVERFLOW_REFERENCE_TYPE,
+                "key": upload.key,
+            },
+            "api_version": LOGS_API_VERSION,
+        })
+        .to_string();
+        let (post_result, post_attempts) =
+            run_with_backoff(|| self.post_logs3_raw(&overflow_reference)).await;
+        requests_sent += post_attempts;
+        post_result?;
+
+        Ok(Logs3UploadResult {
+            rows_uploaded: items.len(),
+            bytes_processed: payload_bytes,
+            requests_sent,
+        })
+    }
+
+    async fn request_overflow_upload(
+        &self,
+        rows: &[Logs3OverflowInputRow],
+        payload_bytes: usize,
+    ) -> Result<Logs3OverflowUpload> {
+        let url = self
+            .api_url
+            .join("logs3/overflow")
+            .map_err(|err| anyhow!("invalid overflow URL: {err}"))?;
+        let request_body = json!({
+            "content_type": "application/json",
+            "size_bytes": payload_bytes,
+            "rows": rows,
+        });
+        let mut request = self
+            .client
+            .post(url)
+            .bearer_auth(&self.api_key)
+            .header("content-type", "application/json")
+            .json(&request_body);
+        if let Some(org_name) = &self.org_name {
+            request = request.header("x-bt-org-name", org_name);
+        }
+        let response = request
+            .send()
+            .await
+            .context("failed to request logs3 overflow upload")?;
+        ensure_success(response)
+            .await?
+            .json::<Logs3OverflowUpload>()
+            .await
+            .context("failed to parse logs3 overflow response")
+    }
+
+    async fn upload_overflow_payload(
+        &self,
+        upload: &Logs3OverflowUpload,
+        payload: &str,
+    ) -> Result<()> {
+        let signed_url = Url::parse(&upload.signed_url)
+            .map_err(|err| anyhow!("invalid logs3 overflow signed URL: {err}"))?;
+
+        match upload.method {
+            OverflowMethod::Post => {
+                let fields = upload
+                    .fields
+                    .clone()
+                    .ok_or_else(|| anyhow!("logs3 overflow POST upload missing form fields"))?;
+                let content_type = fields
+                    .get("Content-Type")
+                    .cloned()
+                    .unwrap_or_else(|| "application/json".to_string());
+                let mut form = multipart::Form::new();
+                for (key, value) in &fields {
+                    form = form.text(key.clone(), value.clone());
+                }
+                let file_part = multipart::Part::text(payload.to_string())
+                    .mime_str(&content_type)
+                    .map_err(|err| {
+                        anyhow!("invalid overflow content-type '{content_type}': {err}")
+                    })?;
+                form = form.part("file", file_part);
+
+                let mut request = self.client.post(signed_url).multipart(form);
+                let mut headers = header_map_from_pairs(upload.headers.as_ref())?;
+                headers.remove("content-type");
+                if !headers.is_empty() {
+                    request = request.headers(headers);
+                }
+                let response = request
+                    .send()
+                    .await
+                    .context("failed to upload overflow payload")?;
+                ensure_success(response).await?;
+            }
+            OverflowMethod::Put => {
+                let mut headers = header_map_from_pairs(upload.headers.as_ref())?;
+                if upload.signed_url.contains("blob.core.windows.net")
+                    && !headers.contains_key("x-ms-blob-type")
+                {
+                    headers.insert("x-ms-blob-type", HeaderValue::from_static("BlockBlob"));
+                }
+
+                let mut request = self.client.put(signed_url).body(payload.to_string());
+                if !headers.is_empty() {
+                    request = request.headers(headers);
+                }
+                let response = request
+                    .send()
+                    .await
+                    .context("failed to upload overflow payload")?;
+                ensure_success(response).await?;
+            }
+        }
+
+        Ok(())
+    }
+
+    async fn post_logs3_raw(&self, payload: &str) -> Result<()> {
+        let url = self
+            .api_url
+            .join("logs3")
+            .map_err(|err| anyhow!("invalid logs3 URL: {err}"))?;
+        let mut request = self
+            .client
+            .post(url)
+            .bearer_auth(&self.api_key)
+            .header("content-type", "application/json")
+            .body(payload.to_string());
+        if let Some(org_name) = &self.org_name {
+            request = request.header("x-bt-org-name", org_name);
+        }
+        let response = request.send().await.context("failed to post logs3 batch")?;
+        ensure_success(response).await?;
+        Ok(())
+    }
+}
+
+impl RowPayload {
+    fn from_row(row: &Map<String, Value>) -> Result<Self> {
+        let row_json = serde_json::to_string(row).context("failed to serialize logs3 row")?;
+        let row_bytes = row_json.len();
+        let mut object_ids = Map::new();
+        for key in OBJECT_ID_KEYS {
+            if let Some(value) = row.get(key) {
+                object_ids.insert(key.to_string(), value.clone());
+            }
+        }
+        let is_delete = row.get("_object_delete").and_then(Value::as_bool);
+        Ok(Self {
+            row_json,
+            row_bytes,
+            overflow_meta: Logs3OverflowInputRow {
+                object_ids,
+                is_delete,
+                input_row: OverflowInputRowInfo {
+                    byte_size: row_bytes,
+                },
+            },
+        })
+    }
+}
+
+fn ensure_success(
+    response: reqwest::Response,
+) -> std::pin::Pin<Box<dyn std::future::Future<Output = Result<reqwest::Response>> + Send>> {
+    Box::pin(async move {
+        if response.status().is_success() {
+            return Ok(response);
+        }
+        let status = response.status().as_u16();
+        let body = response.text().await.unwrap_or_default();
+        Err(UploadApiError { status, body }.into())
+    })
+}
+
+fn upload_api_status(err: &anyhow::Error) -> Option<u16> {
+    err.chain().find_map(|source| {
+        source
+            .downcast_ref::<UploadApiError>()
+            .map(|err| err.status)
+    })
+}
+
+fn construct_logs3_payload(items: &[RowPayload]) -> String {
+    let rows = items
+        .iter()
+        .map(|item| item.row_json.as_str())
+        .collect::<Vec<_>>()
+        .join(",");
+    format!("{{\"rows\":[{rows}],\"api_version\":{LOGS_API_VERSION}}}")
+}
+
+fn header_map_from_pairs(headers: Option<&HashMap<String, String>>) -> Result<HeaderMap> {
+    let mut out = HeaderMap::new();
+    if let Some(headers) = headers {
+        for (key, value) in headers {
+            let name = HeaderName::from_bytes(key.as_bytes())
+                .map_err(|err| anyhow!("invalid HTTP header name '{key}': {err}"))?;
+            let header_value = HeaderValue::from_str(value)
+                .map_err(|err| anyhow!("invalid HTTP header value for '{key}': {err}"))?;
+            out.insert(name, header_value);
+        }
+    }
+    Ok(out)
+}
+
+fn should_retry(err: &anyhow::Error) -> bool {
+    if let Some(reqwest_err) = err
+        .chain()
+        .find_map(|source| source.downcast_ref::<reqwest::Error>())
+    {
+        return reqwest_err.is_timeout() || reqwest_err.is_connect();
+    }
+
+    matches!(upload_api_status(err), Some(429 | 500..=599))
+}
+
+async fn run_with_backoff<T, F, Fut>(mut operation: F) -> (Result<T>, usize)
+where
+    F: FnMut() -> Fut,
+    Fut: std::future::Future<Output = Result<T>>,
+{
+    let mut attempts = 0usize;
+    let mut backoff = ExponentialBackoffBuilder::new()
+        .with_initial_interval(Duration::from_millis(BASE_BACKOFF_MS))
+        .with_multiplier(2.0)
+        .with_randomization_factor(0.2)
+        .with_max_interval(Duration::from_millis(MAX_BACKOFF_MS))
+        .with_max_elapsed_time(None)
+        .build();
+
+    loop {
+        attempts += 1;
+        match operation().await {
+            Ok(value) => return (Ok(value), attempts),
+            Err(err) => {
+                if !should_retry(&err) || attempts >= MAX_ATTEMPTS {
+                    return (Err(err), attempts);
+                }
+                match backoff.next_backoff() {
+                    Some(delay) => sleep(delay).await,
+                    None => return (Err(err), attempts),
+                }
+            }
+        }
+    }
+}
+
+fn batch_items<T, F>(items: Vec<T>, max_items: usize, max_bytes: usize, size_of: F) -> Vec<Vec<T>>
+where
+    F: Fn(&T) -> usize,
+{
+    let mut batches = Vec::new();
+    let mut current = Vec::new();
+    let mut current_bytes = 0usize;
+
+    for item in items {
+        let item_bytes = size_of(&item);
+        let would_overflow = !current.is_empty()
+            && (current.len() >= max_items || current_bytes.saturating_add(item_bytes) > max_bytes);
+        if would_overflow {
+            batches.push(current);
+            current = Vec::new();
+            current_bytes = 0;
+        }
+        current_bytes = current_bytes.saturating_add(item_bytes);
+        current.push(item);
+    }
+
+    if !current.is_empty() {
+        batches.push(current);
+    }
+
+    batches
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -14,6 +14,7 @@ mod functions;
 mod http;
 mod init;
 mod js_runner;
+mod logs3_uploader;
 mod projects;
 mod prompts;
 mod python_runner;
@@ -76,7 +77,8 @@ Additional
   setup        Configure Braintrust setup flows
   status       Show current org and project context
 
-Flags
+Common Flags
+Pass these after the command, for example `bt status --ca-cert /path/to/ca.pem`.
       --profile <PROFILE>    Use a saved login profile [env: BRAINTRUST_PROFILE]
   -o, --org <ORG>            Override active org [env: BRAINTRUST_ORG_NAME]
   -p, --project <PROJECT>    Override active project [env: BRAINTRUST_DEFAULT_PROJECT]
@@ -86,6 +88,7 @@ Flags
       --no-input             Disable all interactive prompts
       --api-url <URL>        Override API URL [env: BRAINTRUST_API_URL]
       --app-url <URL>        Override app URL [env: BRAINTRUST_APP_URL]
+      --ca-cert <PATH>       PEM CA bundle [env: BRAINTRUST_CA_CERT or SSL_CERT_FILE]
       --env-file <PATH>      Path to a .env file to load
   -h, --help                 Print help
   -V, --version              Print version
@@ -227,7 +230,7 @@ async fn try_main() -> Result<()> {
         Commands::Experiments(cmd) => experiments::run(cmd.base, cmd.args).await?,
         Commands::Sync(cmd) => sync::run(cmd.base, cmd.args).await?,
         Commands::Util(cmd) => util_cmd::run(cmd.base, cmd.args).await?,
-        Commands::SelfCommand(cmd) => self_update::run(cmd.args).await?,
+        Commands::SelfCommand(cmd) => self_update::run(cmd.base, cmd.args).await?,
         Commands::Switch(cmd) => switch::run(cmd.base, cmd.args).await?,
         Commands::Status(cmd) => status::run(cmd.base, cmd.args).await?,
     }
@@ -343,7 +346,25 @@ fn looks_like_user_error(err: &anyhow::Error) -> bool {
 
 fn print_error(err: &anyhow::Error, code: ExitCode) {
     eprintln!("error: {err}");
+    let mut causes = err.chain().skip(1).peekable();
+    if causes.peek().is_some() {
+        eprintln!("caused by:");
+        for cause in causes {
+            eprintln!("  - {cause}");
+        }
+    }
     if code == ExitCode::Error {
         eprintln!("If this seems like a bug, file an issue at https://github.com/braintrustdata/bt/issues/new and include `bt --version`, `bt status --json`, and the command you ran.");
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::HELP_TEMPLATE;
+
+    #[test]
+    fn help_template_mentions_ca_cert_and_flag_placement() {
+        assert!(HELP_TEMPLATE.contains("--ca-cert <PATH>"));
+        assert!(HELP_TEMPLATE.contains("Pass these after the command"));
     }
 }

--- a/src/projects/context.rs
+++ b/src/projects/context.rs
@@ -25,7 +25,7 @@ pub(crate) async fn resolve_project_context(
     } else {
         login(base).await?
     };
-    let client = ApiClient::new(&auth)?;
+    let client = ApiClient::new(base, &auth)?;
     let config_project = config::load().ok().and_then(|c| c.project);
     let project_name = match base.project.as_deref().or(config_project.as_deref()) {
         Some(p) => p.to_string(),

--- a/src/projects/mod.rs
+++ b/src/projects/mod.rs
@@ -73,7 +73,7 @@ struct DeleteArgs {
 
 pub async fn run(base: BaseArgs, args: ProjectsArgs) -> Result<()> {
     let ctx = login(&base).await?;
-    let client = ApiClient::new(&ctx)?;
+    let client = ApiClient::new(&base, &ctx)?;
 
     match args.command {
         None | Some(ProjectsCommands::List) => {

--- a/src/self_update.rs
+++ b/src/self_update.rs
@@ -1,13 +1,13 @@
 use std::env;
+use std::io::Write;
 use std::path::{Path, PathBuf};
-use std::process::Command;
+use std::process::{Command, Stdio};
 
 use anyhow::{Context, Result};
 use clap::{Args, Subcommand, ValueEnum};
-use reqwest::Client;
 use serde::Deserialize;
 
-use crate::http::DEFAULT_HTTP_TIMEOUT;
+use crate::{args::BaseArgs, http::DEFAULT_HTTP_TIMEOUT};
 
 #[derive(Debug, Clone, Args)]
 #[command(after_help = "\
@@ -82,25 +82,25 @@ struct GitHubRelease {
     tag_name: String,
 }
 
-pub async fn run(args: SelfArgs) -> Result<()> {
+pub async fn run(base: BaseArgs, args: SelfArgs) -> Result<()> {
     match args.command {
-        SelfSubcommand::Update(args) => run_update(args).await,
+        SelfSubcommand::Update(args) => run_update(&base, args).await,
     }
 }
 
-async fn run_update(args: UpdateArgs) -> Result<()> {
+async fn run_update(base: &BaseArgs, args: UpdateArgs) -> Result<()> {
     ensure_installer_managed_install()?;
     let channel = args
         .channel
         .unwrap_or_else(|| inferred_update_channel(BUILD_UPDATE_CHANNEL));
 
     if args.check {
-        check_for_update(channel).await?;
+        check_for_update(base, channel).await?;
         return Ok(());
     }
 
     if channel == UpdateChannel::Stable {
-        match fetch_release(channel).await {
+        match fetch_release(base, channel).await {
             Ok(release) => {
                 let current = env!("CARGO_PKG_VERSION");
                 if stable_is_up_to_date(current, &release.tag_name) {
@@ -116,7 +116,7 @@ async fn run_update(args: UpdateArgs) -> Result<()> {
         }
     }
 
-    run_installer(channel)?;
+    run_installer(base, channel).await?;
     Ok(())
 }
 
@@ -135,8 +135,8 @@ fn ensure_installer_managed_install() -> Result<()> {
     );
 }
 
-async fn check_for_update(channel: UpdateChannel) -> Result<()> {
-    let release = fetch_release(channel).await?;
+async fn check_for_update(base: &BaseArgs, channel: UpdateChannel) -> Result<()> {
+    let release = fetch_release(base, channel).await?;
     let current = env!("CARGO_PKG_VERSION");
 
     match channel {
@@ -151,10 +151,9 @@ async fn check_for_update(channel: UpdateChannel) -> Result<()> {
     Ok(())
 }
 
-async fn fetch_release(channel: UpdateChannel) -> Result<GitHubRelease> {
-    let client = Client::builder()
+async fn fetch_release(base: &BaseArgs, channel: UpdateChannel) -> Result<GitHubRelease> {
+    let client = crate::http::client_builder(base, DEFAULT_HTTP_TIMEOUT)?
         .user_agent("bt-self-update")
-        .timeout(DEFAULT_HTTP_TIMEOUT)
         .build()
         .context("failed to initialize HTTP client")?;
 
@@ -184,17 +183,26 @@ async fn fetch_release(channel: UpdateChannel) -> Result<GitHubRelease> {
         .context("failed to parse GitHub release response")
 }
 
-fn run_installer(channel: UpdateChannel) -> Result<()> {
+async fn run_installer(base: &BaseArgs, channel: UpdateChannel) -> Result<()> {
+    let installer_url = channel.installer_url();
+    let installer_script = fetch_installer_script(base, installer_url).await?;
+
     #[cfg(not(windows))]
     {
-        let installer_url = channel.installer_url();
         println!("updating bt from {} channel...", channel.name());
-        let cmd = format!("curl -fsSL '{installer_url}' | sh");
-        let status = Command::new("sh")
-            .arg("-c")
-            .arg(cmd)
-            .status()
+        let mut child = Command::new("sh")
+            .arg("-s")
+            .stdin(Stdio::piped())
+            .spawn()
             .context("failed to execute installer")?;
+
+        if let Some(mut stdin) = child.stdin.take() {
+            stdin
+                .write_all(installer_script.as_bytes())
+                .context("failed to write installer script")?;
+        }
+
+        let status = child.wait().context("failed to wait for installer")?;
 
         if !status.success() {
             anyhow::bail!("installer exited with status {status}");
@@ -206,25 +214,20 @@ fn run_installer(channel: UpdateChannel) -> Result<()> {
 
     #[cfg(windows)]
     {
-        let installer_url = match channel {
-            UpdateChannel::Stable => {
-                "https://github.com/braintrustdata/bt/releases/latest/download/bt-installer.ps1"
-            }
-            UpdateChannel::Canary => {
-                "https://github.com/braintrustdata/bt/releases/download/canary/bt-installer.ps1"
-            }
-        };
-        let script = format!("irm {installer_url} | iex");
-        let status = Command::new("powershell")
-            .args([
-                "-NoProfile",
-                "-ExecutionPolicy",
-                "Bypass",
-                "-Command",
-                &script,
-            ])
-            .status()
+        println!("updating bt from {} channel...", channel.name());
+        let mut child = Command::new("powershell")
+            .args(["-NoProfile", "-ExecutionPolicy", "Bypass", "-Command", "-"])
+            .stdin(Stdio::piped())
+            .spawn()
             .context("failed to execute PowerShell installer")?;
+        if let Some(mut stdin) = child.stdin.take() {
+            stdin
+                .write_all(installer_script.as_bytes())
+                .context("failed to write PowerShell installer script")?;
+        }
+        let status = child
+            .wait()
+            .context("failed to wait for PowerShell installer")?;
         if !status.success() {
             anyhow::bail!("installer exited with status {status}");
         }
@@ -232,6 +235,27 @@ fn run_installer(channel: UpdateChannel) -> Result<()> {
         println!("update completed");
         return Ok(());
     }
+}
+
+async fn fetch_installer_script(base: &BaseArgs, installer_url: &str) -> Result<String> {
+    let client = crate::http::client_builder(base, DEFAULT_HTTP_TIMEOUT)?
+        .user_agent("bt-self-update")
+        .build()
+        .context("failed to initialize installer HTTP client")?;
+    let response = client
+        .get(installer_url)
+        .send()
+        .await
+        .with_context(|| format!("failed to download installer {installer_url}"))?;
+    if !response.status().is_success() {
+        let status = response.status();
+        let body = response.text().await.unwrap_or_default();
+        anyhow::bail!("failed to download installer {installer_url} ({status}): {body}");
+    }
+    response
+        .text()
+        .await
+        .context("failed to read installer script")
 }
 
 fn receipt_path() -> Option<PathBuf> {

--- a/src/setup/docs.rs
+++ b/src/setup/docs.rs
@@ -5,7 +5,6 @@ use std::path::{Path, PathBuf};
 use anyhow::{bail, Context, Result};
 use clap::{Args, Subcommand};
 use regex::Regex;
-use reqwest::Client;
 use serde::Serialize;
 
 use crate::args::BaseArgs;
@@ -117,7 +116,7 @@ async fn run_docs(base: BaseArgs, args: DocsArgs) -> Result<()> {
 
 async fn run_docs_fetch(base: BaseArgs, args: DocsFetchArgs) -> Result<()> {
     let selected_workflows = resolve_workflow_selection(&args.workflows);
-    let fetch_result = fetch_docs_pages(&args, &selected_workflows).await?;
+    let fetch_result = fetch_docs_pages(&base, &args, &selected_workflows).await?;
 
     if base.json {
         let report = DocsFetchJsonReport {
@@ -176,6 +175,7 @@ async fn run_docs_fetch(base: BaseArgs, args: DocsFetchArgs) -> Result<()> {
 }
 
 pub(super) async fn fetch_docs_pages(
+    base: &BaseArgs,
     args: &DocsFetchArgs,
     selected_workflows: &[WorkflowArg],
 ) -> Result<DocsFetchResult> {
@@ -194,8 +194,7 @@ pub(super) async fn fetch_docs_pages(
         Regex::new(r#"(?m)\b(https?://[^\s<>"')]+)"#).context("failed to build URL regex")?;
     let llms_base = reqwest::Url::parse(&args.llms_url)
         .with_context(|| format!("invalid llms URL: {}", args.llms_url))?;
-    let client = Client::builder()
-        .timeout(crate::http::DEFAULT_HTTP_TIMEOUT)
+    let client = crate::http::client_builder(base, crate::http::DEFAULT_HTTP_TIMEOUT)?
         .build()
         .context("failed to build HTTP client")?;
 

--- a/src/setup/mod.rs
+++ b/src/setup/mod.rs
@@ -438,7 +438,7 @@ async fn run_setup_wizard(mut base: BaseArgs, flags: WizardFlags) -> Result<()> 
     }
     let project_flag = base.project.clone();
     let login_ctx = ensure_auth(&mut base).await?;
-    let client = ApiClient::new(&login_ctx)?;
+    let client = ApiClient::new(&base, &login_ctx)?;
     let org = client.org_name().to_string();
     if !quiet {
         eprintln!("   {} Using org '{}'", style("✓").green(), org);
@@ -889,6 +889,7 @@ async fn execute_skills_setup(
         notes.push("Skipped workflow docs prefetch (no workflows selected).".to_string());
     } else {
         prefetch_workflow_docs(
+            &base,
             show_progress,
             scope,
             local_root.as_deref(),
@@ -1026,6 +1027,7 @@ async fn run_instrument_setup(
         });
         notes.push("Skipped skills setup (already configured).".to_string());
         prefetch_workflow_docs(
+            &base,
             show_progress,
             InstallScope::Local,
             Some(&root),
@@ -1388,6 +1390,7 @@ fn skill_config_path(
 
 #[allow(clippy::too_many_arguments)]
 async fn prefetch_workflow_docs(
+    base: &BaseArgs,
     show_progress: bool,
     scope: InstallScope,
     local_root: Option<&Path>,
@@ -1419,11 +1422,11 @@ async fn prefetch_workflow_docs(
     let fetch_result = if show_progress {
         with_spinner(
             "Prefetching workflow docs...",
-            docs::fetch_docs_pages(&docs_args, selected_workflows),
+            docs::fetch_docs_pages(&base, &docs_args, selected_workflows),
         )
         .await
     } else {
-        docs::fetch_docs_pages(&docs_args, selected_workflows).await
+        docs::fetch_docs_pages(&base, &docs_args, selected_workflows).await
     };
     match fetch_result {
         Ok(fetch_result) => {

--- a/src/sql.rs
+++ b/src/sql.rs
@@ -80,7 +80,7 @@ struct RealtimeState {
 
 pub async fn run(base: BaseArgs, args: SqlArgs) -> Result<()> {
     let ctx = login(&base).await?;
-    let client = ApiClient::new(&ctx)?;
+    let client = ApiClient::new(&base, &ctx)?;
     let interactive = !base.json && crate::ui::is_interactive() && !args.non_interactive;
     let query = read_non_interactive_query(&args.query, interactive)?;
 

--- a/src/switch.rs
+++ b/src/switch.rs
@@ -109,7 +109,7 @@ pub async fn run(base: BaseArgs, args: SwitchArgs) -> Result<()> {
     };
 
     let ctx = login(&login_base).await?;
-    let client = ApiClient::new(&ctx)?;
+    let client = ApiClient::new(&login_base, &ctx)?;
     let org_name = client.org_name().to_string();
 
     let project = match resolved_project {
@@ -263,6 +263,7 @@ mod tests {
             no_input: false,
             api_url: None,
             app_url: None,
+            ca_cert: None,
             env_file: None,
         }
     }

--- a/src/sync.rs
+++ b/src/sync.rs
@@ -11,7 +11,6 @@ use anyhow::{anyhow, bail, Context, Result};
 use backoff::future::retry_notify;
 use backoff::{Error as BackoffError, ExponentialBackoffBuilder};
 use base64::prelude::{Engine as _, BASE64_STANDARD};
-use braintrust_sdk_rust::Logs3BatchUploader;
 use clap::{Args, Subcommand, ValueEnum};
 use indicatif::{MultiProgress, ProgressBar, ProgressStyle};
 use serde::de::DeserializeOwned;
@@ -24,6 +23,7 @@ use crate::args::BaseArgs;
 use crate::auth::{login, LoginContext};
 use crate::experiments::api::create_experiment;
 use crate::http::ApiClient;
+use crate::logs3_uploader::Logs3BatchUploader;
 use crate::projects::api::{create_project, list_projects, Project};
 use crate::ui::{animations_enabled, fuzzy_select, is_quiet};
 
@@ -543,13 +543,13 @@ pub async fn run(base: BaseArgs, args: SyncArgs) -> Result<()> {
     match args.command {
         SyncCommand::Pull(pull) => {
             let ctx = login(&base).await?;
-            let client = ApiClient::new(&ctx)?;
+            let client = ApiClient::new(&base, &ctx)?;
             run_pull(base.json, &ctx, &client, project.as_deref(), pull).await
         }
         SyncCommand::Push(push) => {
             let ctx = login(&base).await?;
-            let client = ApiClient::new(&ctx)?;
-            run_push(base.json, &ctx, &client, project.as_deref(), push).await
+            let client = ApiClient::new(&base, &ctx)?;
+            run_push(&base, base.json, &ctx, &client, project.as_deref(), push).await
         }
         SyncCommand::Status(status) => run_status(base.json, status),
     }
@@ -1569,6 +1569,7 @@ async fn process_trace_chunk(
 }
 
 async fn run_push(
+    base: &BaseArgs,
     json_output: bool,
     ctx: &LoginContext,
     client: &ApiClient,
@@ -1697,6 +1698,7 @@ async fn run_push(
     });
 
     let uploader_template = Logs3BatchUploader::new(
+        &base,
         ctx.api_url.clone(),
         ctx.login.api_key.clone(),
         (!ctx.login.org_name.trim().is_empty()).then_some(ctx.login.org_name.clone()),

--- a/src/traces.rs
+++ b/src/traces.rs
@@ -882,7 +882,7 @@ pub async fn run(base: BaseArgs, args: ViewArgs) -> Result<()> {
     let base = apply_url_hints_to_base(base, parsed_startup_url.as_ref());
 
     let ctx = login(&base).await?;
-    let client = ApiClient::new(&ctx)?;
+    let client = ApiClient::new(&base, &ctx)?;
 
     match args.command {
         None => run_logs_command(base, client, LogsArgs::default()).await,
@@ -6068,6 +6068,7 @@ mod tests {
             no_input: false,
             api_url: None,
             app_url: None,
+            ca_cert: None,
             env_file: None,
         }
     }


### PR DESCRIPTION
- thread --ca-cert, BRAINTRUST_CA_CERT, and SSL_CERT_FILE through auth, uploads, docs, eval, self-update, and sync
- preserve oauth fallback and HTTP status behavior while clarifying common flag usage