### PR TITLE
Fix progress visualization for evals

### DIFF
--- a/scripts/eval-runner.py
+++ b/scripts/eval-runner.py
@@ -730,20 +730,115 @@ def infer_data_total(data: Any) -> int | None:
     return None
 
 
+def normalize_trial_count(value: Any) -> int:
+    try:
+        trial_count = int(value)
+    except Exception:
+        trial_count = 1
+    if trial_count < 1:
+        trial_count = 1
+    return trial_count
+
+
 def infer_evaluator_total(evaluator: Any) -> int | None:
     data_total = infer_data_total(getattr(evaluator, "data", None))
     if data_total is None:
         return None
 
-    trial_count = getattr(evaluator, "trial_count", 1)
-    try:
-        trial_count = int(trial_count)
-    except Exception:
-        trial_count = 1
-    if trial_count < 1:
-        trial_count = 1
+    trial_count = normalize_trial_count(getattr(evaluator, "trial_count", 1))
 
     return data_total * trial_count
+
+
+def wrap_data_with_adaptive_total(
+    data: Any,
+    progress_cb: Callable[[str, int | None], None] | None,
+    trial_count: int,
+    state: dict[str, int] | None = None,
+) -> Any:
+    if progress_cb is None:
+        return data
+    if state is None:
+        state = {"rows_seen": 0, "last_total": 0}
+
+    def report_rows_seen() -> None:
+        rows_seen = state["rows_seen"]
+        if rows_seen <= 0:
+            return
+        total = rows_seen * trial_count
+        if total <= state["last_total"]:
+            return
+        state["last_total"] = total
+        progress_cb("set_total", total)
+
+    if inspect.isclass(data):
+        return data
+
+    if inspect.isroutine(data):
+        def wrapped_data(*args, **kwargs):
+            resolved = data(*args, **kwargs)
+            return wrap_data_with_adaptive_total(
+                resolved,
+                progress_cb,
+                trial_count,
+                state,
+            )
+
+        if hasattr(data, "__name__"):
+            setattr(wrapped_data, "__name__", getattr(data, "__name__"))
+        if hasattr(data, "__qualname__"):
+            setattr(wrapped_data, "__qualname__", getattr(data, "__qualname__"))
+        return wrapped_data
+
+    if inspect.isawaitable(data):
+        async def wrapped_awaitable():
+            resolved = await data
+            return wrap_data_with_adaptive_total(
+                resolved,
+                progress_cb,
+                trial_count,
+                state,
+            )
+
+        return wrapped_awaitable()
+
+    if inspect.isasyncgen(data) or hasattr(data, "__aiter__"):
+        async def wrapped_async_iter():
+            async for item in data:
+                state["rows_seen"] += 1
+                report_rows_seen()
+                yield item
+
+        return wrapped_async_iter()
+
+    if inspect.isgenerator(data):
+        async def wrapped_iter():
+            for item in data:
+                state["rows_seen"] += 1
+                report_rows_seen()
+                yield item
+                # Let scheduled eval tasks make progress while we keep ingesting rows.
+                await asyncio.sleep(0)
+
+        return wrapped_iter()
+
+    if isinstance(data, (str, bytes, dict)):
+        return data
+
+    try:
+        iterator = iter(data)
+    except Exception:
+        return data
+
+    async def wrapped_iterable():
+        for item in iterator:
+            state["rows_seen"] += 1
+            report_rows_seen()
+            yield item
+            # Avoid starving task execution while iterating synchronous data sources.
+            await asyncio.sleep(0)
+
+    return wrapped_iterable()
 
 
 def wrap_task(
@@ -826,7 +921,15 @@ async def run_evaluator_task(
     supports_stream = run_evaluator_supports_stream()
 
     if fallback_progress:
-        progress_cb("start", infer_evaluator_total(evaluator))
+        inferred_total = infer_evaluator_total(evaluator)
+        progress_cb("start", inferred_total)
+        if inferred_total is None:
+            trial_count = normalize_trial_count(getattr(evaluator, "trial_count", 1))
+            evaluator.data = wrap_data_with_adaptive_total(
+                evaluator.data,
+                progress_cb,
+                trial_count,
+            )
 
     evaluator.task = wrap_task(
         original_task,

--- a/scripts/eval-runner.py
+++ b/scripts/eval-runner.py
@@ -759,17 +759,29 @@ def wrap_data_with_adaptive_total(
     if progress_cb is None:
         return data
     if state is None:
-        state = {"rows_seen": 0, "last_total": 0}
+        state = {"rows_seen": 0, "last_emitted_total": 0}
 
     def report_rows_seen() -> None:
         rows_seen = state["rows_seen"]
         if rows_seen <= 0:
             return
         total = rows_seen * trial_count
-        if total <= state["last_total"]:
+        if total <= state["last_emitted_total"]:
             return
-        state["last_total"] = total
+        state["last_emitted_total"] = total
         progress_cb("set_total", total)
+
+    def maybe_report_empty_total(exhausted: bool) -> None:
+        # Unknown-total evaluators that exhaust without yielding should still
+        # emit an explicit total of 0. The renderer decides whether that
+        # threshold is shown as spinner or determinate progress.
+        if not exhausted:
+            return
+        if state["rows_seen"] != 0:
+            return
+        if state["last_emitted_total"] != 0:
+            return
+        progress_cb("set_total", 0)
 
     if inspect.isclass(data):
         return data
@@ -804,21 +816,31 @@ def wrap_data_with_adaptive_total(
 
     if inspect.isasyncgen(data) or hasattr(data, "__aiter__"):
         async def wrapped_async_iter():
-            async for item in data:
-                state["rows_seen"] += 1
-                report_rows_seen()
-                yield item
+            exhausted = False
+            try:
+                async for item in data:
+                    state["rows_seen"] += 1
+                    report_rows_seen()
+                    yield item
+                exhausted = True
+            finally:
+                maybe_report_empty_total(exhausted)
 
         return wrapped_async_iter()
 
     if inspect.isgenerator(data):
         async def wrapped_iter():
-            for item in data:
-                state["rows_seen"] += 1
-                report_rows_seen()
-                yield item
-                # Let scheduled eval tasks make progress while we keep ingesting rows.
-                await asyncio.sleep(0)
+            exhausted = False
+            try:
+                for item in data:
+                    state["rows_seen"] += 1
+                    report_rows_seen()
+                    yield item
+                    # Let scheduled eval tasks make progress while we keep ingesting rows.
+                    await asyncio.sleep(0)
+                exhausted = True
+            finally:
+                maybe_report_empty_total(exhausted)
 
         return wrapped_iter()
 
@@ -831,12 +853,17 @@ def wrap_data_with_adaptive_total(
         return data
 
     async def wrapped_iterable():
-        for item in iterator:
-            state["rows_seen"] += 1
-            report_rows_seen()
-            yield item
-            # Avoid starving task execution while iterating synchronous data sources.
-            await asyncio.sleep(0)
+        exhausted = False
+        try:
+            for item in iterator:
+                state["rows_seen"] += 1
+                report_rows_seen()
+                yield item
+                # Avoid starving task execution while iterating synchronous data sources.
+                await asyncio.sleep(0)
+            exhausted = True
+        finally:
+            maybe_report_empty_total(exhausted)
 
     return wrapped_iterable()
 

--- a/src/eval.rs
+++ b/src/eval.rs
@@ -60,6 +60,7 @@ const SSE_SOCKET_BIND_MAX_ATTEMPTS: u8 = 16;
 const EVAL_NODE_MAX_OLD_SPACE_SIZE_MB: usize = 8192;
 const MAX_DEFERRED_EVAL_ERRORS: usize = 8;
 const DEFAULT_EVAL_SAMPLE_SEED: u64 = 0;
+const EVAL_SPINNER_TICK_STRINGS: &[&str] = &["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏", " "];
 
 fn parse_positive_usize(value: &str) -> std::result::Result<usize, String> {
     let parsed = value
@@ -2838,7 +2839,10 @@ impl EvalUi {
         let bar_style =
             ProgressStyle::with_template("{bar:10.blue} {msg} {percent}% {pos}/{len} {eta}")
                 .unwrap();
-        let spinner_style = ProgressStyle::with_template("{spinner} {msg}").unwrap();
+        let spinner_style = ProgressStyle::default_spinner()
+            .tick_strings(EVAL_SPINNER_TICK_STRINGS)
+            .template("{spinner:.cyan} {msg}")
+            .unwrap();
         Self {
             progress,
             bars: HashMap::new(),
@@ -2943,11 +2947,17 @@ impl EvalUi {
                     } else {
                         let bar = self.progress.add(ProgressBar::new_spinner());
                         bar.set_style(self.spinner_style.clone());
+                        if std::io::stderr().is_terminal() && animations_enabled() && !is_quiet() {
+                            bar.enable_steady_tick(Duration::from_millis(80));
+                        }
                         bar
                     }
                 } else {
                     let bar = self.progress.add(ProgressBar::new_spinner());
                     bar.set_style(self.spinner_style.clone());
+                    if std::io::stderr().is_terminal() && animations_enabled() && !is_quiet() {
+                        bar.enable_steady_tick(Duration::from_millis(80));
+                    }
                     bar
                 };
                 bar.set_message(fit_name_to_spaces(&progress.name, MAX_NAME_LENGTH));
@@ -2955,13 +2965,16 @@ impl EvalUi {
             }
             "increment" => {
                 if let Some(bar) = self.bars.get(&progress.name) {
-                    bar.inc(1);
+                    if bar.length().is_some() {
+                        bar.inc(1);
+                    }
                     bar.set_message(fit_name_to_spaces(&progress.name, MAX_NAME_LENGTH));
                 }
             }
             "set_total" => {
                 if let Some(bar) = self.bars.get(&progress.name) {
                     if let Some(total) = payload.total {
+                        bar.disable_steady_tick();
                         bar.set_length(total);
                         bar.set_style(self.bar_style.clone());
                     }

--- a/src/eval.rs
+++ b/src/eval.rs
@@ -61,6 +61,16 @@ const EVAL_NODE_MAX_OLD_SPACE_SIZE_MB: usize = 8192;
 const MAX_DEFERRED_EVAL_ERRORS: usize = 8;
 const DEFAULT_EVAL_SAMPLE_SEED: u64 = 0;
 const EVAL_SPINNER_TICK_STRINGS: &[&str] = &["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏", " "];
+// UI-only smoothing knobs for adaptive totals.
+// We intentionally smooth in the CLI renderer (not the runner protocol) so
+// non-CLI consumers still receive truthful progress events.
+// `EVAL_TOTAL_SMOOTH_INTERVAL` roughly matches perceptible terminal updates.
+// `EVAL_TOTAL_SMOOTH_DELTA_DIVISOR` + `EVAL_TOTAL_SMOOTH_MIN_STEP` avoid redrawing
+// for tiny len changes while still applying meaningful jumps immediately.
+const EVAL_TOTAL_SMOOTH_INTERVAL: Duration = Duration::from_millis(100);
+const EVAL_TOTAL_SMOOTH_DELTA_DIVISOR: u64 = 50;
+const EVAL_TOTAL_SMOOTH_MIN_STEP: u64 = 2;
+const EVAL_MIN_DETERMINATE_TOTAL: u64 = 2;
 
 fn parse_positive_usize(value: &str) -> std::result::Result<usize, String> {
     let parsed = value
@@ -2816,7 +2826,7 @@ fn handle_sse_event(event: Option<String>, data: String, tx: &mpsc::UnboundedSen
 
 struct EvalUi {
     progress: MultiProgress,
-    bars: HashMap<String, ProgressBar>,
+    bars: HashMap<String, EvalBarState>,
     bar_style: ProgressStyle,
     spinner_style: ProgressStyle,
     jsonl: bool,
@@ -2825,6 +2835,12 @@ struct EvalUi {
     deferred_errors: Vec<String>,
     suppressed_stderr_lines: usize,
     finished: bool,
+}
+
+struct EvalBarState {
+    bar: ProgressBar,
+    pending_total: Option<u64>,
+    last_total_update: Option<std::time::Instant>,
 }
 
 impl EvalUi {
@@ -2861,8 +2877,8 @@ impl EvalUi {
         if self.finished {
             return;
         }
-        for (_, bar) in self.bars.drain() {
-            bar.finish_and_clear();
+        for (_, state) in self.bars.drain() {
+            state.bar.finish_and_clear();
         }
         let _ = self.progress.clear();
         self.progress.set_draw_target(ProgressDrawTarget::hidden());
@@ -2940,7 +2956,7 @@ impl EvalUi {
         match payload.kind.as_str() {
             "start" => {
                 let bar = if let Some(total) = payload.total {
-                    if total > 0 {
+                    if total >= EVAL_MIN_DETERMINATE_TOTAL {
                         let bar = self.progress.add(ProgressBar::new(total));
                         bar.set_style(self.bar_style.clone());
                         bar
@@ -2961,31 +2977,112 @@ impl EvalUi {
                     bar
                 };
                 bar.set_message(fit_name_to_spaces(&progress.name, MAX_NAME_LENGTH));
-                self.bars.insert(progress.name.clone(), bar);
+                let last_total_update = if bar.length().is_some() {
+                    Some(std::time::Instant::now())
+                } else {
+                    None
+                };
+                self.bars.insert(
+                    progress.name.clone(),
+                    EvalBarState {
+                        bar,
+                        pending_total: None,
+                        last_total_update,
+                    },
+                );
             }
             "increment" => {
-                if let Some(bar) = self.bars.get(&progress.name) {
-                    if bar.length().is_some() {
-                        bar.inc(1);
-                    }
-                    bar.set_message(fit_name_to_spaces(&progress.name, MAX_NAME_LENGTH));
+                if let Some(state) = self.bars.get_mut(&progress.name) {
+                    state.bar.inc(1);
+                    state
+                        .bar
+                        .set_message(fit_name_to_spaces(&progress.name, MAX_NAME_LENGTH));
+                    Self::ensure_total_not_below_position(state, &self.bar_style);
+                    Self::maybe_apply_pending_total(state, &self.bar_style, false);
                 }
             }
             "set_total" => {
-                if let Some(bar) = self.bars.get(&progress.name) {
+                if let Some(state) = self.bars.get_mut(&progress.name) {
                     if let Some(total) = payload.total {
-                        bar.disable_steady_tick();
-                        bar.set_length(total);
-                        bar.set_style(self.bar_style.clone());
+                        let target = total.max(state.bar.position());
+                        state.pending_total = Some(
+                            state
+                                .pending_total
+                                .map_or(target, |pending| pending.max(target)),
+                        );
+                        let force_apply = state.bar.length().is_none();
+                        Self::maybe_apply_pending_total(state, &self.bar_style, force_apply);
                     }
                 }
             }
             "stop" => {
-                if let Some(bar) = self.bars.remove(&progress.name) {
-                    bar.finish_and_clear();
+                if let Some(mut state) = self.bars.remove(&progress.name) {
+                    Self::maybe_apply_pending_total(&mut state, &self.bar_style, true);
+                    state.bar.finish_and_clear();
                 }
             }
             _ => {}
+        }
+    }
+
+    fn min_total_update_step(current_total: u64) -> u64 {
+        EVAL_TOTAL_SMOOTH_MIN_STEP.max(current_total / EVAL_TOTAL_SMOOTH_DELTA_DIVISOR)
+    }
+
+    fn should_apply_total_update(state: &EvalBarState, target_total: u64) -> bool {
+        let current_total = state.bar.length().unwrap_or(0);
+        if current_total == 0 {
+            return true;
+        }
+        let delta = target_total.saturating_sub(current_total);
+        if delta >= Self::min_total_update_step(current_total) {
+            return true;
+        }
+        state
+            .last_total_update
+            .map(|instant| instant.elapsed() >= EVAL_TOTAL_SMOOTH_INTERVAL)
+            .unwrap_or(true)
+    }
+
+    fn apply_total_update(state: &mut EvalBarState, style: &ProgressStyle, total: u64) {
+        let clamped = total.max(state.bar.position());
+        state.bar.disable_steady_tick();
+        state.bar.set_length(clamped);
+        state.bar.set_style(style.clone());
+        state.last_total_update = Some(std::time::Instant::now());
+    }
+
+    fn maybe_apply_pending_total(state: &mut EvalBarState, style: &ProgressStyle, force: bool) {
+        let mut target_total = match state.pending_total {
+            Some(total) => total,
+            None => return,
+        };
+
+        target_total = target_total.max(state.bar.position());
+        if state.bar.length().is_none() && target_total < EVAL_MIN_DETERMINATE_TOTAL {
+            return;
+        }
+        let current_total = state.bar.length().unwrap_or(0);
+        if target_total <= current_total {
+            state.pending_total = None;
+            return;
+        }
+
+        if force || Self::should_apply_total_update(state, target_total) {
+            Self::apply_total_update(state, style, target_total);
+            state.pending_total = None;
+        }
+    }
+
+    fn ensure_total_not_below_position(state: &mut EvalBarState, style: &ProgressStyle) {
+        if let Some(total) = state.bar.length() {
+            let position = state.bar.position();
+            if position > total {
+                Self::apply_total_update(state, style, position);
+                if let Some(pending_total) = state.pending_total {
+                    state.pending_total = Some(pending_total.max(position));
+                }
+            }
         }
     }
 
@@ -3600,6 +3697,24 @@ mod tests {
         ));
         fs::create_dir_all(&path).expect("create temp dir");
         path
+    }
+
+    fn eval_progress_event(name: &str, kind: &str, total: Option<u64>) -> SseProgressEventData {
+        SseProgressEventData {
+            id: format!("id-{kind}"),
+            object_type: "task".to_string(),
+            origin: None,
+            format: "global".to_string(),
+            output_type: "any".to_string(),
+            name: name.to_string(),
+            event: "progress".to_string(),
+            data: serde_json::json!({
+                "type": "eval_progress",
+                "kind": kind,
+                "total": total,
+            })
+            .to_string(),
+        }
     }
 
     #[test]
@@ -4235,6 +4350,78 @@ mod tests {
         let encoded = encode_eval_event_for_http(&event).expect("progress should be forwarded");
         assert!(encoded.contains("event: progress"));
         assert!(encoded.contains("json_delta"));
+    }
+
+    #[test]
+    fn eval_ui_preserves_spinner_increments_before_set_total() {
+        let mut ui = EvalUi::new(false, false, false);
+        let eval_name = "My evaluation";
+
+        ui.handle_progress(eval_progress_event(eval_name, "start", None));
+        ui.handle_progress(eval_progress_event(eval_name, "increment", None));
+        ui.handle_progress(eval_progress_event(eval_name, "increment", None));
+        ui.handle_progress(eval_progress_event(eval_name, "set_total", Some(10)));
+
+        let bar = ui
+            .bars
+            .get(eval_name)
+            .expect("progress bar should still exist");
+        assert_eq!(bar.bar.position(), 2);
+        assert_eq!(bar.bar.length(), Some(10));
+
+        ui.finish();
+    }
+
+    #[test]
+    fn eval_ui_never_sets_total_below_position() {
+        let mut ui = EvalUi::new(false, false, false);
+        let eval_name = "My evaluation";
+
+        ui.handle_progress(eval_progress_event(eval_name, "start", Some(1)));
+        ui.handle_progress(eval_progress_event(eval_name, "increment", None));
+        ui.handle_progress(eval_progress_event(eval_name, "increment", None));
+        ui.handle_progress(eval_progress_event(eval_name, "set_total", Some(1)));
+
+        let bar = ui
+            .bars
+            .get(eval_name)
+            .expect("progress bar should still exist");
+        assert!(
+            bar.bar
+                .length()
+                .expect("determinate bar should have a total")
+                >= bar.bar.position()
+        );
+
+        ui.finish();
+    }
+
+    #[test]
+    fn eval_ui_keeps_spinner_until_total_exceeds_one() {
+        let mut ui = EvalUi::new(false, false, false);
+        let eval_name = "My evaluation";
+
+        ui.handle_progress(eval_progress_event(eval_name, "start", None));
+        ui.handle_progress(eval_progress_event(eval_name, "set_total", Some(1)));
+
+        let bar = ui
+            .bars
+            .get(eval_name)
+            .expect("progress bar should still exist");
+        assert_eq!(bar.bar.length(), None, "total=1 should remain spinner mode");
+
+        ui.handle_progress(eval_progress_event(eval_name, "set_total", Some(2)));
+        let bar = ui
+            .bars
+            .get(eval_name)
+            .expect("progress bar should still exist");
+        assert_eq!(
+            bar.bar.length(),
+            Some(2),
+            "total>1 should become determinate"
+        );
+
+        ui.finish();
     }
 
     #[test]


### PR DESCRIPTION
### TL;DR

Adds adaptive progress tracking for evaluators with unknown dataset sizes, smoothing total updates in the CLI renderer to avoid flickering.

### What changed?

When an evaluator's `data` source has no known length upfront, the runner now wraps it with `wrap_data_with_adaptive_total`, which intercepts each yielded row and emits `set_total` progress events as rows are discovered. This works across all data source types: sync iterables, generators, async generators, async iterables, callables, and awaitables.

On the CLI renderer side, `EvalBarState` replaces the raw `ProgressBar` in the bars map, carrying a `pending_total` and `last_total_update` timestamp. Incoming `set_total` events are buffered and applied only when the delta is large enough or enough time has elapsed, preventing rapid redraws as the total grows row-by-row. The bar stays in spinner mode until the total reaches at least 2, avoiding a determinate bar that immediately completes for single-item datasets. The total is also clamped so it can never fall below the current position.

`trial_count` normalization is extracted into a shared `normalize_trial_count` helper used by both `infer_evaluator_total` and the new adaptive wrapping path.

### How to test?

- Run an eval against a dataset defined as a generator or other lazy iterable with no `__len__`. Confirm the progress bar starts as a spinner and transitions to a determinate bar as rows are consumed.
- Run an eval with a known-length dataset and confirm the progress bar behaves as before.
- Run an eval with a single-row dataset and confirm it stays in spinner mode rather than flashing a 1/1 determinate bar.
- The three new unit tests cover: spinner increments preserved before `set_total`, total never set below position, and spinner held until total exceeds 1.

### Why make this change?

Previously, evaluators backed by generators or other length-unknown data sources showed no progress indication beyond a static spinner with no total. By streaming row counts back through the progress protocol as data is consumed, the CLI can display a meaningful and smoothly updating progress bar without requiring evaluator authors to pre-compute dataset sizes.