### PR TITLE
Compile bt for Windows ARM64

### DIFF
--- a/.github/workflows/release-canary.yml
+++ b/.github/workflows/release-canary.yml
@@ -140,6 +140,14 @@ jobs:
             echo "$HOME/.cargo/bin" >> $GITHUB_PATH
           fi
 
+      - name: Install sha256sum (macOS ARM64)
+        if: ${{ runner.os == 'macOS' && runner.arch == 'ARM64' }}
+        shell: bash
+        run: |
+          printf '#!/bin/sh\nexec shasum -a 256 "$@"\n' > /tmp/sha256sum
+          chmod +x /tmp/sha256sum
+          echo /tmp >> "$GITHUB_PATH"
+
       - name: Install dist
         run: ${{ matrix.install_dist.run }}
 

--- a/.github/workflows/release-canary.yml
+++ b/.github/workflows/release-canary.yml
@@ -113,7 +113,6 @@ jobs:
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       BUILD_MANIFEST_NAME: target/distrib/${{ join(matrix.targets, '-') }}-dist-manifest.json
-      HAS_SSLDOTCOM_SIGNING: ${{ secrets.SSLDOTCOM_USERNAME != '' && secrets.SSLDOTCOM_PASSWORD != '' && secrets.SSLDOTCOM_CREDENTIAL_ID != '' && secrets.SSLDOTCOM_TOTP_SECRET != '' }}
     steps:
       - name: Enable windows longpaths
         run: git config --global core.longpaths true
@@ -160,31 +159,6 @@ jobs:
 
       - name: Install dependencies
         run: ${{ matrix.packages_install }}
-
-      - name: Configure SSL.com signing env
-        if: ${{ runner.os == 'Windows' && env.HAS_SSLDOTCOM_SIGNING == 'true' }}
-        shell: bash
-        env:
-          SSLDOTCOM_USERNAME: ${{ secrets.SSLDOTCOM_USERNAME }}
-          SSLDOTCOM_PASSWORD: ${{ secrets.SSLDOTCOM_PASSWORD }}
-          SSLDOTCOM_CREDENTIAL_ID: ${{ secrets.SSLDOTCOM_CREDENTIAL_ID }}
-          SSLDOTCOM_TOTP_SECRET: ${{ secrets.SSLDOTCOM_TOTP_SECRET }}
-        run: |
-          write_github_env() {
-            local key="$1"
-            local value="$2"
-            local delimiter="EOF_${key}_$$"
-            {
-              echo "${key}<<${delimiter}"
-              echo "${value}"
-              echo "${delimiter}"
-            } >> "$GITHUB_ENV"
-          }
-
-          write_github_env "SSLDOTCOM_USERNAME" "$SSLDOTCOM_USERNAME"
-          write_github_env "SSLDOTCOM_PASSWORD" "$SSLDOTCOM_PASSWORD"
-          write_github_env "SSLDOTCOM_CREDENTIAL_ID" "$SSLDOTCOM_CREDENTIAL_ID"
-          write_github_env "SSLDOTCOM_TOTP_SECRET" "$SSLDOTCOM_TOTP_SECRET"
 
       - name: Build artifacts
         shell: bash

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -125,6 +125,14 @@ jobs:
             echo "$HOME/.cargo/bin" >> $GITHUB_PATH
           fi
 
+      - name: Install sha256sum (macOS ARM64)
+        if: ${{ runner.os == 'macOS' && runner.arch == 'ARM64' }}
+        shell: bash
+        run: |
+          printf '#!/bin/sh\nexec shasum -a 256 "$@"\n' > /tmp/sha256sum
+          chmod +x /tmp/sha256sum
+          echo /tmp >> "$GITHUB_PATH"
+
       - name: Install dist
         run: ${{ matrix.install_dist.run }}
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -139,7 +139,7 @@ jobs:
         run: ${{ matrix.packages_install }}
 
       - name: Configure SSL.com signing env
