### PR TITLE
Dotenv not loaded by default

### DIFF
--- a/src/auth.rs
+++ b/src/auth.rs
@@ -784,6 +784,16 @@ async fn run_login_set(base: &BaseArgs, args: AuthLoginArgs) -> Result<()> {
     if args.oauth {
         return run_login_oauth(base, args).await;
     }
+
+    let has_explicit_api_key = base.api_key.as_ref().is_some_and(|k| !k.trim().is_empty());
+    if !has_explicit_api_key && ui::can_prompt() {
+        let methods = ["OAuth (browser)", "API key"];
+        let selected = ui::fuzzy_select("Select login method", &methods, 0)?;
+        if selected == 0 {
+            return run_login_oauth(base, args).await;
+        }
+    }
+
     let interactive = ui::can_prompt();
 
     let api_key = match base.api_key.clone() {

--- a/src/env.rs
+++ b/src/env.rs
@@ -1,6 +1,6 @@
 use std::collections::HashMap;
 use std::ffi::OsString;
-use std::path::{Path, PathBuf};
+use std::path::PathBuf;
 
 use anyhow::{Context, Result};
 
@@ -11,15 +11,14 @@ pub fn bootstrap_from_args(args: &[OsString]) -> Result<()> {
 }
 
 pub fn load_env(explicit_env_file: Option<&PathBuf>) -> Result<()> {
+    let Some(explicit_env_file) = explicit_env_file else {
+        return Ok(());
+    };
     let cwd = std::env::current_dir().context("failed to read current directory")?;
     let env_files = resolve_env_files(&cwd, explicit_env_file);
     let mut loaded = HashMap::new();
 
     for env_file in env_files {
-        if !env_file.exists() && explicit_env_file.is_none() {
-            continue;
-        }
-
         let parsed = dotenvy::from_path_iter(&env_file)
             .with_context(|| format!("failed to read env file {}", env_file.display()))?;
         for item in parsed {
@@ -72,21 +71,11 @@ fn extract_env_file_arg(args: &[OsString]) -> Option<PathBuf> {
     explicit
 }
 
-fn resolve_env_files(cwd: &Path, explicit_env_file: Option<&PathBuf>) -> Vec<PathBuf> {
-    if let Some(path) = explicit_env_file {
-        let full_path = if path.is_absolute() {
-            path.clone()
-        } else {
-            cwd.join(path)
-        };
-        return vec![full_path];
-    }
-
-    let node_env = std::env::var("NODE_ENV").unwrap_or_else(|_| "development".to_string());
-    let mut files = vec![cwd.join(".env"), cwd.join(format!(".env.{node_env}"))];
-    if node_env != "test" {
-        files.push(cwd.join(".env.local"));
-    }
-    files.push(cwd.join(format!(".env.{node_env}.local")));
-    files
+fn resolve_env_files(cwd: &std::path::Path, explicit_env_file: &PathBuf) -> Vec<PathBuf> {
+    let full_path = if explicit_env_file.is_absolute() {
+        explicit_env_file.clone()
+    } else {
+        cwd.join(explicit_env_file)
+    };
+    vec![full_path]
 }

--- a/src/switch.rs
+++ b/src/switch.rs
@@ -54,6 +54,10 @@ pub async fn run(base: BaseArgs, args: SwitchArgs) -> Result<()> {
     let current_cfg = config::load().unwrap_or_default();
     let (resolved_org, resolved_project) = args.resolve_target(&base);
     let mut interactive = false;
+    let has_api_key_override = base
+        .api_key
+        .as_ref()
+        .is_some_and(|value| !value.trim().is_empty());
 
     let profile_name = match &resolved_org {
         Some(org_or_profile) => {
@@ -64,14 +68,13 @@ pub async fn run(base: BaseArgs, args: SwitchArgs) -> Result<()> {
                 Some(auth::resolve_org_to_profile(org_or_profile, &profiles)?)
             }
         }
-        None => {
-            if resolved_project.is_none() && is_interactive() {
-                interactive = true;
-                auth::select_profile_interactive(current_cfg.org.as_deref())?
-            } else {
-                None
-            }
-        }
+        None => resolve_profile_for_switch(
+            has_api_key_override,
+            resolved_project.is_none(),
+            is_interactive(),
+            || auth::select_profile_interactive(current_cfg.org.as_deref()),
+            &mut interactive,
+        )?,
     };
 
     // When we resolved a profile from an org identifier, clear org_name — the raw identifier
@@ -88,10 +91,10 @@ pub async fn run(base: BaseArgs, args: SwitchArgs) -> Result<()> {
         },
         _ => {
             let mut b = base.clone();
-            if b.org_name.is_none() && b.profile.is_none() {
+            if !has_api_key_override && b.org_name.is_none() && b.profile.is_none() {
                 b.org_name = current_cfg.org.clone();
             }
-            if b.org_name.is_none() && b.profile.is_none() {
+            if !has_api_key_override && b.org_name.is_none() && b.profile.is_none() {
                 let profiles = auth::list_profiles()?;
                 if profiles.len() > 1 {
                     let names: Vec<&str> = profiles.iter().map(|p| p.name.as_str()).collect();
@@ -230,6 +233,31 @@ fn apply_switch_config(cfg: &mut config::Config, org_name: &str, project: &api::
     cfg.org = Some(org_name.to_string());
     cfg.project = Some(project.name.clone());
     cfg.project_id = Some(project.id.clone());
+}
+
+fn resolve_profile_for_switch<F>(
+    has_api_key_override: bool,
+    prompting_for_project_only: bool,
+    is_interactive: bool,
+    select_profile_interactive: F,
+    interactive: &mut bool,
+) -> Result<Option<String>>
+where
+    F: FnOnce() -> Result<Option<String>>,
+{
+    if has_api_key_override {
+        if prompting_for_project_only && is_interactive {
+            *interactive = true;
+        }
+        return Ok(None);
+    }
+
+    if prompting_for_project_only && is_interactive {
+        *interactive = true;
+        select_profile_interactive()
+    } else {
+        Ok(None)
+    }
 }
 
 #[cfg(test)]
@@ -478,5 +506,53 @@ mod tests {
         assert_eq!(cfg.org.as_deref(), Some("acme-org"));
         assert_eq!(cfg.project.as_deref(), Some("my-project"));
         assert_eq!(cfg.project_id.as_deref(), Some("proj_123"));
+    }
+
+    #[test]
+    fn resolve_profile_for_switch_skips_org_prompt_when_api_key_infers_profile() {
+        let mut interactive = false;
+        let profile = resolve_profile_for_switch(
+            true,
+            true,
+            true,
+            || panic!("org picker should not be called"),
+            &mut interactive,
+        )
+        .expect("resolve");
+
+        assert_eq!(profile, None);
+        assert!(interactive);
+    }
+
+    #[test]
+    fn resolve_profile_for_switch_prompts_when_no_inferred_profile() {
+        let mut interactive = false;
+        let profile = resolve_profile_for_switch(
+            false,
+            true,
+            true,
+            || Ok(Some("picked-profile".to_string())),
+            &mut interactive,
+        )
+        .expect("resolve");
+
+        assert_eq!(profile.as_deref(), Some("picked-profile"));
+        assert!(interactive);
+    }
+
+    #[test]
+    fn resolve_profile_for_switch_skips_org_prompt_when_api_key_override_has_no_profile_match() {
+        let mut interactive = false;
+        let profile = resolve_profile_for_switch(
+            true,
+            true,
+            true,
+            || panic!("org picker should not be called"),
+            &mut interactive,
+        )
+        .expect("resolve");
+
+        assert_eq!(profile, None);
+        assert!(interactive);
     }
 }

--- a/tests/evals/js/env-default/env-default.eval.ts
+++ b/tests/evals/js/env-default/env-default.eval.ts
@@ -1,21 +1,16 @@
 import { Eval } from "braintrust";
 
-const EXPECTED = "from-dotenv-development-local";
-
 Eval("BT CLI Env Default", {
   evalName: "env-default",
-  data: () => [{ input: null, expected: EXPECTED }],
+  data: () => [{ input: null }],
   task: () => {
     const value = process.env.BT_FIXTURE_ENV_ORDER;
-    if (value !== EXPECTED) {
-      throw new Error(
-        `BT_FIXTURE_ENV_ORDER expected ${EXPECTED}, got ${value ?? "<missing>"}`,
-      );
+    if (value !== undefined) {
+      throw new Error(`BT_FIXTURE_ENV_ORDER expected <missing>, got ${value}`);
     }
-    return value;
+    return "<missing>";
   },
   scores: [
-    ({ output, expected }: { output: string; expected: string }) =>
-      output === expected ? 1 : 0,
+    ({ output }: { output: string }) => (output === "<missing>" ? 1 : 0),
   ],
 });


### PR DESCRIPTION
2 bug fixes:
auth-related bt commands (bt auth, bt switch for example) now require explicit --env-file or BRAINTRUST_ENV_FILE to look at .env files

OAuth login was no longer an option in `bt auth login` since b02d8b82e5eef8b3afd740cad6be19ea5eace81f