### PR TITLE
Bundle Braintrust SDK into JS and Python function archives by default

### DIFF
--- a/scripts/functions-bundler.ts
+++ b/scripts/functions-bundler.ts
@@ -41,9 +41,7 @@ function loadTsconfigPath(): string | undefined {
 
 function buildExternalPackagePatterns(additionalPackages: string[]): string[] {
   const knownPackages = [
-    "braintrust",
-    "autoevals",
-    "@braintrust/",
+    // Keep compatibility externals that are commonly optional/native.
     "config",
     "lightningcss",
     "@mapbox/node-pre-gyp",

--- a/src/functions/mod.rs
+++ b/src/functions/mod.rs
@@ -319,6 +319,7 @@ pub(crate) struct PushArgs {
     pub tsconfig: Option<PathBuf>,
 
     /// Additional packages to mark external during JS bundling.
+    /// SDK dependencies (for example `braintrust`) are bundled by default.
     #[arg(
         long = "external-packages",
         env = "BT_FUNCTIONS_PUSH_EXTERNAL_PACKAGES",

--- a/src/functions/push.rs
+++ b/src/functions/push.rs
@@ -1633,6 +1633,8 @@ fn build_python_bundle_archive(
         baseline_dep_versions,
         python_version,
     )?;
+    ensure_python_package_staged(&pkg_dir, &python, "braintrust")
+        .context("failed to stage required Python package 'braintrust'")?;
 
     let stage_dir = build_dir.path.join("stage");
     std::fs::create_dir_all(&stage_dir)
@@ -1865,6 +1867,100 @@ fn install_python_dependencies(
     }
 
     Ok(())
+}
+
+fn ensure_python_package_staged(pkg_dir: &Path, python: &Path, package_name: &str) -> Result<()> {
+    if python_package_staged(pkg_dir, package_name) {
+        return Ok(());
+    }
+
+    vendor_python_package_from_interpreter(pkg_dir, python, package_name)?;
+
+    if python_package_staged(pkg_dir, package_name) {
+        return Ok(());
+    }
+
+    bail!(
+        "python bundle staging is missing required package '{}' under {}",
+        package_name,
+        pkg_dir.display()
+    );
+}
+
+fn python_package_staged(pkg_dir: &Path, package_name: &str) -> bool {
+    pkg_dir.join(package_name).is_dir() || pkg_dir.join(format!("{package_name}.py")).is_file()
+}
+
+fn vendor_python_package_from_interpreter(
+    pkg_dir: &Path,
+    python: &Path,
+    package_name: &str,
+) -> Result<()> {
+    const VENDOR_PACKAGE_SCRIPT: &str = r#"import importlib
+import pathlib
+import shutil
+import sys
+
+target_root = pathlib.Path(sys.argv[1])
+package_name = sys.argv[2]
+module = importlib.import_module(package_name)
+module_file = getattr(module, "__file__", None)
+if not module_file:
+    raise RuntimeError(f"package {package_name!r} has no __file__")
+source = pathlib.Path(module_file).resolve()
+
+if source.name == "__init__.py":
+    src_dir = source.parent
+    dest = target_root / package_name
+    if dest.exists():
+        if dest.is_dir():
+            shutil.rmtree(dest)
+        else:
+            dest.unlink()
+    shutil.copytree(src_dir, dest)
+else:
+    dest = target_root / f"{package_name}.py"
+    dest.parent.mkdir(parents=True, exist_ok=True)
+    shutil.copy2(source, dest)
+"#;
+
+    let output = Command::new(python)
+        .arg("-c")
+        .arg(VENDOR_PACKAGE_SCRIPT)
+        .arg(pkg_dir)
+        .arg(package_name)
+        .output()
+        .with_context(|| {
+            format!(
+                "failed to spawn Python package vendor helper for '{}'",
+                package_name
+            )
+        })?;
+    if output.status.success() {
+        return Ok(());
+    }
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    let excerpt = stderr
+        .lines()
+        .take(20)
+        .collect::<Vec<_>>()
+        .join("\n")
+        .trim()
+        .to_string();
+    if excerpt.is_empty() {
+        bail!(
+            "Python package vendor helper failed with status {} for '{}'",
+            output.status,
+            package_name
+        );
+    }
+    bail!(
+        "Python package vendor helper failed with status {} for '{}': {}",
+        output.status,
+        package_name,
+        excerpt
+    );
 }
 
 fn run_uv_command(uv: &Path, args: &[OsString], stage: &str) -> Result<()> {
@@ -3331,6 +3427,32 @@ mod tests {
 
         assert_eq!(value["type"], "code");
         assert!(value["data"].get("preview").is_none());
+    }
+
+    #[test]
+    fn python_package_staged_detects_module_files_and_directories() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let pkg_dir = dir.path();
+
+        assert!(
+            !python_package_staged(pkg_dir, "braintrust"),
+            "package should be missing initially"
+        );
+
+        let package_dir = pkg_dir.join("braintrust");
+        std::fs::create_dir_all(&package_dir).expect("create package dir");
+        std::fs::write(package_dir.join("__init__.py"), "").expect("write __init__");
+        assert!(
+            python_package_staged(pkg_dir, "braintrust"),
+            "package directory should be detected"
+        );
+
+        std::fs::remove_dir_all(&package_dir).expect("remove package dir");
+        std::fs::write(pkg_dir.join("braintrust.py"), "VALUE = 1\n").expect("write module file");
+        assert!(
+            python_package_staged(pkg_dir, "braintrust"),
+            "single-file module should be detected"
+        );
     }
 
     #[test]

--- a/src/functions/push.rs
+++ b/src/functions/push.rs
@@ -3456,6 +3456,25 @@ mod tests {
     }
 
     #[test]
+    fn ensure_python_package_staged_can_vendor_stdlib_package() {
+        let Some(python) = crate::python_runner::resolve_python_interpreter(None, &[]) else {
+            eprintln!(
+                "Skipping ensure_python_package_staged_can_vendor_stdlib_package (python not installed)."
+            );
+            return;
+        };
+
+        let dir = tempfile::tempdir().expect("tempdir");
+        let pkg_dir = dir.path();
+        ensure_python_package_staged(pkg_dir, &python, "json")
+            .expect("should vendor stdlib package from interpreter");
+        assert!(
+            python_package_staged(pkg_dir, "json"),
+            "json package should be staged after vendor fallback"
+        );
+    }
+
+    #[test]
     fn js_bundler_defaults_do_not_externalize_braintrust_sdk() {
         assert!(
             !FUNCTIONS_JS_BUNDLER_SOURCE.contains("\"braintrust\"")

--- a/src/functions/push.rs
+++ b/src/functions/push.rs
@@ -3334,6 +3334,16 @@ mod tests {
     }
 
     #[test]
+    fn js_bundler_defaults_do_not_externalize_braintrust_sdk() {
+        assert!(
+            !FUNCTIONS_JS_BUNDLER_SOURCE.contains("\"braintrust\"")
+                && !FUNCTIONS_JS_BUNDLER_SOURCE.contains("\"autoevals\"")
+                && !FUNCTIONS_JS_BUNDLER_SOURCE.contains("\"@braintrust/\""),
+            "default JS bundler externals must not include Braintrust SDK packages"
+        );
+    }
+
+    #[test]
     fn uv_install_args_include_selected_python() {
         let pkg_dir = PathBuf::from("/tmp/pkg");
         let python = PathBuf::from("/tmp/custom-python");


### PR DESCRIPTION
## Summary
Fixes: https://github.com/braintrustdata/braintrust-sdk-javascript/issues/1865

This PR fixes function bundle runtime dependency issues that caused deployed invocations to fail with missing SDK modules.

### JS/TS
- Stop externalizing Braintrust SDK packages by default in `functions-bundler.ts`.
- Keep `--external-packages` as explicit opt-in externalization.
- Update CLI help text to clarify SDK deps are bundled by default.
- Add regression test to prevent reintroducing default externalization of:
  - `braintrust`
  - `autoevals`
  - `@braintrust/*`

### Python
- Add a staging safeguard to ensure `braintrust` exists in the staged Python bundle dependencies.
- If missing after dependency installation, vendor the package from the selected interpreter as fallback.
- Add tests for staged-package detection and fallback vendoring path.


## Manual testing

1. using the current stable version of the CLI (`0.6.0`), push a tool definition to your project
2. invoke that function with stable version, observe "Cannot find module" error
3. using the CLI binary from this branch, push the same tool definition with `--if-exists replace`
4. invoke the function with both the stable version and pr build of the CLI, observe correct output

## Validation

- `cargo test js_bundler_defaults_do_not_externalize_braintrust_sdk -- --nocapture`
- `cargo test functions_push_external_packages_bundles_with_runner -- --nocapture`
- `cargo test functions_push_js_bundles_by_default -- --nocapture`
- `cargo test python_package_staged_detects_module_files_and_directories -- --nocapture`
- `cargo test ensure_python_package_staged_can_vendor_stdlib_package -- --nocapture`
