### PR TITLE
fix(cli): surface stable ids in function selection

### DIFF
--- a/src/functions/mod.rs
+++ b/src/functions/mod.rs
@@ -550,6 +550,22 @@ async fn resolve_context(base: &BaseArgs) -> Result<ResolvedContext> {
     })
 }
 
+fn function_selection_label(function: &Function, ft: Option<FunctionTypeFilter>) -> String {
+    let slug_suffix = if function.slug == function.name {
+        String::new()
+    } else {
+        format!(" [slug: {}]", function.slug)
+    };
+
+    match ft {
+        Some(_) => format!("{}{}", function.name, slug_suffix),
+        None => {
+            let t = function.function_type.as_deref().unwrap_or("?");
+            format!("{}{} ({})", function.name, slug_suffix, t)
+        }
+    }
+}
+
 pub(crate) async fn select_function_interactive(
     client: &ApiClient,
     project_id: &str,
@@ -568,17 +584,10 @@ pub(crate) async fn select_function_interactive(
 
     functions.sort_by(|a, b| a.name.cmp(&b.name));
 
-    let names: Vec<String> = if ft.is_none() {
-        functions
-            .iter()
-            .map(|f| {
-                let t = f.function_type.as_deref().unwrap_or("?");
-                format!("{} ({})", f.name, t)
-            })
-            .collect()
-    } else {
-        functions.iter().map(|f| f.name.clone()).collect()
-    };
+    let names: Vec<String> = functions
+        .iter()
+        .map(|f| function_selection_label(f, ft))
+        .collect();
 
     let selection = ui::fuzzy_select(&format!("Select {}", label(ft)), &names, 0)?;
     Ok(functions[selection].clone())
@@ -954,6 +963,57 @@ mod tests {
             panic!("expected pull command");
         };
         assert_eq!(pull.slug_flag, vec!["a", "b", "c"]);
+    }
+
+    #[test]
+    fn function_selection_label_includes_slug_when_name_differs() {
+        let function = Function {
+            id: "id".to_string(),
+            name: "Display name".to_string(),
+            slug: "display-name".to_string(),
+            project_id: "project".to_string(),
+            description: None,
+            function_type: Some("classifier".to_string()),
+            prompt_data: None,
+            function_data: None,
+            tags: None,
+            metadata: None,
+            created: None,
+            _xact_id: None,
+        };
+
+        assert_eq!(
+            function_selection_label(&function, None),
+            "Display name [slug: display-name] (classifier)"
+        );
+        assert_eq!(
+            function_selection_label(&function, Some(FunctionTypeFilter::Classifier)),
+            "Display name [slug: display-name]"
+        );
+    }
+
+    #[test]
+    fn function_selection_label_avoids_duplicate_slug_when_equal_to_name() {
+        let function = Function {
+            id: "id".to_string(),
+            name: "same".to_string(),
+            slug: "same".to_string(),
+            project_id: "project".to_string(),
+            description: None,
+            function_type: Some("tool".to_string()),
+            prompt_data: None,
+            function_data: None,
+            tags: None,
+            metadata: None,
+            created: None,
+            _xact_id: None,
+        };
+
+        assert_eq!(function_selection_label(&function, None), "same (tool)");
+        assert_eq!(
+            function_selection_label(&function, Some(FunctionTypeFilter::Tool)),
+            "same"
+        );
     }
 
     #[derive(Debug, Parser)]

--- a/src/functions/view.rs
+++ b/src/functions/view.rs
@@ -63,6 +63,12 @@ pub async fn run(
 
     let mut output = String::new();
     writeln!(output, "Viewing {}", console::style(&function.name).bold())?;
+    writeln!(
+        output,
+        "{} {}",
+        console::style("Slug:").dim(),
+        function.slug
+    )?;
 
     if let Some(ft) = &function.function_type {
         writeln!(output, "{} {}", console::style("Type:").dim(), ft)?;


### PR DESCRIPTION
Before, the interactive selector showed only the display label (and type for mixed lists), while follow-up commands still expected the stable identifier. The detail view also omitted that identifier, which made it hard to copy after selecting an item.

Before:
```
✔ Select function · Friendly name (classifier)
Viewing Friendly name
Type: classifier
```

After:
```
✔ Select function · Friendly name [slug: friendly-name-20260421] (classifier)
Viewing Friendly name
Slug: friendly-name-20260421
Type: classifier
```

When the display label already matches the stable identifier, the selector stays compact and only the detail view adds the explicit `Slug:` line. Add focused tests so that compact case stays unchanged.