### PR TITLE
Add --matrix-param argument to eval

### DIFF
--- a/scripts/eval-runner.py
+++ b/scripts/eval-runner.py
@@ -11,6 +11,7 @@ import re
 import socket
 import sys
 import traceback
+import dataclasses
 from dataclasses import dataclass
 from typing import Any, Callable
 
@@ -54,6 +55,12 @@ class EvalFilter:
 
 
 @dataclass(frozen=True)
+class MatrixAxis:
+    key: str
+    values: list[Any]
+
+
+@dataclass(frozen=True)
 class RunnerConfig:
     jsonl: bool
     list_only: bool
@@ -66,6 +73,7 @@ class RunnerConfig:
     dev_mode: str | None
     dev_request_json: str | None
     params: dict[str, Any] | None
+    matrix: list[MatrixAxis] | None
 
 
 @dataclass
@@ -176,6 +184,46 @@ def parse_params_json(raw: str | None) -> dict[str, Any] | None:
     return parsed
 
 
+def parse_matrix_json(raw: str | None) -> list[MatrixAxis] | None:
+    if not raw:
+        return None
+    try:
+        parsed = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        raise ValueError(f"BT_EVAL_MATRIX_JSON is not valid JSON: {raw}") from exc
+    if not isinstance(parsed, list):
+        raise ValueError("BT_EVAL_MATRIX_JSON must be a JSON array.")
+    axes: list[MatrixAxis] = []
+    for entry in parsed:
+        if not isinstance(entry, dict):
+            raise ValueError("BT_EVAL_MATRIX_JSON entries must be objects with key and values.")
+        key = entry.get("key")
+        values = entry.get("values")
+        if not isinstance(key, str) or not key:
+            raise ValueError("BT_EVAL_MATRIX_JSON entry missing string key.")
+        if not isinstance(values, list) or not values:
+            raise ValueError(
+                f"BT_EVAL_MATRIX_JSON axis \"{key}\" must have a non-empty values array."
+            )
+        axes.append(MatrixAxis(key=key, values=values))
+    return axes if axes else None
+
+
+def matrix_combinations(axes: list[MatrixAxis]) -> list[list[tuple[str, Any]]]:
+    combos: list[list[tuple[str, Any]]] = [[]]
+    for axis in axes:
+        next_combos: list[list[tuple[str, Any]]] = []
+        for existing in combos:
+            for value in axis.values:
+                next_combos.append(existing + [(axis.key, value)])
+        combos = next_combos
+    return combos
+
+
+def format_matrix_label(combo: list[tuple[str, Any]]) -> str:
+    return ", ".join(f"{k}={json.dumps(v)}" for k, v in combo)
+
+
 def get_declared_parameter_keys(parameters: Any) -> set[str] | None:
     if parameters is None:
         return None
@@ -213,6 +261,7 @@ def read_runner_config() -> RunnerConfig:
         dev_mode=parse_dev_mode(os.getenv("BT_EVAL_DEV_MODE")),
         dev_request_json=os.getenv("BT_EVAL_DEV_REQUEST_JSON"),
         params=parse_params_json(os.getenv("BT_EVAL_PARAMS_JSON")),
+        matrix=parse_matrix_json(os.getenv("BT_EVAL_MATRIX_JSON")),
     )
 
 
