### PR TITLE
bump version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -498,7 +498,7 @@ dependencies = [
 
 [[package]]
 name = "bt"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "actix-web",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bt"
-version = "0.7.0"
+version = "0.7.1"
 edition = "2021"
 rust-version = "1.86.0"
 authors = ["Braintrust engineering <eng@braintrust.dev>"]


### PR DESCRIPTION
### TL;DR

Bump version to `0.7.1`

### What changed?

The package version has been incremented from `0.7.0` to `0.7.1`.

### How to test?

Verify the version reported by the binary matches `0.7.1` after building:

```sh
cargo build
./target/debug/bt --version
```

### Why make this change?

Patch release to publish the latest changes under a new version number.