### PR TITLE
Inform user API key is created during bt setup

### DIFF
--- a/src/setup/mod.rs
+++ b/src/setup/mod.rs
@@ -1625,7 +1625,8 @@ async fn maybe_create_api_key_for_oauth(base: &BaseArgs, client: &ApiClient) -> 
     let body = serde_json::json!({ "name": name, "org_name": client.org_name() });
     let created: CreatedKey = client.post("/v1/api_key", &body).await?;
 
-    if std::io::stderr().is_terminal() && base.verbose {
+    let explicitly_quiet = base.quiet && base.quiet_source.is_some();
+    if std::io::stderr().is_terminal() && !explicitly_quiet {
         eprintln!();
         eprintln!(
             "{} Created Braintrust API key '{}' for instrumentation and exported it to this setup process:",


### PR DESCRIPTION
Users who don't have an API key in their env (for example new users) need one to run the instrumented code.
So after OAuth login, when needed, an API key is created.
However it wasn't shown to the user unless `bt setup` was run with the `-v/--verbose` flag.
Now this is printed unless `-q/--quiet` is passed.
```
! Created Braintrust API key 'cedric@braintrustdata.com-created-by-bt-setup34' for instrumentation and exported it to this setup process:

   sk-...

   To reuse it later in your shell, run:
   export BRAINTRUST_API_KEY=sk-...
```