### PR TITLE
fix: use new api for loginstate in test

### DIFF
--- a/src/projects/create.rs
+++ b/src/projects/create.rs
@@ -177,13 +177,16 @@ mod tests {
             create_behavior,
         });
         let server = MockServer::start(state).await;
+        let login = LoginState::new();
+        login.set(
+            "test-key".to_string(),
+            "org-1".to_string(),
+            "test-org".to_string(),
+            server.base_url.clone(),
+            "https://app.example.com".to_string(),
+        );
         let client = ApiClient::new(&LoginContext {
-            login: LoginState {
-                api_key: "test-key".to_string(),
-                org_id: "org-1".to_string(),
-                org_name: "test-org".to_string(),
-                api_url: Some(server.base_url.clone()),
-            },
+            login,
             api_url: server.base_url.clone(),
             app_url: "https://app.example.com".to_string(),
         })


### PR DESCRIPTION
Fix test that crashed the CI.

99c84b58f01f820c68c16600eec25f37f9320083 updated braintrust-sdk-rust:
```diff
-source = "git+https://github.com/braintrustdata/braintrust-sdk-rust?rev=c8c7c7a8d9189164584adef71449a26d4ae8be2b#c8c7c7a8d9189164584adef71449a26d4ae8be2b"
+source = "git+https://github.com/braintrustdata/braintrust-sdk-rust?rev=43ba73edbf5220b57090e049feb094b60a92fcd4#43ba73edbf5220b57090e049feb094b60a92fcd4"
```
which changed `LoginState`.

e0fcccb7e22203c1686936a6d95d9d73f5e88be4 added a test using the old `LoginState`. Its CI passed because it was run before 99c84b58f01f820c68c16600eec25f37f9320083 was merged.

The fix was simply to use the new `LoginState` logic.