-        if: ${{ runner.os == 'Windows' && env.HAS_SSLDOTCOM_SIGNING == 'true' }}
+        if: ${{ contains(toJSON(matrix.targets), 'windows') && env.HAS_SSLDOTCOM_SIGNING == 'true' && !fromJson(needs.plan.outputs.val).announcement_is_prerelease }}
         shell: bash
         env:
           SSLDOTCOM_USERNAME: ${{ secrets.SSLDOTCOM_USERNAME }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -147,7 +147,7 @@ jobs:
         run: ${{ matrix.packages_install }}
 
       - name: Configure SSL.com signing env
-        if: ${{ contains(toJSON(matrix.targets), 'windows') && env.HAS_SSLDOTCOM_SIGNING == 'true' && !fromJson(needs.plan.outputs.val).announcement_is_prerelease }}
+        if: ${{ runner.os == 'Windows' && env.HAS_SSLDOTCOM_SIGNING == 'true' && !fromJson(needs.plan.outputs.val).announcement_is_prerelease }}
         shell: bash
         env:
           SSLDOTCOM_USERNAME: ${{ secrets.SSLDOTCOM_USERNAME }}

--- a/dist-workspace.toml
+++ b/dist-workspace.toml
@@ -21,12 +21,12 @@ homepage = "https://github.com/braintrustdata/bt"
 targets = ["aarch64-apple-darwin", "aarch64-unknown-linux-gnu", "aarch64-pc-windows-msvc", "x86_64-apple-darwin", "x86_64-unknown-linux-gnu", "x86_64-unknown-linux-musl", "x86_64-pc-windows-msvc"]
 # Path that installers should place binaries in
 install-path = ["$XDG_BIN_HOME/", "$XDG_DATA_HOME/../bin", "~/.local/bin"]
-
-[dist.github-custom-runners]
-aarch64-pc-windows-msvc = "windows-11-arm"
 # The archive format to use for non-windows builds (defaults .tar.xz)
 unix-archive = ".tar.gz"
 # The archive format to use for windows builds (defaults .zip)
 windows-archive = ".zip"
 # Custom message to display on successful install
 install-success-msg = ""
+
+[dist.github-custom-runners]
+aarch64-pc-windows-msvc = "windows-11-arm"

--- a/dist-workspace.toml
+++ b/dist-workspace.toml
@@ -3,6 +3,8 @@ members = ["cargo:."]
 
 # Config for 'dist'
 [dist]
+# Skip checking whether the specified configuration files are up to date
+allow-dirty = ["ci"]
 # The preferred dist version to use in CI (Cargo.toml SemVer syntax)
 cargo-dist-version = "0.31.0"
 # CI backends to support
@@ -11,21 +13,20 @@ ci = "github"
 create-release = true
 # Which actions to run on pull requests
 pr-run-mode = "plan"
-# Skip checking whether the specified configuration files are up to date
-allow-dirty = ["ci"]
 ssldotcom-windows-sign = "test"
 # The installers to generate for each app
 installers = ["shell", "powershell", "homebrew"]
 homepage = "https://github.com/braintrustdata/bt"
 # Target platforms to build apps for (Rust target-triple syntax)
-targets = ["aarch64-apple-darwin", "aarch64-unknown-linux-gnu", "x86_64-apple-darwin", "x86_64-unknown-linux-gnu", "x86_64-unknown-linux-musl", "x86_64-pc-windows-msvc"]
+targets = ["aarch64-apple-darwin", "aarch64-unknown-linux-gnu", "aarch64-pc-windows-msvc", "x86_64-apple-darwin", "x86_64-unknown-linux-gnu", "x86_64-unknown-linux-musl", "x86_64-pc-windows-msvc"]
+# Path that installers should place binaries in
+install-path = ["$XDG_BIN_HOME/", "$XDG_DATA_HOME/../bin", "~/.local/bin"]
+
+[dist.github-custom-runners]
+aarch64-pc-windows-msvc = "windows-11-arm"
 # The archive format to use for non-windows builds (defaults .tar.xz)
 unix-archive = ".tar.gz"
 # The archive format to use for windows builds (defaults .zip)
 windows-archive = ".zip"
-# Path that installers should place binaries in
-install-path = ["$XDG_BIN_HOME/", "$XDG_DATA_HOME/../bin", "~/.local/bin"]
-# Whether to install an updater program
-install-updater = true
 # Custom message to display on successful install
 install-success-msg = ""

--- a/dist-workspace.toml
+++ b/dist-workspace.toml
@@ -4,7 +4,7 @@ members = ["cargo:."]
 # Config for 'dist'
 [dist]
 # Skip checking whether the specified configuration files are up to date
-allow-dirty = ["ci"]
+# allow-dirty = ["ci"]
 # The preferred dist version to use in CI (Cargo.toml SemVer syntax)
 cargo-dist-version = "0.31.0"
 # CI backends to support

--- a/dist-workspace.toml
+++ b/dist-workspace.toml
@@ -4,7 +4,7 @@ members = ["cargo:."]
 # Config for 'dist'
 [dist]
 # Skip checking whether the specified configuration files are up to date
-# allow-dirty = ["ci"]
+allow-dirty = ["ci"]
 # The preferred dist version to use in CI (Cargo.toml SemVer syntax)
 cargo-dist-version = "0.31.0"
 # CI backends to support


### PR DESCRIPTION
`bt.exe` now has an ARM64 version.

Cross compilation of the ring crate to Windows aarch64 fails, so the compilation of the ARM64 bt.exe runs on Windows server ARM64.
Compilation of the auto-updater on Windows server ARM64 fails, so is has been removed (this settings is global and can'tr be turned off just for one architecture). `bt self update` exists anyway so it's not an issue.