@@ -1034,6 +1083,49 @@ async def run_once(
             print(evaluator_instance.evaluator.eval_name)
         return True
 
+    if config.matrix:
+        if len(evaluators) != 1:
+            names = [ev.evaluator.eval_name for ev in evaluators]
+            listed = "  (none matched)" if not names else "\n".join(f"  - {n}" for n in names)
+            message = (
+                "--matrix-param is not supported when running multiple evals.\n"
+                f"Matched evals:\n{listed}\n"
+                "Use --filter to select exactly one eval."
+            )
+            if sse:
+                sse.send("error", serialize_error(message, None))
+            else:
+                eprint(message)
+            return False
+
+        source = evaluators[0]
+        expanded: list[EvaluatorInstance] = []
+        for combo in matrix_combinations(config.matrix):
+            label = format_matrix_label(combo)
+            overlay = {k: v for k, v in combo}
+            orig_experiment_name = getattr(source.evaluator, "experiment_name", None)
+            new_experiment_name = (
+                f"{orig_experiment_name} [{label}]"
+                if isinstance(orig_experiment_name, str) and orig_experiment_name
+                else f"[{label}]"
+            )
+            # Disambiguate the progress-bar / tracking key too — progress events are
+            # keyed by eval_name, so combos must have distinct eval_names or bars collapse.
+            new_eval_name = f"{source.evaluator.eval_name} [{label}]"
+            cloned_evaluator = dataclasses.replace(
+                source.evaluator,
+                eval_name=new_eval_name,
+                experiment_name=new_experiment_name,
+            )
+            cloned_instance = EvaluatorInstance(
+                evaluator=cloned_evaluator,
+                reporter=source.reporter,
+            )
+            # Attach the overlay so run_single_evaluator can merge it on top of config.params.
+            setattr(cloned_instance, "_bt_matrix_params_override", overlay)
+            expanded.append(cloned_instance)
+        evaluators = expanded
+
     if sse:
         sse.send("processing", {"evaluators": len(evaluators)})
 
@@ -1052,11 +1144,17 @@ async def run_once(
             return evaluator_instance, None, None, err
 
         progress_cb = create_progress_reporter(sse, evaluator_instance.evaluator.eval_name)
-        if config.params is not None and evaluator_instance.evaluator.parameters is not None:
+        matrix_override = getattr(evaluator_instance, "_bt_matrix_params_override", None)
+        effective_params: dict[str, Any] | None
+        if matrix_override is not None:
+            effective_params = {**(config.params or {}), **matrix_override}
+        else:
+            effective_params = config.params
+        if effective_params is not None and evaluator_instance.evaluator.parameters is not None:
             evaluator = evaluator_instance.evaluator
             # Drop any --param keys the evaluator doesn't declare so a single
             # command running multiple evaluators doesn't fail on unrelated params.
-            filtered_params = filter_params_for_evaluator(config.params, evaluator.parameters)
+            filtered_params = filter_params_for_evaluator(effective_params, evaluator.parameters)
             evaluator.parameters = validate_parameters(filtered_params, evaluator.parameters)
         try:
             result = await run_evaluator_task(

--- a/scripts/eval-runner.ts
+++ b/scripts/eval-runner.ts
@@ -8,6 +8,12 @@ type EvaluatorEntry = {
     projectName: string;
   } & Record<string, unknown>;
   reporter?: unknown;
+  paramsOverride?: Record<string, unknown>;
+};
+
+type MatrixAxis = {
+  key: string;
+  values: unknown[];
 };
 
 type EvalResult = {
@@ -122,6 +128,7 @@ type RunnerConfig = {
   devMode: "list" | "eval" | null;
   devRequestJson: string | null;
   params: Record<string, unknown> | null;
+  matrix: MatrixAxis[] | null;
 };
 
 type EvalRunner = {
@@ -134,6 +141,7 @@ type EvalRunner = {
     projectName: string,
     evaluator: Record<string, unknown>,
     options?: EvalOptions,
+    paramsOverride?: Record<string, unknown>,
   ) => Promise<EvalResult>;
   runRegisteredEvals: (evaluators: EvaluatorEntry[]) => Promise<boolean>;
   makeEvalOptions: (
@@ -346,6 +354,59 @@ function filterParamsForEvaluator(
   return filtered;
 }
 
+function parseMatrixJson(raw: string | undefined): MatrixAxis[] | null {
+  if (!raw) {
+    return null;
+  }
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    throw new Error(`BT_EVAL_MATRIX_JSON is not valid JSON: ${raw}`);
+  }
+  if (!Array.isArray(parsed)) {
+    throw new Error("BT_EVAL_MATRIX_JSON must be a JSON array of {key, values}.");
+  }
+  const axes: MatrixAxis[] = [];
+  for (const entry of parsed) {
+    if (!isObject(entry)) {
+      throw new Error("BT_EVAL_MATRIX_JSON entries must be objects with key and values.");
+    }
+    const key = Reflect.get(entry, "key");
+    const values = Reflect.get(entry, "values");
+    if (typeof key !== "string" || key.length === 0) {
+      throw new Error("BT_EVAL_MATRIX_JSON entry missing string key.");
+    }
+    if (!Array.isArray(values) || values.length === 0) {
+      throw new Error(
+        `BT_EVAL_MATRIX_JSON axis "${key}" must have a non-empty values array.`,
+      );
+    }
+    axes.push({ key, values });
+  }
+  return axes.length > 0 ? axes : null;
+}
+
+function matrixCombinations(axes: MatrixAxis[]): Array<Array<[string, unknown]>> {
+  let combos: Array<Array<[string, unknown]>> = [[]];
+  for (const axis of axes) {
+    const next: Array<Array<[string, unknown]>> = [];
+    for (const existing of combos) {
+      for (const value of axis.values) {
+        next.push([...existing, [axis.key, value]]);
+      }
+    }
+    combos = next;
+  }
+  return combos;
+}
+
+function formatMatrixLabel(combo: Array<[string, unknown]>): string {
+  return combo
+    .map(([key, value]) => `${key}=${JSON.stringify(value)}`)
+    .join(", ");
+}
+
 function readRunnerConfig(): RunnerConfig {
   return {
     jsonl: envFlag("BT_EVAL_JSONL"),
@@ -358,6 +419,7 @@ function readRunnerConfig(): RunnerConfig {
     devMode: parseDevMode(process.env.BT_EVAL_DEV_MODE),
     devRequestJson: process.env.BT_EVAL_DEV_REQUEST_JSON ?? null,
     params: parseParamsJson(process.env.BT_EVAL_PARAMS_JSON),
+    matrix: parseMatrixJson(process.env.BT_EVAL_MATRIX_JSON),
   };
 }
 
@@ -2217,15 +2279,20 @@ async function createEvalRunner(config: RunnerConfig): Promise<EvalRunner> {
     projectName: string,
     evaluator: Record<string, unknown>,
     options?: EvalOptions,
+    paramsOverride?: Record<string, unknown>,
   ) => {
     globalThis._lazy_load = false;
     const evaluatorName = getEvaluatorName(evaluator, projectName);
     // Only inject CLI params when the evaluator declares a parameters schema.
     // Drop any --param keys the evaluator doesn't declare so a single command
     // running multiple evaluators doesn't fail on unrelated params.
+    const effectiveParams =
+      paramsOverride != null
+        ? { ...(config.params ?? {}), ...paramsOverride }
+        : config.params;
     const filteredParams =
-      config.params != null && evaluator.parameters != null
-        ? filterParamsForEvaluator(config.params, evaluator.parameters)
+      effectiveParams != null && evaluator.parameters != null
+        ? filterParamsForEvaluator(effectiveParams, evaluator.parameters)
         : null;
     const effectiveOptions =
       filteredParams != null
@@ -2274,6 +2341,7 @@ async function createEvalRunner(config: RunnerConfig): Promise<EvalRunner> {
           entry.evaluator.projectName,
           entry.evaluator,
           options,
+          entry.paramsOverride,
         );
         const failingResults = result.results.filter(
           (r: { error?: unknown }) => r.error !== undefined,
@@ -2398,7 +2466,7 @@ async function main() {
   let ok = true;
   try {
     const discoveredEvaluators = getEvaluators();
-    const filteredEvaluators = filterEvaluators(
+    let filteredEvaluators = filterEvaluators(
       discoveredEvaluators,
       config.filters,
     );
@@ -2419,6 +2487,50 @@ async function main() {
         console.log(entry.evaluator.evalName);
       }
       return;
+    }
+
+    if (config.matrix && config.matrix.length > 0) {
+      if (filteredEvaluators.length !== 1) {
+        const names = filteredEvaluators.map((e) => e.evaluator.evalName);
+        const listed =
+          names.length === 0
+            ? "  (none matched)"
+            : names.map((n) => `  - ${n}`).join("\n");
+        const message = `--matrix-param is not supported when running multiple evals.\nMatched evals:\n${listed}\nUse --filter to select exactly one eval.`;
+        if (runner.sse) {
+          runner.sse.send("error", serializeError(new Error(message)));
+        } else {
+          console.error(message);
+        }
+        ok = false;
+        return;
+      }
+      const [sourceEntry] = filteredEvaluators;
+      const combos = matrixCombinations(config.matrix);
+      filteredEvaluators = combos.map((combo) => {
+        const label = formatMatrixLabel(combo);
+        const paramsOverride: Record<string, unknown> = {};
+        for (const [key, value] of combo) {
+          paramsOverride[key] = value;
+        }
+        const origExperimentName = sourceEntry.evaluator.experimentName;
+        const newExperimentName =
+          typeof origExperimentName === "string" && origExperimentName.length > 0
+            ? `${origExperimentName} [${label}]`
+            : `[${label}]`;
+        // Disambiguate the progress-bar / tracking key too — the runner emits progress
+        // events keyed by evalName, so combos must have distinct evalNames or bars collapse.
+        const newEvalName = `${sourceEntry.evaluator.evalName} [${label}]`;
+        return {
+          evaluator: {
+            ...sourceEntry.evaluator,
+            evalName: newEvalName,
+            experimentName: newExperimentName,
+          },
+          reporter: sourceEntry.reporter,
+          paramsOverride,
+        } satisfies EvaluatorEntry;
+      });
     }
 
     if (btEvalMains.length > 0) {

--- a/scripts/eval-runner.ts
+++ b/scripts/eval-runner.ts
@@ -365,12 +365,16 @@ function parseMatrixJson(raw: string | undefined): MatrixAxis[] | null {
     throw new Error(`BT_EVAL_MATRIX_JSON is not valid JSON: ${raw}`);
   }
   if (!Array.isArray(parsed)) {
-    throw new Error("BT_EVAL_MATRIX_JSON must be a JSON array of {key, values}.");
+    throw new Error(
+      "BT_EVAL_MATRIX_JSON must be a JSON array of {key, values}.",
+    );
   }
   const axes: MatrixAxis[] = [];
   for (const entry of parsed) {
     if (!isObject(entry)) {
-      throw new Error("BT_EVAL_MATRIX_JSON entries must be objects with key and values.");
+      throw new Error(
+        "BT_EVAL_MATRIX_JSON entries must be objects with key and values.",
+      );
     }
     const key = Reflect.get(entry, "key");
     const values = Reflect.get(entry, "values");
@@ -387,7 +391,9 @@ function parseMatrixJson(raw: string | undefined): MatrixAxis[] | null {
   return axes.length > 0 ? axes : null;
 }
 
-function matrixCombinations(axes: MatrixAxis[]): Array<Array<[string, unknown]>> {
+function matrixCombinations(
+  axes: MatrixAxis[],
+): Array<Array<[string, unknown]>> {
   let combos: Array<Array<[string, unknown]>> = [[]];
   for (const axis of axes) {
     const next: Array<Array<[string, unknown]>> = [];
@@ -2515,7 +2521,8 @@ async function main() {
         }
         const origExperimentName = sourceEntry.evaluator.experimentName;
         const newExperimentName =
-          typeof origExperimentName === "string" && origExperimentName.length > 0
+          typeof origExperimentName === "string" &&
+          origExperimentName.length > 0
             ? `${origExperimentName} [${label}]`
             : `[${label}]`;
         // Disambiguate the progress-bar / tracking key too — the runner emits progress

--- a/scripts/eval-runner.ts
+++ b/scripts/eval-runner.ts
@@ -2495,14 +2495,10 @@ async function main() {
       return;
     }
 
-    if (config.matrix && config.matrix.length > 0) {
-      if (filteredEvaluators.length !== 1) {
-        const names = filteredEvaluators.map((e) => e.evaluator.evalName);
-        const listed =
-          names.length === 0
-            ? "  (none matched)"
-            : names.map((n) => `  - ${n}`).join("\n");
-        const message = `--matrix-param is not supported when running multiple evals.\nMatched evals:\n${listed}\nUse --filter to select exactly one eval.`;
+    if (btEvalMains.length > 0) {
+      if (config.matrix && config.matrix.length > 0) {
+        const message =
+          "--matrix-param is not supported for eval files that export btEvalMain. Remove the btEvalMain export or drop --matrix-param.";
         if (runner.sse) {
           runner.sse.send("error", serializeError(new Error(message)));
         } else {
@@ -2511,36 +2507,6 @@ async function main() {
         ok = false;
         return;
       }
-      const [sourceEntry] = filteredEvaluators;
-      const combos = matrixCombinations(config.matrix);
-      filteredEvaluators = combos.map((combo) => {
-        const label = formatMatrixLabel(combo);
-        const paramsOverride: Record<string, unknown> = {};
-        for (const [key, value] of combo) {
-          paramsOverride[key] = value;
-        }
-        const origExperimentName = sourceEntry.evaluator.experimentName;
-        const newExperimentName =
-          typeof origExperimentName === "string" &&
-          origExperimentName.length > 0
-            ? `${origExperimentName} [${label}]`
-            : `[${label}]`;
-        // Disambiguate the progress-bar / tracking key too — the runner emits progress
-        // events keyed by evalName, so combos must have distinct evalNames or bars collapse.
-        const newEvalName = `${sourceEntry.evaluator.evalName} [${label}]`;
-        return {
-          evaluator: {
-            ...sourceEntry.evaluator,
-            evalName: newEvalName,
-            experimentName: newExperimentName,
-          },
-          reporter: sourceEntry.reporter,
-          paramsOverride,
-        } satisfies EvaluatorEntry;
-      });
-    }
-
-    if (btEvalMains.length > 0) {
       globalThis._lazy_load = false;
       for (const main of btEvalMains) {
         try {
@@ -2555,6 +2521,50 @@ async function main() {
         }
       }
     } else {
+      if (config.matrix && config.matrix.length > 0) {
+        if (filteredEvaluators.length !== 1) {
+          const names = filteredEvaluators.map((e) => e.evaluator.evalName);
+          const listed =
+            names.length === 0
+              ? "  (none matched)"
+              : names.map((n) => `  - ${n}`).join("\n");
+          const message = `--matrix-param is not supported when running multiple evals.\nMatched evals:\n${listed}\nUse --filter to select exactly one eval.`;
+          if (runner.sse) {
+            runner.sse.send("error", serializeError(new Error(message)));
+          } else {
+            console.error(message);
+          }
+          ok = false;
+          return;
+        }
+        const [sourceEntry] = filteredEvaluators;
+        const combos = matrixCombinations(config.matrix);
+        filteredEvaluators = combos.map((combo) => {
+          const label = formatMatrixLabel(combo);
+          const paramsOverride: Record<string, unknown> = {};
+          for (const [key, value] of combo) {
+            paramsOverride[key] = value;
+          }
+          const origExperimentName = sourceEntry.evaluator.experimentName;
+          const newExperimentName =
+            typeof origExperimentName === "string" &&
+            origExperimentName.length > 0
+              ? `${origExperimentName} [${label}]`
+              : `[${label}]`;
+          // Disambiguate the progress-bar / tracking key too — the runner emits progress
+          // events keyed by evalName, so combos must have distinct evalNames or bars collapse.
+          const newEvalName = `${sourceEntry.evaluator.evalName} [${label}]`;
+          return {
+            evaluator: {
+              ...sourceEntry.evaluator,
+              evalName: newEvalName,
+              experimentName: newExperimentName,
+            },
+            reporter: sourceEntry.reporter,
+            paramsOverride,
+          } satisfies EvaluatorEntry;
+        });
+      }
       if (discoveredEvaluators.length === 0) {
         console.error("No evaluators found. Did you call Eval() in the file?");
         process.exit(1);

--- a/src/eval.rs
+++ b/src/eval.rs
@@ -460,9 +460,7 @@ pub async fn run(base: BaseArgs, args: EvalArgs) -> Result<()> {
         Vec::new()
     } else {
         if args.watch || args.dev || args.list {
-            anyhow::bail!(
-                "--matrix-param cannot be combined with --watch, --dev, or --list"
-            );
+            anyhow::bail!("--matrix-param cannot be combined with --watch, --dev, or --list");
         }
         parse_matrix_params(&args.matrix_param)?
     };
@@ -1876,9 +1874,10 @@ fn parse_matrix_params(raw: &[String]) -> Result<Vec<(String, Vec<serde_json::Va
         let rest = &trimmed[eq_pos + 1..];
         let rest_trimmed = rest.trim();
         let values: Vec<serde_json::Value> = if rest_trimmed.starts_with('[') {
-            let arr: Vec<serde_json::Value> = serde_json::from_str(rest_trimmed).with_context(
-                || format!("--matrix-param value is not a valid JSON array: {entry}"),
-            )?;
+            let arr: Vec<serde_json::Value> =
+                serde_json::from_str(rest_trimmed).with_context(|| {
+                    format!("--matrix-param value is not a valid JSON array: {entry}")
+                })?;
             if arr.is_empty() {
                 anyhow::bail!("--matrix-param must have at least one value: {entry}");
             }
@@ -4573,10 +4572,7 @@ mod tests {
         assert_eq!(axes[0].0, "model");
         assert_eq!(
             axes[0].1,
-            vec![
-                serde_json::json!("gpt-4"),
-                serde_json::json!("gpt-5"),
-            ]
+            vec![serde_json::json!("gpt-4"), serde_json::json!("gpt-5"),]
         );
     }
 
@@ -4586,10 +4582,7 @@ mod tests {
         let axes = parse_matrix_params(&raw).expect("should parse");
         assert_eq!(
             axes[0].1,
-            vec![
-                serde_json::json!("gpt-4"),
-                serde_json::json!("gpt-5"),
-            ]
+            vec![serde_json::json!("gpt-4"), serde_json::json!("gpt-5"),]
         );
     }
 

--- a/src/eval.rs
+++ b/src/eval.rs
@@ -355,6 +355,20 @@ pub struct EvalArgs {
     )]
     pub param: Vec<String>,
 
+    /// Run the selected eval once per combination of matrix values.
+    /// Two value formats are supported:
+    ///   key=v1,v2,v3          comma-separated (each value parsed as JSON, falling back to string)
+    ///   key=[JSON_ARRAY]      JSON array, e.g. --matrix-param model='["gpt-4","hello, world"]'
+    ///                         Use the JSON array form when values must contain commas.
+    /// Repeat the flag to sweep multiple keys; the Cartesian product of all values is run.
+    /// Requires exactly one eval after filters; multiple evals error out.
+    #[arg(
+        long = "matrix-param",
+        value_name = "KEY=V1,V2,... | KEY=[JSON_ARRAY]",
+        allow_hyphen_values = true
+    )]
+    pub matrix_param: Vec<String>,
+
     /// Arguments forwarded to the eval file via process.argv (everything after `--`).
     /// Example: bt eval foo.eval.ts -- --description "Prod" --shard=1/4
     #[arg(last = true, value_name = "ARG")]
@@ -410,6 +424,7 @@ struct EvalRunOptions {
     verbose: bool,
     extra_args: Vec<String>,
     params: Vec<String>,
+    matrix_axes: Vec<(String, Vec<serde_json::Value>)>,
 }
 
 pub async fn run(base: BaseArgs, args: EvalArgs) -> Result<()> {
@@ -441,6 +456,17 @@ pub async fn run(base: BaseArgs, args: EvalArgs) -> Result<()> {
         EvalSamplingMode::Full
     };
 
+    let matrix_axes = if args.matrix_param.is_empty() {
+        Vec::new()
+    } else {
+        if args.watch || args.dev || args.list {
+            anyhow::bail!(
+                "--matrix-param cannot be combined with --watch, --dev, or --list"
+            );
+        }
+        parse_matrix_params(&args.matrix_param)?
+    };
+
     let options = EvalRunOptions {
         jsonl: args.jsonl,
         terminate_on_failure: args.terminate_on_failure,
@@ -451,6 +477,7 @@ pub async fn run(base: BaseArgs, args: EvalArgs) -> Result<()> {
         sampling,
         extra_args: args.extra_args,
         params: args.param,
+        matrix_axes,
     };
 
     if args.dev {
@@ -843,6 +870,21 @@ async fn spawn_eval_runner(
         let serialized =
             serde_json::to_string(&parsed).context("failed to serialize eval params")?;
         cmd.env("BT_EVAL_PARAMS_JSON", serialized);
+    }
+    if !options.matrix_axes.is_empty() {
+        let payload: Vec<serde_json::Value> = options
+            .matrix_axes
+            .iter()
+            .map(|(key, values)| {
+                serde_json::json!({
+                    "key": key,
+                    "values": values,
+                })
+            })
+            .collect();
+        let serialized =
+            serde_json::to_string(&payload).context("failed to serialize matrix axes")?;
+        cmd.env("BT_EVAL_MATRIX_JSON", serialized);
     }
     cmd.env(
         "BT_EVAL_SSE_SOCK",
@@ -1815,6 +1857,49 @@ fn parse_eval_params(params: &[String]) -> Result<serde_json::Map<String, serde_
         }
     }
     Ok(result)
+}
+
+fn parse_matrix_params(raw: &[String]) -> Result<Vec<(String, Vec<serde_json::Value>)>> {
+    let mut axes: Vec<(String, Vec<serde_json::Value>)> = Vec::new();
+    for entry in raw {
+        let trimmed = entry.trim();
+        let eq_pos = trimmed.find('=').ok_or_else(|| {
+            anyhow::anyhow!("--matrix-param value must be in key=V1,V2,... format: {entry}")
+        })?;
+        let key = trimmed[..eq_pos].trim();
+        if key.is_empty() {
+            anyhow::bail!("--matrix-param key must not be empty: {entry}");
+        }
+        if axes.iter().any(|(k, _)| k == key) {
+            anyhow::bail!("--matrix-param key specified more than once: {key}");
+        }
+        let rest = &trimmed[eq_pos + 1..];
+        let rest_trimmed = rest.trim();
+        let values: Vec<serde_json::Value> = if rest_trimmed.starts_with('[') {
+            let arr: Vec<serde_json::Value> = serde_json::from_str(rest_trimmed).with_context(
+                || format!("--matrix-param value is not a valid JSON array: {entry}"),
+            )?;
+            if arr.is_empty() {
+                anyhow::bail!("--matrix-param must have at least one value: {entry}");
+            }
+            arr
+        } else {
+            let pieces: Vec<&str> = rest.split(',').collect();
+            if pieces.iter().all(|p| p.trim().is_empty()) {
+                anyhow::bail!("--matrix-param must have at least one value: {entry}");
+            }
+            pieces
+                .iter()
+                .map(|piece| {
+                    let s = piece.trim();
+                    serde_json::from_str(s)
+                        .unwrap_or_else(|_| serde_json::Value::String(s.to_string()))
+                })
+                .collect()
+        };
+        axes.push((key.to_string(), values));
+    }
+    Ok(axes)
 }
 
 fn parse_eval_filter_expression(expression: &str) -> Result<RunnerFilter> {
@@ -2948,11 +3033,10 @@ impl EvalUi {
             EvalEvent::Error { message, stack, .. } => {
                 let show_hint = message.contains("Please specify an api key");
                 if self.verbose {
-                    let line = message.as_str().red().to_string();
-                    let _ = self.progress.println(line);
+                    self.print_persistent_line(message.as_str().red().to_string());
                     if let Some(stack) = stack {
                         for line in stack.lines() {
-                            let _ = self.progress.println(line.dark_grey().to_string());
+                            self.print_persistent_line(line.dark_grey().to_string());
                         }
                     }
                 } else {
@@ -4477,6 +4561,127 @@ mod tests {
         let err = parse_eval_params(&params).expect_err("should fail");
         assert!(
             err.to_string().contains("key must not be empty"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn parse_matrix_params_single_axis_multiple_values() {
+        let raw = vec!["model=\"gpt-4\",\"gpt-5\"".to_string()];
+        let axes = parse_matrix_params(&raw).expect("should parse");
+        assert_eq!(axes.len(), 1);
+        assert_eq!(axes[0].0, "model");
+        assert_eq!(
+            axes[0].1,
+            vec![
+                serde_json::json!("gpt-4"),
+                serde_json::json!("gpt-5"),
+            ]
+        );
+    }
+
+    #[test]
+    fn parse_matrix_params_bare_strings_fallback() {
+        let raw = vec!["model=gpt-4,gpt-5".to_string()];
+        let axes = parse_matrix_params(&raw).expect("should parse");
+        assert_eq!(
+            axes[0].1,
+            vec![
+                serde_json::json!("gpt-4"),
+                serde_json::json!("gpt-5"),
+            ]
+        );
+    }
+
+    #[test]
+    fn parse_matrix_params_mixed_types() {
+        let raw = vec!["enableBashTool=true,false".to_string()];
+        let axes = parse_matrix_params(&raw).expect("should parse");
+        assert_eq!(
+            axes[0].1,
+            vec![serde_json::json!(true), serde_json::json!(false)]
+        );
+    }
+
+    #[test]
+    fn parse_matrix_params_rejects_duplicate_key() {
+        let raw = vec!["model=a,b".to_string(), "model=c,d".to_string()];
+        let err = parse_matrix_params(&raw).expect_err("should fail");
+        assert!(
+            err.to_string().contains("specified more than once"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn parse_matrix_params_rejects_empty_key() {
+        let raw = vec!["=a,b".to_string()];
+        let err = parse_matrix_params(&raw).expect_err("should fail");
+        assert!(
+            err.to_string().contains("key must not be empty"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn parse_matrix_params_rejects_missing_equals() {
+        let raw = vec!["modelonly".to_string()];
+        let err = parse_matrix_params(&raw).expect_err("should fail");
+        assert!(
+            err.to_string().contains("key=V1,V2"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn parse_matrix_params_rejects_empty_values() {
+        let raw = vec!["model=".to_string()];
+        let err = parse_matrix_params(&raw).expect_err("should fail");
+        assert!(
+            err.to_string().contains("at least one value"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn parse_matrix_params_json_array_allows_values_with_commas() {
+        let raw = vec![r#"prompt=["hello, world","goodbye, friend"]"#.to_string()];
+        let axes = parse_matrix_params(&raw).expect("should parse");
+        assert_eq!(
+            axes[0].1,
+            vec![
+                serde_json::json!("hello, world"),
+                serde_json::json!("goodbye, friend"),
+            ]
+        );
+    }
+
+    #[test]
+    fn parse_matrix_params_json_array_supports_nested_json() {
+        let raw = vec![r#"tools=[[1,2],[3,4]]"#.to_string()];
+        let axes = parse_matrix_params(&raw).expect("should parse");
+        assert_eq!(
+            axes[0].1,
+            vec![serde_json::json!([1, 2]), serde_json::json!([3, 4])]
+        );
+    }
+
+    #[test]
+    fn parse_matrix_params_json_array_rejects_empty() {
+        let raw = vec!["model=[]".to_string()];
+        let err = parse_matrix_params(&raw).expect_err("should fail");
+        assert!(
+            err.to_string().contains("at least one value"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn parse_matrix_params_json_array_rejects_malformed() {
+        let raw = vec!["model=[\"a\"".to_string()];
+        let err = parse_matrix_params(&raw).expect_err("should fail");
+        assert!(
+            err.to_string().contains("not a valid JSON array"),
             "unexpected error: {err}"
         );
     }

--- a/tests/eval_fixtures.rs
+++ b/tests/eval_fixtures.rs
@@ -435,6 +435,195 @@ fn eval_runner_list_mode_serializes_parameter_defaults() {
     );
 }
 
+#[test]
+fn eval_matrix_param_single_runs_all_combinations() {
+    let _guard = test_lock();
+    if !command_exists("node") {
+        if required_runtimes().contains("node") {
+            panic!("node runtime is required but unavailable for matrix-param test");
+        }
+        eprintln!(
+            "Skipping eval_matrix_param_single_runs_all_combinations (node not installed)."
+        );
+        return;
+    }
+
+    let root = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    let fixture_dir = root
+        .join("tests")
+        .join("evals")
+        .join("js")
+        .join("eval-matrix-param-single");
+    ensure_dependencies(&fixture_dir);
+
+    let bt_path = bt_binary_path(&root);
+    let out_file = fixture_dir.join(format!(
+        ".matrix-out-{}.txt",
+        SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("system clock before epoch")
+            .as_nanos()
+    ));
+    let _ = fs::remove_file(&out_file);
+
+    let output = Command::new(&bt_path)
+        .arg("eval")
+        .arg("matrix-single.eval.mjs")
+        .arg("--matrix-param")
+        .arg("model=a,b")
+        .arg("--matrix-param")
+        .arg("enableBashTool=true,false")
+        .current_dir(&fixture_dir)
+        .env("BT_EVAL_LOCAL", "1")
+        .env("BT_MATRIX_TEST_OUT", &out_file)
+        .env(
+            "BRAINTRUST_API_KEY",
+            std::env::var("BRAINTRUST_API_KEY").unwrap_or_else(|_| "local".to_string()),
+        )
+        .output()
+        .expect("run bt eval --matrix-param");
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+
+    assert!(
+        output.status.success(),
+        "bt eval --matrix-param should succeed.\nstdout:\n{stdout}\nstderr:\n{stderr}"
+    );
+
+    let contents = fs::read_to_string(&out_file).unwrap_or_default();
+    let _ = fs::remove_file(&out_file);
+    let mut lines: Vec<&str> = contents.lines().filter(|l| !l.trim().is_empty()).collect();
+    lines.sort();
+    assert_eq!(
+        lines,
+        vec!["a|false", "a|true", "b|false", "b|true"],
+        "expected all 4 matrix combinations to run.\nstdout:\n{stdout}\nstderr:\n{stderr}"
+    );
+}
+
+#[test]
+fn eval_matrix_param_rejects_multiple_evals() {
+    let _guard = test_lock();
+    if !command_exists("node") {
+        if required_runtimes().contains("node") {
+            panic!("node runtime is required but unavailable for matrix-param multi-eval test");
+        }
+        eprintln!(
+            "Skipping eval_matrix_param_rejects_multiple_evals (node not installed)."
+        );
+        return;
+    }
+
+    let root = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    let fixture_dir = root
+        .join("tests")
+        .join("evals")
+        .join("js")
+        .join("eval-matrix-param-multi-error");
+    ensure_dependencies(&fixture_dir);
+
+    let bt_path = bt_binary_path(&root);
+
+    let output = Command::new(&bt_path)
+        .arg("eval")
+        .arg("matrix-multi.eval.mjs")
+        .arg("--matrix-param")
+        .arg("model=a,b")
+        .current_dir(&fixture_dir)
+        .env("BT_EVAL_LOCAL", "1")
+        .env(
+            "BRAINTRUST_API_KEY",
+            std::env::var("BRAINTRUST_API_KEY").unwrap_or_else(|_| "local".to_string()),
+        )
+        .output()
+        .expect("run bt eval --matrix-param on multi-eval file");
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+
+    assert!(
+        !output.status.success(),
+        "bt eval --matrix-param against multiple evals should fail.\nstdout:\n{stdout}\nstderr:\n{stderr}"
+    );
+    assert!(
+        stderr.contains("not supported when running multiple evals"),
+        "expected guidance message in stderr, got:\n{stderr}"
+    );
+    assert!(
+        stderr.contains("matrix-multi-alpha") && stderr.contains("matrix-multi-beta"),
+        "expected both eval names in stderr, got:\n{stderr}"
+    );
+}
+
+#[test]
+fn eval_matrix_param_terminate_on_failure_stops_early() {
+    let _guard = test_lock();
+    if !command_exists("node") {
+        if required_runtimes().contains("node") {
+            panic!(
+                "node runtime is required but unavailable for matrix-param terminate test"
+            );
+        }
+        eprintln!(
+            "Skipping eval_matrix_param_terminate_on_failure_stops_early (node not installed)."
+        );
+        return;
+    }
+
+    let root = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    let fixture_dir = root
+        .join("tests")
+        .join("evals")
+        .join("js")
+        .join("eval-matrix-param-terminate");
+    ensure_dependencies(&fixture_dir);
+
+    let bt_path = bt_binary_path(&root);
+    let out_file = fixture_dir.join(format!(
+        ".matrix-out-{}.txt",
+        SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("system clock before epoch")
+            .as_nanos()
+    ));
+    let _ = fs::remove_file(&out_file);
+
+    let output = Command::new(&bt_path)
+        .arg("eval")
+        .arg("matrix-terminate.eval.mjs")
+        .arg("--matrix-param")
+        .arg("model=fail,ok,ok2")
+        .arg("--terminate-on-failure")
+        .current_dir(&fixture_dir)
+        .env("BT_EVAL_LOCAL", "1")
+        .env("BT_MATRIX_TEST_OUT", &out_file)
+        .env(
+            "BRAINTRUST_API_KEY",
+            std::env::var("BRAINTRUST_API_KEY").unwrap_or_else(|_| "local".to_string()),
+        )
+        .output()
+        .expect("run bt eval --matrix-param --terminate-on-failure");
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+
+    assert!(
+        !output.status.success(),
+        "failing matrix run should exit non-zero.\nstdout:\n{stdout}\nstderr:\n{stderr}"
+    );
+
+    let contents = fs::read_to_string(&out_file).unwrap_or_default();
+    let _ = fs::remove_file(&out_file);
+    let lines: Vec<&str> = contents.lines().filter(|l| !l.trim().is_empty()).collect();
+
+    assert_eq!(
+        lines,
+        vec!["fail"],
+        "with --terminate-on-failure, only the first (failing) combo should execute.\nstdout:\n{stdout}\nstderr:\n{stderr}"
+    );
+}
+
 fn read_fixture_config(path: &Path) -> FixtureConfig {
     let raw = fs::read_to_string(path).expect("read fixture.json");
     serde_json::from_str(&raw).expect("parse fixture.json")

--- a/tests/eval_fixtures.rs
+++ b/tests/eval_fixtures.rs
@@ -442,9 +442,7 @@ fn eval_matrix_param_single_runs_all_combinations() {
         if required_runtimes().contains("node") {
             panic!("node runtime is required but unavailable for matrix-param test");
         }
-        eprintln!(
-            "Skipping eval_matrix_param_single_runs_all_combinations (node not installed)."
-        );
+        eprintln!("Skipping eval_matrix_param_single_runs_all_combinations (node not installed).");
         return;
     }
 
@@ -509,9 +507,7 @@ fn eval_matrix_param_rejects_multiple_evals() {
         if required_runtimes().contains("node") {
             panic!("node runtime is required but unavailable for matrix-param multi-eval test");
         }
-        eprintln!(
-            "Skipping eval_matrix_param_rejects_multiple_evals (node not installed)."
-        );
+        eprintln!("Skipping eval_matrix_param_rejects_multiple_evals (node not installed).");
         return;
     }
 
@@ -561,9 +557,7 @@ fn eval_matrix_param_terminate_on_failure_stops_early() {
     let _guard = test_lock();
     if !command_exists("node") {
         if required_runtimes().contains("node") {
-            panic!(
-                "node runtime is required but unavailable for matrix-param terminate test"
-            );
+            panic!("node runtime is required but unavailable for matrix-param terminate test");
         }
         eprintln!(
             "Skipping eval_matrix_param_terminate_on_failure_stops_early (node not installed)."

--- a/tests/evals/js/eval-bt-eval-main-matrix-error/fixture.json
+++ b/tests/evals/js/eval-bt-eval-main-matrix-error/fixture.json
@@ -1,0 +1,5 @@
+{
+  "files": ["main.eval.mjs"],
+  "args": ["--matrix-param", "model=a,b"],
+  "expect_success": false
+}

--- a/tests/evals/js/eval-bt-eval-main-matrix-error/main.eval.mjs
+++ b/tests/evals/js/eval-bt-eval-main-matrix-error/main.eval.mjs
@@ -1,0 +1,9 @@
+export async function btEvalMain(ctx) {
+  // The runner should error before reaching this code when --matrix-param is set.
+  await ctx.runEval("BT CLI Tests", {
+    evalName: "bt-eval-main-matrix-error",
+    data: () => [{ input: "x", expected: "x" }],
+    task: (input) => input,
+    scores: [],
+  });
+}

--- a/tests/evals/js/eval-bt-eval-main-matrix-error/package.json
+++ b/tests/evals/js/eval-bt-eval-main-matrix-error/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "bt-eval-bt-eval-main-matrix-error",
+  "private": true,
+  "type": "module",
+  "dependencies": {
+    "braintrust": "^2.2.0"
+  }
+}

--- a/tests/evals/js/eval-matrix-param-multi-error/fixture.json
+++ b/tests/evals/js/eval-matrix-param-multi-error/fixture.json
@@ -1,0 +1,5 @@
+{
+  "files": ["matrix-multi.eval.mjs"],
+  "args": ["--matrix-param", "model=a,b"],
+  "expect_success": false
+}

--- a/tests/evals/js/eval-matrix-param-multi-error/matrix-multi.eval.mjs
+++ b/tests/evals/js/eval-matrix-param-multi-error/matrix-multi.eval.mjs
@@ -1,0 +1,13 @@
+import { Eval } from "braintrust";
+
+Eval("matrix-multi-alpha", {
+  data: () => [{ input: "a", expected: "a" }],
+  task: (input) => input,
+  scores: [],
+});
+
+Eval("matrix-multi-beta", {
+  data: () => [{ input: "b", expected: "b" }],
+  task: (input) => input,
+  scores: [],
+});

--- a/tests/evals/js/eval-matrix-param-multi-error/package.json
+++ b/tests/evals/js/eval-matrix-param-multi-error/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "bt-eval-matrix-param-multi-error",
+  "private": true,
+  "type": "module",
+  "dependencies": {
+    "braintrust": "^2.2.0",
+    "zod": "^3.0.0"
+  },
+  "devDependencies": {
+    "tsx": "^4.16.2"
+  }
+}

--- a/tests/evals/js/eval-matrix-param-single/fixture.json
+++ b/tests/evals/js/eval-matrix-param-single/fixture.json
@@ -1,0 +1,9 @@
+{
+  "files": ["matrix-single.eval.mjs"],
+  "args": [
+    "--matrix-param",
+    "model=a,b",
+    "--matrix-param",
+    "enableBashTool=true,false"
+  ]
+}

--- a/tests/evals/js/eval-matrix-param-single/matrix-single.eval.mjs
+++ b/tests/evals/js/eval-matrix-param-single/matrix-single.eval.mjs
@@ -1,0 +1,21 @@
+import { appendFileSync } from "node:fs";
+import { Eval } from "braintrust";
+import { z } from "zod";
+
+const outPath = process.env.BT_MATRIX_TEST_OUT;
+
+Eval("matrix-single", {
+  parameters: {
+    model: z.string().default("default-model"),
+    enableBashTool: z.boolean().default(false),
+  },
+  data: () => [{ input: "x", expected: "x" }],
+  task: (input, hooks) => {
+    const { model, enableBashTool } = hooks.parameters;
+    if (outPath) {
+      appendFileSync(outPath, `${model}|${enableBashTool}\n`);
+    }
+    return input;
+  },
+  scores: [],
+});

--- a/tests/evals/js/eval-matrix-param-single/package.json
+++ b/tests/evals/js/eval-matrix-param-single/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "bt-eval-matrix-param-single",
+  "private": true,
+  "type": "module",
+  "dependencies": {
+    "braintrust": "^2.2.0",
+    "zod": "^3.0.0"
+  },
+  "devDependencies": {
+    "tsx": "^4.16.2"
+  }
+}

--- a/tests/evals/js/eval-matrix-param-terminate/fixture.json
+++ b/tests/evals/js/eval-matrix-param-terminate/fixture.json
@@ -1,9 +1,5 @@
 {
   "files": ["matrix-terminate.eval.mjs"],
-  "args": [
-    "--matrix-param",
-    "model=fail,ok,ok2",
-    "--terminate-on-failure"
-  ],
+  "args": ["--matrix-param", "model=fail,ok,ok2", "--terminate-on-failure"],
   "expect_success": false
 }

--- a/tests/evals/js/eval-matrix-param-terminate/fixture.json
+++ b/tests/evals/js/eval-matrix-param-terminate/fixture.json
@@ -1,0 +1,9 @@
+{
+  "files": ["matrix-terminate.eval.mjs"],
+  "args": [
+    "--matrix-param",
+    "model=fail,ok,ok2",
+    "--terminate-on-failure"
+  ],
+  "expect_success": false
+}

--- a/tests/evals/js/eval-matrix-param-terminate/matrix-terminate.eval.mjs
+++ b/tests/evals/js/eval-matrix-param-terminate/matrix-terminate.eval.mjs
@@ -1,0 +1,23 @@
+import { appendFileSync } from "node:fs";
+import { Eval } from "braintrust";
+import { z } from "zod";
+
+const outPath = process.env.BT_MATRIX_TEST_OUT;
+
+Eval("matrix-terminate", {
+  parameters: {
+    model: z.string().default("default-model"),
+  },
+  data: () => [{ input: "x", expected: "x" }],
+  task: (input, hooks) => {
+    const { model } = hooks.parameters;
+    if (outPath) {
+      appendFileSync(outPath, `${model}\n`);
+    }
+    if (model === "fail") {
+      throw new Error("intentional failure for terminate test");
+    }
+    return input;
+  },
+  scores: [],
+});

--- a/tests/evals/js/eval-matrix-param-terminate/package.json
+++ b/tests/evals/js/eval-matrix-param-terminate/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "bt-eval-matrix-param-terminate",
+  "private": true,
+  "type": "module",
+  "dependencies": {
+    "braintrust": "^2.2.0",
+    "zod": "^3.0.0"
+  },
+  "devDependencies": {
+    "tsx": "^4.16.2"
+  }
+}


### PR DESCRIPTION
Adds the `--matrix-param` flag to `bt eval`

will create all combinations of arguments when multiple flags used. 

`--matrix-param` hashes are appended to eval name and experiment name to ensure uniqueness and make it easier to differentiate between multiple experiments in the CLI and links. 

```
 framework-evals git:(main) ✗ bt eval rewrite.eval.ts --matrix-param model=claude-haiku-4-5,claude-sonnet-4-6 --matrix-param includeSkill=true,false --sample 1
Processing 4 evaluators...
▶ Experiment Rewrite test [model="claude-sonnet-4-6", includeSkill=false] is running at https://www.braintrust.dev/app/braintrustdata.com/p/Rewrite%20Evals/experiments/Rewrite%20test%20%5Bmodel%3D%22claude-sonnet-4-6%22%2C%20includeSkill%3Dfalse%5D
▶ Experiment Rewrite test [model="claude-haiku-4-5", includeSkill=true] is running at https://www.braintrust.dev/app/braintrustdata.com/p/Rewrite%20Evals/experiments/Rewrite%20test%20%5Bmodel%3D%22claude-haiku-4-5%22%2C%20includeSkill%3Dtrue%5D
▶ Experiment Rewrite test [model="claude-haiku-4-5", includeSkill=false] is running at https://www.braintrust.dev/app/braintrustdata.com/p/Rewrite%20Evals/experiments/Rewrite%20test%20%5Bmodel%3D%22claude-haiku-4-5%22%2C%20includeSkill%3Dfalse%5D
▶ Experiment Rewrite test [model="claude-sonnet-4-6", includeSkill=true] is running at https://www.braintrust.dev/app/braintrustdata.com/p/Rewrite%20Evals/experiments/Rewrite%20test%20%5Bmodel%3D%22claude-sonnet-4-6%22%2C%20includeSkill%3Dtrue%5D
⠁ Rewrite Evals [exp...includeSkill=false]
⠁ Rewrite Evals [exp... includeSkill=true]
⠁ Rewrite Evals [exp...includeSkill=false]
⠁ Rewrite Evals [exp... includeSkill=true]  
```

If the value contains a comma, must use a JSON string containing an array
```
framework-evals git:(main) ✗ bt eval rewrite.eval.ts --matrix-param model="[\"claude-haiku-4-5\",\"claude-sonnet-4-6\"]"  --sample 1                                    
Processing 2 evaluators...
▶ Experiment Rewrite test [model="claude-sonnet-4-6"] is running at https://www.braintrust.dev/app/braintrustdata.com/p/Rewrite%20Evals/experiments/Rewrite%20test%20%5Bmodel%3D%22claude-sonnet-4-6%22%5D
▶ Experiment Rewrite test [model="claude-haiku-4-5"] is running at https://www.braintrust.dev/app/braintrustdata.com/p/Rewrite%20Evals/experiments/Rewrite%20test%20%5Bmodel%3D%22claude-haiku-4-5%22%5D
⠁ Rewrite Evals [exp...claude-sonnet-4-6"]
⠁ Rewrite Evals [exp..."claude-haiku-4-5"]                 
```
