### PR TITLE
Re-creating already existing project uses project in bt setup

### DIFF
--- a/src/projects/create.rs
+++ b/src/projects/create.rs
@@ -71,11 +71,8 @@ pub async fn run(client: &ApiClient, name: Option<&str>) -> Result<()> {
             Ok(())
         }
         Ok(CreateProjectOutcome::Existing(_)) => {
-            print_command_status(
-                CommandStatus::Success,
-                &format!("Project '{name}' already exists"),
-            );
-            Ok(())
+            print_command_status(CommandStatus::Error, &format!("Failed to create '{name}'"));
+            bail!("project '{name}' already exists")
         }
         Err(e) => {
             print_command_status(CommandStatus::Error, &format!("Failed to create '{name}'"));

--- a/src/projects/create.rs
+++ b/src/projects/create.rs
@@ -10,22 +10,45 @@ use crate::ui::{
 
 use super::api;
 
-pub(crate) async fn create_project_checked(client: &ApiClient, name: &str) -> Result<api::Project> {
+pub(crate) enum CreateProjectOutcome {
+    Created(api::Project),
+    Existing(api::Project),
+}
+
+pub(crate) async fn create_project_checked(
+    client: &ApiClient,
+    name: &str,
+) -> Result<CreateProjectOutcome> {
     let exists = with_spinner(
         "Checking project...",
         api::get_project_by_name(client, name),
     )
     .await?;
-    if exists.is_some() {
-        bail!("project '{name}' already exists");
+    if let Some(project) = exists {
+        return Ok(CreateProjectOutcome::Existing(project));
     }
 
-    with_spinner_visible(
+    match with_spinner_visible(
         "Creating project...",
         api::create_project(client, name),
         Duration::from_millis(300),
     )
     .await
+    {
+        Ok(project) => Ok(CreateProjectOutcome::Created(project)),
+        Err(err) => {
+            if let Some(project) = with_spinner(
+                "Checking project...",
+                api::get_project_by_name(client, name),
+            )
+            .await?
+            {
+                Ok(CreateProjectOutcome::Existing(project))
+            } else {
+                Err(err)
+            }
+        }
+    }
 }
 
 pub async fn run(client: &ApiClient, name: Option<&str>) -> Result<()> {
@@ -40,10 +63,17 @@ pub async fn run(client: &ApiClient, name: Option<&str>) -> Result<()> {
     };
 
     match create_project_checked(client, &name).await {
-        Ok(_) => {
+        Ok(CreateProjectOutcome::Created(_)) => {
             print_command_status(
                 CommandStatus::Success,
                 &format!("Successfully created '{name}'"),
+            );
+            Ok(())
+        }
+        Ok(CreateProjectOutcome::Existing(_)) => {
+            print_command_status(
+                CommandStatus::Success,
+                &format!("Project '{name}' already exists"),
             );
             Ok(())
         }
@@ -51,5 +81,243 @@ pub async fn run(client: &ApiClient, name: Option<&str>) -> Result<()> {
             print_command_status(CommandStatus::Error, &format!("Failed to create '{name}'"));
             Err(e)
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::net::TcpListener;
+    use std::sync::{Arc, Mutex};
+
+    use actix_web::{web, App, HttpRequest, HttpResponse, HttpServer};
+    use braintrust_sdk_rust::LoginState;
+    use serde::Deserialize;
+
+    use super::*;
+    use crate::auth::LoginContext;
+
+    #[derive(Clone)]
+    struct MockProject {
+        id: String,
+        name: String,
+        org_id: String,
+    }
+
+    #[derive(Clone, Copy)]
+    enum CreateBehavior {
+        Create,
+        ConflictThenReveal,
+    }
+
+    struct MockState {
+        projects: Mutex<Vec<MockProject>>,
+        create_behavior: CreateBehavior,
+    }
+
+    struct MockServer {
+        base_url: String,
+        handle: actix_web::dev::ServerHandle,
+    }
+
+    impl MockServer {
+        async fn start(state: Arc<MockState>) -> Self {
+            let listener = TcpListener::bind(("127.0.0.1", 0)).expect("bind mock server");
+            let addr = listener.local_addr().expect("mock server addr");
+            let base_url = format!("http://{addr}");
+            let data = web::Data::new(state);
+
+            let server = HttpServer::new(move || {
+                App::new()
+                    .app_data(data.clone())
+                    .route("/v1/project", web::get().to(mock_list_projects))
+                    .route("/v1/project", web::post().to(mock_create_project))
+            })
+            .workers(1)
+            .listen(listener)
+            .expect("listen mock server")
+            .run();
+            let handle = server.handle();
+            tokio::spawn(server);
+
+            Self { base_url, handle }
+        }
+
+        async fn stop(&self) {
+            self.handle.stop(true).await;
+        }
+    }
+
+    fn make_client(base_url: &str) -> ApiClient {
+        ApiClient::new(&LoginContext {
+            login: LoginState {
+                api_key: "test-key".to_string(),
+                org_id: "org-1".to_string(),
+                org_name: "test-org".to_string(),
+                api_url: Some(base_url.to_string()),
+            },
+            api_url: base_url.to_string(),
+            app_url: "https://app.example.com".to_string(),
+        })
+        .expect("build client")
+    }
+
+    fn parse_query(req: &HttpRequest) -> std::collections::HashMap<String, String> {
+        req.query_string()
+            .split('&')
+            .filter(|part| !part.is_empty())
+            .filter_map(|part| {
+                let (key, value) = part.split_once('=').unwrap_or((part, ""));
+                let key = urlencoding::decode(key).ok()?.into_owned();
+                let value = urlencoding::decode(value).ok()?.into_owned();
+                Some((key, value))
+            })
+            .collect()
+    }
+
+    async fn mock_list_projects(
+        state: web::Data<Arc<MockState>>,
+        req: HttpRequest,
+    ) -> HttpResponse {
+        let query = parse_query(&req);
+        let requested_name = query.get("project_name").cloned();
+        let projects = state.projects.lock().expect("projects lock").clone();
+        let objects = projects
+            .into_iter()
+            .filter(|project| {
+                requested_name
+                    .as_deref()
+                    .is_none_or(|name| project.name == name)
+            })
+            .map(|project| {
+                serde_json::json!({
+                    "id": project.id,
+                    "name": project.name,
+                    "org_id": project.org_id,
+                })
+            })
+            .collect::<Vec<_>>();
+        HttpResponse::Ok().json(serde_json::json!({ "objects": objects }))
+    }
+
+    #[derive(Deserialize)]
+    struct CreateProjectRequest {
+        name: String,
+        org_name: String,
+    }
+
+    async fn mock_create_project(
+        state: web::Data<Arc<MockState>>,
+        body: web::Json<CreateProjectRequest>,
+    ) -> HttpResponse {
+        match state.create_behavior {
+            CreateBehavior::Create => {
+                let mut projects = state.projects.lock().expect("projects lock");
+                let created = MockProject {
+                    id: format!("proj-created-{}", projects.len() + 1),
+                    name: body.name.clone(),
+                    org_id: body.org_name.clone(),
+                };
+                projects.push(created.clone());
+                HttpResponse::Ok().json(serde_json::json!({
+                    "id": created.id,
+                    "name": created.name,
+                    "org_id": created.org_id,
+                }))
+            }
+            CreateBehavior::ConflictThenReveal => {
+                let mut projects = state.projects.lock().expect("projects lock");
+                if !projects.iter().any(|project| project.name == body.name) {
+                    projects.push(MockProject {
+                        id: "proj-race".to_string(),
+                        name: body.name.clone(),
+                        org_id: body.org_name.clone(),
+                    });
+                }
+                HttpResponse::Conflict()
+                    .json(serde_json::json!({ "error": "project already exists" }))
+            }
+        }
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn create_project_checked_returns_existing_project() {
+        let state = Arc::new(MockState {
+            projects: Mutex::new(vec![MockProject {
+                id: "proj-1".to_string(),
+                name: "existing-project".to_string(),
+                org_id: "test-org".to_string(),
+            }]),
+            create_behavior: CreateBehavior::Create,
+        });
+        let server = MockServer::start(state).await;
+        let client = make_client(&server.base_url);
+
+        let outcome = create_project_checked(&client, "existing-project")
+            .await
+            .expect("reuse existing project");
+
+        match outcome {
+            CreateProjectOutcome::Existing(project) => {
+                assert_eq!(project.id, "proj-1");
+                assert_eq!(project.name, "existing-project");
+            }
+            CreateProjectOutcome::Created(_) => panic!("expected existing project outcome"),
+        }
+
+        server.stop().await;
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn create_project_checked_falls_back_to_lookup_after_create_conflict() {
+        let state = Arc::new(MockState {
+            projects: Mutex::new(vec![MockProject {
+                id: "proj-2".to_string(),
+                name: "unrelated-project".to_string(),
+                org_id: "test-org".to_string(),
+            }]),
+            create_behavior: CreateBehavior::ConflictThenReveal,
+        });
+        let server = MockServer::start(state).await;
+        let client = make_client(&server.base_url);
+
+        let outcome = create_project_checked(&client, "race-project")
+            .await
+            .expect("resolve project after create conflict");
+
+        match outcome {
+            CreateProjectOutcome::Existing(project) => {
+                assert_eq!(project.id, "proj-race");
+                assert_eq!(project.name, "race-project");
+            }
+            CreateProjectOutcome::Created(_) => {
+                panic!("expected existing project outcome after create conflict")
+            }
+        }
+
+        server.stop().await;
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn create_project_checked_returns_created_project() {
+        let state = Arc::new(MockState {
+            projects: Mutex::new(vec![]),
+            create_behavior: CreateBehavior::Create,
+        });
+        let server = MockServer::start(state).await;
+        let client = make_client(&server.base_url);
+
+        let outcome = create_project_checked(&client, "new-project")
+            .await
+            .expect("create new project");
+
+        match outcome {
+            CreateProjectOutcome::Created(project) => {
+                assert_eq!(project.id, "proj-created-1");
+                assert_eq!(project.name, "new-project");
+            }
+            CreateProjectOutcome::Existing(_) => panic!("expected created project outcome"),
+        }
+
+        server.stop().await;
     }
 }

--- a/src/projects/create.rs
+++ b/src/projects/create.rs
@@ -86,7 +86,7 @@ mod tests {
     use std::net::TcpListener;
     use std::sync::{Arc, Mutex};
 
-    use actix_web::{web, App, HttpRequest, HttpResponse, HttpServer};
+    use actix_web::{web, App, HttpResponse, HttpServer};
     use braintrust_sdk_rust::LoginState;
     use serde::Deserialize;
 
@@ -98,6 +98,16 @@ mod tests {
         id: String,
         name: String,
         org_id: String,
+    }
+
+    impl MockProject {
+        fn new(id: &str, name: &str) -> Self {
+            Self {
+                id: id.to_string(),
+                name: name.to_string(),
+                org_id: "test-org".to_string(),
+            }
+        }
     }
 
     #[derive(Clone, Copy)]
@@ -144,62 +154,50 @@ mod tests {
         }
     }
 
-    fn make_client(base_url: &str) -> ApiClient {
-        ApiClient::new(&LoginContext {
+    async fn setup_test(
+        projects: Vec<MockProject>,
+        create_behavior: CreateBehavior,
+    ) -> (MockServer, ApiClient) {
+        let state = Arc::new(MockState {
+            projects: Mutex::new(projects),
+            create_behavior,
+        });
+        let server = MockServer::start(state).await;
+        let client = ApiClient::new(&LoginContext {
             login: LoginState {
                 api_key: "test-key".to_string(),
                 org_id: "org-1".to_string(),
                 org_name: "test-org".to_string(),
-                api_url: Some(base_url.to_string()),
+                api_url: Some(server.base_url.clone()),
             },
-            api_url: base_url.to_string(),
+            api_url: server.base_url.clone(),
             app_url: "https://app.example.com".to_string(),
         })
-        .expect("build client")
+        .expect("build client");
+        (server, client)
     }
 
-    fn parse_query(req: &HttpRequest) -> std::collections::HashMap<String, String> {
-        req.query_string()
-            .split('&')
-            .filter(|part| !part.is_empty())
-            .filter_map(|part| {
-                let (key, value) = part.split_once('=').unwrap_or((part, ""));
-                let key = urlencoding::decode(key).ok()?.into_owned();
-                let value = urlencoding::decode(value).ok()?.into_owned();
-                Some((key, value))
-            })
-            .collect()
+    #[derive(Deserialize)]
+    struct ListProjectsQuery {
+        project_name: Option<String>,
     }
 
     async fn mock_list_projects(
         state: web::Data<Arc<MockState>>,
-        req: HttpRequest,
+        query: web::Query<ListProjectsQuery>,
     ) -> HttpResponse {
-        let query = parse_query(&req);
-        let requested_name = query.get("project_name").cloned();
         let projects = state.projects.lock().expect("projects lock").clone();
-        let objects = projects
+        let objects: Vec<_> = projects
             .into_iter()
-            .filter(|project| {
-                requested_name
-                    .as_deref()
-                    .is_none_or(|name| project.name == name)
-            })
-            .map(|project| {
-                serde_json::json!({
-                    "id": project.id,
-                    "name": project.name,
-                    "org_id": project.org_id,
-                })
-            })
-            .collect::<Vec<_>>();
+            .filter(|p| query.project_name.as_deref().is_none_or(|n| p.name == n))
+            .map(|p| serde_json::json!({ "id": p.id, "name": p.name, "org_id": p.org_id }))
+            .collect();
         HttpResponse::Ok().json(serde_json::json!({ "objects": objects }))
     }
 
     #[derive(Deserialize)]
     struct CreateProjectRequest {
         name: String,
-        org_name: String,
     }
 
     async fn mock_create_project(
@@ -209,27 +207,19 @@ mod tests {
         match state.create_behavior {
             CreateBehavior::Create => {
                 let mut projects = state.projects.lock().expect("projects lock");
-                let created = MockProject {
-                    id: format!("proj-created-{}", projects.len() + 1),
-                    name: body.name.clone(),
-                    org_id: body.org_name.clone(),
-                };
+                let id = format!("proj-created-{}", projects.len() + 1);
+                let created = MockProject::new(&id, &body.name);
                 projects.push(created.clone());
-                HttpResponse::Ok().json(serde_json::json!({
-                    "id": created.id,
-                    "name": created.name,
-                    "org_id": created.org_id,
-                }))
+                HttpResponse::Ok().json(
+                    serde_json::json!({ "id": created.id, "name": created.name, "org_id": created.org_id }),
+                )
             }
             CreateBehavior::ConflictThenReveal => {
-                let mut projects = state.projects.lock().expect("projects lock");
-                if !projects.iter().any(|project| project.name == body.name) {
-                    projects.push(MockProject {
-                        id: "proj-race".to_string(),
-                        name: body.name.clone(),
-                        org_id: body.org_name.clone(),
-                    });
-                }
+                state
+                    .projects
+                    .lock()
+                    .expect("projects lock")
+                    .push(MockProject::new("proj-race", &body.name));
                 HttpResponse::Conflict()
                     .json(serde_json::json!({ "error": "project already exists" }))
             }
@@ -238,82 +228,55 @@ mod tests {
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn create_project_checked_returns_existing_project() {
-        let state = Arc::new(MockState {
-            projects: Mutex::new(vec![MockProject {
-                id: "proj-1".to_string(),
-                name: "existing-project".to_string(),
-                org_id: "test-org".to_string(),
-            }]),
-            create_behavior: CreateBehavior::Create,
-        });
-        let server = MockServer::start(state).await;
-        let client = make_client(&server.base_url);
+        let (server, client) = setup_test(
+            vec![MockProject::new("proj-1", "existing-project")],
+            CreateBehavior::Create,
+        )
+        .await;
 
         let outcome = create_project_checked(&client, "existing-project")
             .await
             .expect("reuse existing project");
 
-        match outcome {
-            CreateProjectOutcome::Existing(project) => {
-                assert_eq!(project.id, "proj-1");
-                assert_eq!(project.name, "existing-project");
-            }
-            CreateProjectOutcome::Created(_) => panic!("expected existing project outcome"),
-        }
+        let CreateProjectOutcome::Existing(project) = outcome else {
+            panic!("expected existing project outcome");
+        };
+        assert_eq!(project.id, "proj-1");
+        assert_eq!(project.name, "existing-project");
 
         server.stop().await;
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn create_project_checked_falls_back_to_lookup_after_create_conflict() {
-        let state = Arc::new(MockState {
-            projects: Mutex::new(vec![MockProject {
-                id: "proj-2".to_string(),
-                name: "unrelated-project".to_string(),
-                org_id: "test-org".to_string(),
-            }]),
-            create_behavior: CreateBehavior::ConflictThenReveal,
-        });
-        let server = MockServer::start(state).await;
-        let client = make_client(&server.base_url);
+        let (server, client) = setup_test(vec![], CreateBehavior::ConflictThenReveal).await;
 
         let outcome = create_project_checked(&client, "race-project")
             .await
             .expect("resolve project after create conflict");
 
-        match outcome {
-            CreateProjectOutcome::Existing(project) => {
-                assert_eq!(project.id, "proj-race");
-                assert_eq!(project.name, "race-project");
-            }
-            CreateProjectOutcome::Created(_) => {
-                panic!("expected existing project outcome after create conflict")
-            }
-        }
+        let CreateProjectOutcome::Existing(project) = outcome else {
+            panic!("expected existing project outcome after create conflict");
+        };
+        assert_eq!(project.id, "proj-race");
+        assert_eq!(project.name, "race-project");
 
         server.stop().await;
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn create_project_checked_returns_created_project() {
-        let state = Arc::new(MockState {
-            projects: Mutex::new(vec![]),
-            create_behavior: CreateBehavior::Create,
-        });
-        let server = MockServer::start(state).await;
-        let client = make_client(&server.base_url);
+        let (server, client) = setup_test(vec![], CreateBehavior::Create).await;
 
         let outcome = create_project_checked(&client, "new-project")
             .await
             .expect("create new project");
 
-        match outcome {
-            CreateProjectOutcome::Created(project) => {
-                assert_eq!(project.id, "proj-created-1");
-                assert_eq!(project.name, "new-project");
-            }
-            CreateProjectOutcome::Existing(_) => panic!("expected created project outcome"),
-        }
+        let CreateProjectOutcome::Created(project) = outcome else {
+            panic!("expected created project outcome");
+        };
+        assert_eq!(project.id, "proj-created-1");
+        assert_eq!(project.name, "new-project");
 
         server.stop().await;
     }

--- a/src/projects/create.rs
+++ b/src/projects/create.rs
@@ -2,14 +2,16 @@ use std::time::Duration;
 
 use anyhow::{bail, Result};
 use dialoguer::Input;
+use reqwest::StatusCode;
 
-use crate::http::ApiClient;
+use crate::http::{ApiClient, HttpError};
 use crate::ui::{
     is_interactive, print_command_status, with_spinner, with_spinner_visible, CommandStatus,
 };
 
 use super::api;
 
+#[derive(Debug)]
 pub(crate) enum CreateProjectOutcome {
     Created(api::Project),
     Existing(api::Project),
@@ -37,18 +39,30 @@ pub(crate) async fn create_project_checked(
     {
         Ok(project) => Ok(CreateProjectOutcome::Created(project)),
         Err(err) => {
+            if !is_conflict_error(&err) {
+                return Err(err);
+            }
+
             if let Some(project) = with_spinner(
                 "Checking project...",
                 api::get_project_by_name(client, name),
             )
             .await?
             {
-                Ok(CreateProjectOutcome::Existing(project))
-            } else {
-                Err(err)
+                return Ok(CreateProjectOutcome::Existing(project));
             }
+
+            Err(err)
         }
     }
+}
+
+fn is_conflict_error(err: &anyhow::Error) -> bool {
+    err.chain().any(|source| {
+        source
+            .downcast_ref::<HttpError>()
+            .is_some_and(|http_err| http_err.status == StatusCode::CONFLICT)
+    })
 }
 
 pub async fn run(client: &ApiClient, name: Option<&str>) -> Result<()> {

--- a/src/setup/mod.rs
+++ b/src/setup/mod.rs
@@ -4864,7 +4864,7 @@ mod tests {
     }
 
     #[test]
-    fn clear_missing_fallback_setup_project_clears_config_project_without_matches() {
+    fn clear_missing_fallback_setup_project_clears_non_explicit_only() {
         let mut base = make_base_args();
         base.project = Some("stale-project".to_string());
         let mut project_name = Some("stale-project".to_string());
@@ -4873,18 +4873,15 @@ mod tests {
 
         assert_eq!(base.project, None);
         assert_eq!(project_name, None);
-    }
 
-    #[test]
-    fn clear_missing_fallback_setup_project_keeps_explicit_project_without_matches() {
         let mut base = make_base_args();
         base.project = Some("explicit-project".to_string());
         let mut project_name = Some("explicit-project".to_string());
 
         clear_missing_fallback_setup_project(&mut base, &mut project_name, true, &[]);
 
-        assert_eq!(base.project.as_deref(), Some("explicit-project"));
-        assert_eq!(project_name.as_deref(), Some("explicit-project"));
+        assert_eq!(base.project, Some("explicit-project".to_string()));
+        assert_eq!(project_name, Some("explicit-project".to_string()));
     }
 
     #[test]

--- a/src/setup/mod.rs
+++ b/src/setup/mod.rs
@@ -1374,14 +1374,14 @@ async fn ensure_setup_auth(
             .clone()
             .unwrap_or_else(|| DEFAULT_APP_URL.to_string());
         let available_orgs = list_available_orgs_for_setup(api_key, &app_url).await?;
-        if let Some(name) = project_name.as_deref() {
+        if project_name.is_some() && org_name.is_none() && profile_name.is_none() {
+            let name = project_name
+                .as_deref()
+                .expect("project name exists when probing all orgs");
             let matched_orgs = orgs_with_project(base, api_key, &available_orgs, name).await?;
-            clear_missing_fallback_setup_project(
-                base,
-                &mut project_name,
-                project_was_explicit,
-                &matched_orgs,
-            );
+            if matched_orgs.is_empty() {
+                clear_missing_fallback_setup_project(base, &mut project_name, project_was_explicit);
+            }
         }
 
         if let Some(profile_name) = profile_name.as_deref() {
@@ -1407,25 +1407,29 @@ async fn ensure_setup_auth(
 
             if let Some(org) = find_available_org(&available_orgs, target_org) {
                 let client = build_api_key_client(base, api_key, org).await?;
-                if let Some(project_name) = project_name.as_deref() {
-                    if !project_exists_in_org(&client, project_name).await? {
-                        bail!("project '{project_name}' not found in org '{}'", org.name);
-                    }
-                }
+                ensure_selected_setup_project(
+                    base,
+                    &client,
+                    &mut project_name,
+                    project_was_explicit,
+                    &org.name,
+                )
+                .await?;
                 return build_setup_auth_context(base, client, false, needs_api_key).await;
             }
 
             let (login_ctx, is_oauth) =
                 ensure_profile_or_oauth_auth(base, prompt_for_profile_choice).await?;
             let client = ApiClient::new(&login_ctx)?;
-            if let Some(project_name) = project_name.as_deref() {
-                if !project_exists_in_org(&client, project_name).await? {
-                    bail!(
-                        "project '{project_name}' not found in org '{}'",
-                        client.org_name()
-                    );
-                }
-            }
+            let resolved_org = client.org_name().to_string();
+            ensure_selected_setup_project(
+                base,
+                &client,
+                &mut project_name,
+                project_was_explicit,
+                &resolved_org,
+            )
+            .await?;
             return build_setup_auth_context(base, client, is_oauth, needs_api_key).await;
         }
 
@@ -1440,25 +1444,29 @@ async fn ensure_setup_auth(
 
             if let Some(org) = find_available_org(&available_orgs, org_name) {
                 let client = build_api_key_client(base, api_key, org).await?;
-                if let Some(project_name) = project_name.as_deref() {
-                    if !project_exists_in_org(&client, project_name).await? {
-                        bail!("project '{project_name}' not found in org '{org_name}'");
-                    }
-                }
+                ensure_selected_setup_project(
+                    base,
+                    &client,
+                    &mut project_name,
+                    project_was_explicit,
+                    org_name,
+                )
+                .await?;
                 return build_setup_auth_context(base, client, false, needs_api_key).await;
             }
 
             let (login_ctx, is_oauth) =
                 ensure_profile_or_oauth_auth(base, prompt_for_profile_choice).await?;
             let client = ApiClient::new(&login_ctx)?;
-            if let Some(project_name) = project_name.as_deref() {
-                if !project_exists_in_org(&client, project_name).await? {
-                    bail!(
-                        "project '{project_name}' not found in org '{}'",
-                        client.org_name()
-                    );
-                }
-            }
+            let resolved_org = client.org_name().to_string();
+            ensure_selected_setup_project(
+                base,
+                &client,
+                &mut project_name,
+                project_was_explicit,
+                &resolved_org,
+            )
+            .await?;
             return build_setup_auth_context(base, client, is_oauth, needs_api_key).await;
         }
 
@@ -1557,13 +1565,35 @@ async fn ensure_setup_auth(
     build_setup_auth_context(base, client, is_oauth, needs_api_key).await
 }
 
+async fn ensure_selected_setup_project(
+    base: &mut BaseArgs,
+    client: &ApiClient,
+    project_name: &mut Option<String>,
+    project_was_explicit: bool,
+    org_name: &str,
+) -> Result<()> {
+    let Some(requested_project) = project_name.as_deref() else {
+        return Ok(());
+    };
+
+    if project_exists_in_org(client, requested_project).await? {
+        return Ok(());
+    }
+
+    if project_was_explicit {
+        bail!("project '{requested_project}' not found in org '{org_name}'");
+    }
+
+    clear_missing_fallback_setup_project(base, project_name, false);
+    Ok(())
+}
+
 fn clear_missing_fallback_setup_project(
     base: &mut BaseArgs,
     project_name: &mut Option<String>,
     project_was_explicit: bool,
-    matched_orgs: &[auth::AvailableOrg],
 ) {
-    if project_was_explicit || project_name.is_none() || !matched_orgs.is_empty() {
+    if project_was_explicit || project_name.is_none() {
         return;
     }
 
@@ -4869,7 +4899,7 @@ mod tests {
         base.project = Some("stale-project".to_string());
         let mut project_name = Some("stale-project".to_string());
 
-        clear_missing_fallback_setup_project(&mut base, &mut project_name, false, &[]);
+        clear_missing_fallback_setup_project(&mut base, &mut project_name, false);
 
         assert_eq!(base.project, None);
         assert_eq!(project_name, None);
@@ -4878,7 +4908,7 @@ mod tests {
         base.project = Some("explicit-project".to_string());
         let mut project_name = Some("explicit-project".to_string());
 
-        clear_missing_fallback_setup_project(&mut base, &mut project_name, true, &[]);
+        clear_missing_fallback_setup_project(&mut base, &mut project_name, true);
 
         assert_eq!(base.project, Some("explicit-project".to_string()));
         assert_eq!(project_name, Some("explicit-project".to_string()));

--- a/src/setup/mod.rs
+++ b/src/setup/mod.rs
@@ -1335,6 +1335,11 @@ async fn ensure_setup_auth(
     prompt_for_profile_choice: bool,
     needs_api_key: bool,
 ) -> Result<SetupAuthContext> {
+    let project_was_explicit = base
+        .project
+        .as_deref()
+        .map(str::trim)
+        .is_some_and(|value| !value.is_empty());
     apply_setup_config_fallbacks(base);
 
     let explicit_api_key = base
@@ -1344,7 +1349,7 @@ async fn ensure_setup_auth(
         .filter(|value| !value.is_empty())
         .map(str::to_string);
     let stored_profiles = auth::list_stored_profiles()?;
-    let project_name = base
+    let mut project_name = base
         .project
         .as_deref()
         .map(str::trim)
@@ -1369,6 +1374,15 @@ async fn ensure_setup_auth(
             .clone()
             .unwrap_or_else(|| DEFAULT_APP_URL.to_string());
         let available_orgs = list_available_orgs_for_setup(api_key, &app_url).await?;
+        if let Some(name) = project_name.as_deref() {
+            let matched_orgs = orgs_with_project(base, api_key, &available_orgs, name).await?;
+            clear_missing_fallback_setup_project(
+                base,
+                &mut project_name,
+                project_was_explicit,
+                &matched_orgs,
+            );
+        }
 
         if let Some(profile_name) = profile_name.as_deref() {
             let profile = stored_profiles
@@ -1541,6 +1555,20 @@ async fn ensure_setup_auth(
         ensure_profile_or_oauth_auth(base, prompt_for_profile_choice).await?;
     let client = ApiClient::new(&login_ctx)?;
     build_setup_auth_context(base, client, is_oauth, needs_api_key).await
+}
+
+fn clear_missing_fallback_setup_project(
+    base: &mut BaseArgs,
+    project_name: &mut Option<String>,
+    project_was_explicit: bool,
+    matched_orgs: &[auth::AvailableOrg],
+) {
+    if project_was_explicit || project_name.is_none() || !matched_orgs.is_empty() {
+        return;
+    }
+
+    base.project = None;
+    *project_name = None;
 }
 
 fn sync_setup_api_key(base: &mut BaseArgs, api_key: &str) {
@@ -4833,6 +4861,30 @@ mod tests {
         base.api_key = Some("env-key".to_string());
         base.api_key_source = Some(ArgValueSource::EnvVariable);
         assert!(!should_create_api_key_for_setup(true, &base, true));
+    }
+
+    #[test]
+    fn clear_missing_fallback_setup_project_clears_config_project_without_matches() {
+        let mut base = make_base_args();
+        base.project = Some("stale-project".to_string());
+        let mut project_name = Some("stale-project".to_string());
+
+        clear_missing_fallback_setup_project(&mut base, &mut project_name, false, &[]);
+
+        assert_eq!(base.project, None);
+        assert_eq!(project_name, None);
+    }
+
+    #[test]
+    fn clear_missing_fallback_setup_project_keeps_explicit_project_without_matches() {
+        let mut base = make_base_args();
+        base.project = Some("explicit-project".to_string());
+        let mut project_name = Some("explicit-project".to_string());
+
+        clear_missing_fallback_setup_project(&mut base, &mut project_name, true, &[]);
+
+        assert_eq!(base.project.as_deref(), Some("explicit-project"));
+        assert_eq!(project_name.as_deref(), Some("explicit-project"));
     }
 
     #[test]

--- a/src/ui/select.rs
+++ b/src/ui/select.rs
@@ -6,7 +6,10 @@ use dialoguer::{theme::ColorfulTheme, FuzzySelect, Input};
 
 use crate::{
     http::ApiClient,
-    projects::{api, create::create_project_checked},
+    projects::{
+        api,
+        create::{create_project_checked, CreateProjectOutcome},
+    },
     ui::with_spinner,
 };
 
@@ -100,7 +103,11 @@ pub async fn select_project(
         if trimmed.is_empty() {
             bail!("project name cannot be empty");
         }
-        return create_project_checked(client, trimmed).await;
+        return match create_project_checked(client, trimmed).await? {
+            CreateProjectOutcome::Created(project) | CreateProjectOutcome::Existing(project) => {
+                Ok(project)
+            }
+        };
     }
 
     let project_index = selected_project_index(selection, mode);


### PR DESCRIPTION
`bt setup`, choosing `+ Create new project` then typing the name of an already existing project makes the setup continue and use the existing project.

`bt projects create remove-cedric` when `remove-cedric` already exists still fails with
```
✗ Failed to create 'remove-cedric'
error: project 'remove-cedric' already exists
```
I think we want to keep this behavior.