### PR TITLE
feat(setup): update sdk install skills

### DIFF
--- a/skills/sdk-install/csharp.md
+++ b/skills/sdk-install/csharp.md
@@ -8,13 +8,13 @@ Reference guide for installing the Braintrust C# SDK.
 
 ## Find the latest version of the SDK
 
-Look up the latest version from NuGet **without installing anything**. Do not guess -- use a read-only query so the environment stays unchanged until you pin the exact version.
+Look up the latest version from NuGet **without installing anything**. Do not guess -- use a read-only query so the environment stays unchanged until you write the version into the project file.
 
 ```bash
 dotnet package search Braintrust.Sdk --exact-match
 ```
 
-Then install that exact version:
+Then install that version (the latest published release):
 
 ### .NET CLI
 

--- a/skills/sdk-install/go.md
+++ b/skills/sdk-install/go.md
@@ -8,9 +8,19 @@ Reference guide for installing the Braintrust Go SDK.
 
 ## Install the SDK
 
+Install the latest Braintrust SDK. Do not hard-pin the SDK version unless the user asks -- `go get` without a version suffix is fine and will record whatever version `go mod tidy` resolves.
+
 ```bash
 go get github.com/braintrustdata/braintrust-sdk-go
 ```
+
+If you need to know what the latest version is:
+
+```bash
+go list -m -versions github.com/braintrustdata/braintrust-sdk-go
+```
+
+**Note:** Orchestrion, the build-time instrumentation tool described below, **must** be pinned to an exact version. That requirement is separate from the SDK itself.
 
 ## Instrument the application
 
@@ -30,7 +40,6 @@ Every Go project needs OpenTelemetry setup and a Braintrust client.
 package main
 
 import (
-	"context"
 	"log"
 
 	"github.com/braintrustdata/braintrust-sdk-go"
@@ -39,10 +48,7 @@ import (
 )
 
 func main() {
-	ctx := context.Background()
-
 	tp := trace.NewTracerProvider()
-	defer tp.Shutdown(ctx)
 	otel.SetTracerProvider(tp)
 
 	_, err := braintrust.New(tp, braintrust.WithProject("my-project"))
@@ -54,17 +60,24 @@ func main() {
 
 `braintrust.New` reads `BRAINTRUST_API_KEY` from the environment automatically.
 
-### Requirement: build with Orchestrion
+### Requirement: persist Orchestrion into the normal build/run path
 
-Auto-instrumentation requires building the project with Orchestrion -- without this step, nothing will be traced.
+Auto-instrumentation requires the project to be built and run with Orchestrion. A one-off `orchestrion go build` during verification is **not enough** if the next developer, CI job, or deploy will go back to plain `go build` / `go run`.
 
-**1. Install orchestrion:**
+**1. Resolve and pin an exact Orchestrion version:**
+
+Orchestrion is a build-time dependency that modifies the Go toolchain, so it **must** be pinned to an exact version for reproducible builds -- this is different from the Braintrust SDK itself.
 
 ```bash
-go install github.com/DataDog/orchestrion@v1.6.1
+go list -m -versions github.com/DataDog/orchestrion
+go install github.com/DataDog/orchestrion@vX.Y.Z
 ```
 
-**2. Create `orchestrion.tool.go` in the project root:**
+Do not use `@latest`. Prefer the newest version that is compatible with the project's existing `go` / `toolchain` version. If Orchestrion would require bumping the project's Go version or toolchain, ask the user before making that change.
+
+**2. Create `orchestrion.tool.go` in the module root (the same directory as `go.mod`):**
+
+Prefer importing only the integrations the project actually uses. Use `trace/contrib/all` only if provider detection is genuinely unclear or the project uses many supported integrations.
 
 To instrument all supported providers:
 
@@ -96,20 +109,26 @@ import (
 )
 ```
 
-**3. Build with orchestrion:**
+Then run `go mod tidy` so the exact Orchestrion and contrib versions are recorded in `go.mod` / `go.sum`.
 
-```bash
-orchestrion go build ./...
-```
+**3. Persist Orchestrion into the project's actual workflow:**
 
-Or set GOFLAGS to use orchestrion automatically:
+Update the command the project already expects developers or CI to use:
 
-```bash
-export GOFLAGS="-toolexec='orchestrion toolexec'"
-go build ./...
-```
+- `Makefile` / `justfile` / shell scripts: change `go build`, `go run`, and `go test` invocations to `orchestrion go ...` where appropriate.
+- `Dockerfile`: change build steps to use Orchestrion.
+- Bootstrap / CI / devcontainer setup: if the repo already has a checked-in way to install required tooling, add Orchestrion there too so future users do not hit `orchestrion: command not found`.
+- Repo-local env/config files: if the project already uses a checked-in mechanism for env vars, set `GOFLAGS="-toolexec=orchestrion toolexec"` there.
 
-After this, LLM client calls are automatically traced with no code changes.
+A shell-local `export GOFLAGS=...` in the current terminal does **not** satisfy this requirement by itself, because it will not help the next user or CI run.
+
+If you add `orchestrion.tool.go` but do **not** modify any persisted build/run path, treat the installation as incomplete.
+
+**4. Verify using the same persisted command:**
+
+After wiring Orchestrion into the normal workflow, run that exact command and confirm traces are emitted. Do not verify with a custom one-off command that the project will not use later.
+
+After this, LLM client calls are automatically traced with no application wrapper code.
 
 ### Supported providers
 
@@ -117,15 +136,16 @@ For the current list of supported providers and their `trace/contrib/` import pa
 
 ## Run the application
 
-Try to figure out how to run the application from the project structure:
+Prefer the project's existing build/run entrypoint, and make sure that entrypoint now goes through Orchestrion.
 
-- **go run**: `go run .` or `go run ./cmd/myapp`
-- **Orchestrion**: `orchestrion go run .`
-- **Makefile**: check for `run`, `serve`, or similar targets
-- **Docker**: check for a `Dockerfile`
+Try to figure out how the project is normally run from the project structure:
 
-If you can't determine how to run the app, ask the user.
+- **Makefile / justfile / scripts**: prefer `make run`, `just run`, or the existing repo script if present
+- **go run**: if the project is normally run directly, update that path to `orchestrion go run .` or `orchestrion go run ./cmd/myapp`
+- **Docker**: check for a `Dockerfile` or container build script
+
+If you can't determine how the app is supposed to be built or run in normal use, ask the user before proceeding.
 
 ## Generate a permalink (required)
 
-Follow the permalink generation steps in the agent task (Step 5). Use the value passed to `braintrust.WithProject(...)` as the project name.
+Follow the permalink generation steps in the agent task (Step 5). Use the project name you configured in code above.

--- a/skills/sdk-install/instrument-task.md
+++ b/skills/sdk-install/instrument-task.md
@@ -5,13 +5,15 @@
 {RUN_MODE_CONTEXT}
 
 - **Only add Braintrust code.** Do not refactor or modify unrelated code.
-- **Pin exact versions.** Never use `latest`.
+- **One language, one service per install run.** If the repo has more than one candidate, ask the user which one to instrument before starting. Do not instrument multiple languages or services in the same run.
+- **If the language is unclear, ask the user.** Do not guess. See Step 2.
+- **Install the latest Braintrust SDK.** Do not hard-pin the Braintrust SDK version unless the user asks for it -- use the package manager's normal install (which may produce an exact or a ranged version, whichever is idiomatic for that ecosystem). Build-time dependencies (e.g. Orchestrion for Go) must still be pinned to an exact version -- see the language-specific resource.
 - **Set the project name in code.** Do NOT configure project name via env vars.
 - **App must run without Braintrust.** If `BRAINTRUST_API_KEY` is missing at runtime, do not crash.
 - **Abort install if API key is not set.** (Do not modify runtime behavior.)
 - **Do not guess APIs.** Use official documentation/examples only.
 - **Do not add eval code** unless explicitly requested.
-- **Do not add manual flush/shutdown logic.**
+- **Do not add manual flush/shutdown logic** unless the app is a short-lived script, serverless function, Lambda, or CLI that exits immediately after LLM calls -- in which case a single `flush()` (or language equivalent) right before exit is correct, since otherwise traces get dropped. Do not add flush/shutdown for long-running processes (servers, daemons, workers).
 - **If SDK is already installed/configured, do not duplicate work.**
 - **Do not create setup-only files or directories in the repo.** Do not write `.bt/setup/`, `.bt/skills/docs/`, agent skill directories, or setup task files unless explicitly asked by the user.
 
@@ -51,6 +53,7 @@ If not set, **abort installation immediately**.
 
 ### 4. Verify Installation (MANDATORY)
 
+- If the SDK relies on build-time or launch-time auto-instrumentation, make sure the project's normal build/run path now uses it. A one-off verification command is not sufficient.
 - Run the application.
 - Confirm at least one log/trace is emitted to Braintrust.
 - Confirm no runtime errors.
@@ -67,6 +70,8 @@ The permalink must be included in the final output. This confirms the full insta
 The project name is the project field of `bt status --json`. The project must be set in code during installation — do not guess the project name from context.
 
 **How to obtain the permalink:**
+
+Use the project name you configured in code during Step 3 — do not re-derive it, do not guess, and do not read it from the Braintrust UI.
 
 Most language SDKs print a direct URL to the emitted trace after the app runs. Capture that URL and print it.
 

--- a/skills/sdk-install/java.md
+++ b/skills/sdk-install/java.md
@@ -8,13 +8,13 @@ Reference guide for installing the Braintrust Java SDK.
 
 ## Find the latest version of the SDK
 
-Look up the latest version from Maven Central **without modifying the project**. Do not guess -- use a read-only query so dependencies stay unchanged until you pin the exact version.
+Look up the latest version from Maven Central **without modifying the project**. Do not guess -- use a read-only query so dependencies stay unchanged until you write the version into the build file.
 
 ```bash
 curl -s 'https://search.maven.org/solrsearch/select?q=g:dev.braintrust+AND+a:braintrust-sdk-java&rows=1&wt=json' | python3 -c "import sys,json; print(json.load(sys.stdin)['response']['docs'][0]['latestVersion'])"
 ```
 
-Then add the dependency with that exact version:
+Then add the dependency with that version (the latest published release):
 
 ### Gradle
 
@@ -52,15 +52,23 @@ If the project uses a different build tool, the Maven coordinates are:
 ```java
 import dev.braintrust.Braintrust;
 import dev.braintrust.config.BraintrustConfig;
+import io.opentelemetry.api.OpenTelemetry;
 
-var config = BraintrustConfig.builder()
-    .defaultProjectName("my-project")
-    .build();
-var braintrust = Braintrust.get(config);
-var openTelemetry = braintrust.openTelemetryCreate();
+var apiKey = System.getenv("BRAINTRUST_API_KEY");
+Braintrust braintrust = null;
+OpenTelemetry openTelemetry = null;
+
+if (apiKey != null && !apiKey.isEmpty()) {
+    var config = BraintrustConfig.builder()
+        .apiKey(apiKey)
+        .defaultProjectName("my-project")
+        .build();
+    braintrust = Braintrust.get(config);
+    openTelemetry = braintrust.openTelemetryCreate();
+}
 ```
 
-`Braintrust.get()` is the main entry point. It reads `BRAINTRUST_API_KEY` from the environment automatically.
+`Braintrust.get()` is the main entry point. The SDK requires an API key to be present, so initialize Braintrust conditionally and run the application normally when `BRAINTRUST_API_KEY` is missing.
 
 ## Install instrumentation
 
@@ -120,7 +128,7 @@ Assistant assistant = BraintrustLangchain.wrap(
 
 ### Spring AI
 
-For Spring Boot apps using Spring AI, register Braintrust beans and wrap the underlying LLM client. Example with Google GenAI:
+For Spring Boot apps using Spring AI, only register Braintrust beans when `BRAINTRUST_API_KEY` is non-empty, and wrap the underlying LLM client only in that case. Example with Google GenAI:
 
 ```java
 @Bean
@@ -158,4 +166,4 @@ If you can't determine how to run the app, ask the user.
 
 ## Generate a permalink (required)
 
-Follow the permalink generation steps in the agent task (Step 5). Use the value passed to `defaultProjectName(...)` as the project name.
+Follow the permalink generation steps in the agent task (Step 5). Use the project name you configured in code above.

--- a/skills/sdk-install/python.md
+++ b/skills/sdk-install/python.md
@@ -6,32 +6,26 @@ Reference guide for installing the Braintrust Python SDK.
 - PyPI: https://pypi.org/project/braintrust/
 - Requires Python 3.9+
 
-## Find the latest version of the SDK
+## Install the SDK
 
-Look up the latest version from PyPI **without installing anything**. Do not guess -- use a read-only query so the environment stays unchanged until you pin the exact version.
-
-```bash
-pip index versions braintrust
-```
-
-Then install that exact version with the project's package manager:
+Install the latest published version of `braintrust`. Do not hard-pin the version unless the user asks -- let the package manager record whatever it normally records.
 
 ### pip
 
 ```bash
-pip install braintrust==<VERSION>
+pip install braintrust
 ```
 
 ### poetry
 
 ```bash
-poetry add braintrust==<VERSION>
+poetry add braintrust
 ```
 
 ### uv
 
 ```bash
-uv add braintrust==<VERSION>
+uv add braintrust
 ```
 
 ## Instrument the application
@@ -72,4 +66,4 @@ If you can't determine how to run the app, ask the user.
 
 ## Generate a permalink (required)
 
-Follow the permalink generation steps in the agent task (Step 5). Use the `project=` argument passed to `init_logger` as the project name.
+Follow the permalink generation steps in the agent task (Step 5). Use the project name you configured in code above.

--- a/skills/sdk-install/ruby.md
+++ b/skills/sdk-install/ruby.md
@@ -6,15 +6,9 @@ Reference guide for installing the Braintrust Ruby SDK.
 - RubyGems: https://rubygems.org/gems/braintrust
 - Requires Ruby 3.1+
 
-## Find the latest version of the SDK
-
-Look up the latest version from RubyGems **without installing anything**. Do not guess -- use a read-only query so the environment stays unchanged.
-
-```bash
-gem search braintrust --remote --versions
-```
-
 ## Install the SDK
+
+Install the latest published version of the `braintrust` gem. Do not hard-pin the version unless the user asks -- let Bundler record whatever it normally records.
 
 The SDK has three setup approaches. Choose the one that fits the project best.
 
@@ -32,22 +26,30 @@ Then run:
 bundle install
 ```
 
-Configure the project name in code (preferred over env vars):
+Configure the project name **in code** by calling `Braintrust.init` during app boot. In Rails, add `config/initializers/braintrust.rb`:
 
 ```ruby
-require "braintrust"
-
 Braintrust.init(default_project: "my-project")
 ```
 
-**Important**: The application must call `Bundler.require` for this to work (Rails does this by default). If not, add `require "braintrust/setup"` to an initializer file.
+For non-Rails apps, call `Braintrust.init(default_project: "my-project")` early in the boot sequence (e.g. `config.ru`, `boot.rb`, or the main entrypoint before any LLM clients are created).
+
+Do **not** set the project name via the `BRAINTRUST_DEFAULT_PROJECT` environment variable -- the project name must live in code.
+
+**Important**: The application must call `Bundler.require` for the auto-instrumentation to kick in (Rails does this by default). If not, add `require "braintrust/setup"` to an initializer file.
 
 ### Option B: CLI command (no source code changes)
 
-Install the gem system-wide:
+Install the gem:
 
 ```bash
 gem install braintrust
+```
+
+Or, preferably, add it to the Gemfile so it is checked in:
+
+```ruby
+gem "braintrust"
 ```
 
 Then wrap the application's start command:
@@ -62,6 +64,16 @@ To limit which providers are instrumented:
 ```bash
 braintrust exec --only openai -- ruby app.rb
 ```
+
+**Requirement: persist `braintrust exec` into the normal run path.** A one-off `braintrust exec -- ...` during verification is **not enough** if the next developer, CI job, or deploy will go back to a plain `ruby` / `bundle exec` / `rails server` command. Update whichever launch path the project actually uses:
+
+- **`Procfile` / `foreman`**: change `web: bundle exec rails server` to `web: braintrust exec -- bundle exec rails server`.
+- **`Dockerfile` / container entrypoint**: update the `CMD` / `ENTRYPOINT` or checked-in start script.
+- **Process managers / deploy config**: update systemd units, Kubernetes manifests, ECS task definitions, etc.
+- **`Makefile` / scripts**: update `make run` / `bin/start` / etc.
+- **Bootstrap / CI / devcontainer setup**: if the repo already has a checked-in way to install required tooling, make sure `braintrust` is installed there too so future users and CI do not hit `braintrust: command not found`.
+
+A shell-local one-off `braintrust exec -- ...` does **not** satisfy this requirement by itself. If you use Option B but do not modify any persisted launch path, treat the installation as incomplete.
 
 ### Option C: Braintrust.init (explicit control)
 
@@ -115,15 +127,18 @@ export BRAINTRUST_INSTRUMENT_ONLY=openai,anthropic
 
 ## Run the application
 
-Try to figure out how to run the application from the project structure:
+Prefer the project's existing run entrypoint, and -- if you picked Option B -- make sure that entrypoint now goes through `braintrust exec`.
 
-- **Rails**: `bundle exec rails server` or `bin/rails server`
-- **Rack/Sinatra**: `bundle exec rackup` or `ruby app.rb`
+Try to figure out how the project is normally run from the project structure:
+
+- **Procfile / foreman**: prefer `foreman start` or whatever the repo already uses, and update the `Procfile` entries (not an ad-hoc shell command)
+- **Rails**: `bundle exec rails server` or `bin/rails server` -- if using Option B, update the persisted start script to wrap it in `braintrust exec --`
+- **Rack/Sinatra**: `bundle exec rackup` or `ruby app.rb` -- update the persisted launch command, not a one-off invocation
 - **Script**: `bundle exec ruby main.rb` or `ruby main.rb`
-- **CLI wrap**: `braintrust exec -- <start command>`
+- **Docker / container**: update the `Dockerfile`'s `CMD` / `ENTRYPOINT` or checked-in start script
 
-If you can't determine how to run the app, ask the user.
+If you can't determine how the app is supposed to be run in normal use, ask the user before proceeding.
 
 ## Generate a permalink (required)
 
-Follow the permalink generation steps in the agent task (Step 5). Use the `default_project` argument passed to `Braintrust.init` as the project name.
+Follow the permalink generation steps in the agent task (Step 5). Use the project name you configured in code above.

--- a/skills/sdk-install/typescript.md
+++ b/skills/sdk-install/typescript.md
@@ -6,37 +6,9 @@ Reference guide for installing the Braintrust TypeScript SDK.
 - npm: https://www.npmjs.com/package/braintrust
 - Requires Node.js 18.19.0+ or 20.6.0+ (or Bun 1.0+, Deno with Node compat)
 
-## Find the latest version of the SDK
-
-Look up the latest version from npm. Do not guess -- use the package manager to find the actual latest version.
-
-### npm
-
-```bash
-npm view braintrust version
-```
-
-### yarn
-
-```bash
-yarn info braintrust version
-```
-
-### pnpm
-
-```bash
-pnpm view braintrust version
-```
-
-### bun
-
-```bash
-bun pm view braintrust version
-```
-
 ## Install the SDK
 
-Install with exact versions.
+Install the latest published version of `braintrust`. Do not hard-pin the version unless the user asks -- let the package manager record whatever it normally records (a caret range or an exact version, whichever is idiomatic).
 
 Match the package manager the repo already uses. Check lockfiles to decide:
 
@@ -48,25 +20,25 @@ Match the package manager the repo already uses. Check lockfiles to decide:
 ### npm
 
 ```bash
-npm install --save-exact braintrust@<version> --no-audit --no-fund
+npm install braintrust --no-audit --no-fund
 ```
 
 ### yarn
 
 ```bash
-yarn add --exact braintrust@<version>
+yarn add braintrust
 ```
 
 ### pnpm
 
 ```bash
-pnpm add --save-exact braintrust@<version>
+pnpm add braintrust
 ```
 
 ### bun
 
 ```bash
-bun add --exact braintrust@<version>
+bun add braintrust
 ```
 
 ## Instrument the application
@@ -121,12 +93,6 @@ node --import braintrust/hook.mjs ./dist/index.js
 npx tsx --import braintrust/hook.mjs ./src/index.ts
 ```
 
-Or via the environment:
-
-```bash
-export NODE_OPTIONS="--import braintrust/hook.mjs"
-```
-
 **Any runtime with a bundler (Next.js, webpack, Vite, esbuild, etc.)**
 
 Use the appropriate Braintrust bundler plugin / framework integration -- see https://www.braintrust.dev/docs/instrument/trace-llm-calls for the supported plugins and framework setup (e.g. Next.js `instrumentation.ts`, webpack/Vite/esbuild plugins). This is the preferred option whenever a bundler is in play and works under Node, Bun, Deno, and Cloudflare Workers alike.
@@ -137,25 +103,48 @@ There is no automatic instrumentation path for these runtimes without a bundler.
 
 If none of the above is configured, automatic instrumentation will silently do nothing.
 
-## Run the application
+### Requirement: persist the launch hook into the normal run path
 
-Try to figure out how to run the application from the project structure:
+Auto-instrumentation requires the application to be started with the hook on every run. A one-off `node --import braintrust/hook.mjs ...` or a shell-local `export NODE_OPTIONS=...` during verification is **not enough** if the next developer, CI job, or deploy will go back to plain `node`, `tsx`, or `npm start`.
 
-- **npm scripts**: check `package.json` for `start`, `dev`, or similar scripts and add `--import braintrust/hook.mjs` to the run command, for example:
+Persist the hook into whichever launch path the project actually uses:
+
+- **`package.json` scripts**: update `start`, `dev`, `serve`, etc. to include `--import braintrust/hook.mjs`, for example:
   ```json
-  "start": "node --import braintrust/hook.mjs dist/index.js"
+  "start": "node --import braintrust/hook.mjs dist/index.js",
   "dev": "tsx --import braintrust/hook.mjs src/index.ts"
   ```
-- **Next.js**: `npm run dev` or `npx next dev`
-- **ts-node**: ts-node does not support `--import`; migrate to `tsx` instead (`npm install --save-dev tsx`)
-- **tsx**: `npx tsx --import braintrust/hook.mjs src/index.ts`
-- **Node with TypeScript**: `npx tsc && node --import braintrust/hook.mjs dist/index.js`
+- **`Dockerfile` / container entrypoint**: update the `CMD` / `ENTRYPOINT` or a checked-in start script so containers launch with the hook.
+- **Process managers / deploy config**: update `Procfile`, systemd units, PM2 config, ECS task definitions, Kubernetes manifests, etc. that define the real start command.
+- **Checked-in env/config**: if the project already uses a checked-in mechanism for env vars, set `NODE_OPTIONS="--import braintrust/hook.mjs"` there. Do **not** rely on a shell-local `export NODE_OPTIONS=...` -- it will not help the next user or CI run.
+- **Bundler / framework config**: if a bundler plugin is used, register it in the project's real bundler/framework config file, not in an ad-hoc script.
+
+If you add `initLogger` but do **not** modify any persisted launch path, treat the installation as incomplete.
+
+Verify using the same persisted command the project will actually use (e.g. `npm start`, `npm run dev`, `docker run ...`), not a custom one-off invocation.
+
+## Run the application
+
+Prefer the project's existing launch entrypoint, and make sure that entrypoint now loads the Braintrust hook (or bundler plugin) automatically.
+
+Try to figure out how the project is normally run from the project structure:
+
+- **npm scripts**: prefer `npm start` / `npm run dev` / `pnpm dev` / `yarn start` / `bun run start` -- update the script in `package.json` so it includes `--import braintrust/hook.mjs`, for example:
+  ```json
+  "start": "node --import braintrust/hook.mjs dist/index.js",
+  "dev": "tsx --import braintrust/hook.mjs src/index.ts"
+  ```
+- **Next.js**: `npm run dev` or `npx next dev` -- wire the Braintrust bundler/framework integration in the project's real Next.js config (e.g. `instrumentation.ts`), not a one-off command
+- **ts-node**: ts-node does not support `--import`; migrate to `tsx` instead (`npm install --save-dev tsx`) and update the persisted script
+- **tsx**: update the persisted script to `tsx --import braintrust/hook.mjs src/index.ts`
+- **Node with TypeScript**: update the persisted build + start scripts to `tsc && node --import braintrust/hook.mjs dist/index.js`
 - **Bun**: `bun run <script>` or `bun ./src/index.ts` (without a bundler, use manual wrappers -- `--import` is Node-only and does not apply here)
 - **Deno**: `deno run <script>` (without a bundler, use manual wrappers)
-- **Cloudflare Workers**: `wrangler dev` / `wrangler deploy` (without a bundler, use manual wrappers; with a bundler, use the Braintrust bundler plugin)
+- **Cloudflare Workers**: `wrangler dev` / `wrangler deploy` (without a bundler, use manual wrappers; with a bundler, register the Braintrust bundler plugin in the project's real bundler config)
+- **Docker / container**: update the `Dockerfile`'s `CMD`/`ENTRYPOINT` or the checked-in start script
 
-If you can't determine how to run the app, ask the user.
+If you can't determine how the app is supposed to be built or run in normal use, ask the user before proceeding.
 
 ## Generate a permalink (required)
 
-Follow the permalink generation steps in the agent task (Step 5). Search the project for the `initLogger` call to find the `projectName` — it may be in a separate bootstrap or entry file, not the file currently being edited.
+Follow the permalink generation steps in the agent task (Step 5). Use the project name you configured in code above.

--- a/src/setup/mod.rs
+++ b/src/setup/mod.rs
@@ -2842,6 +2842,7 @@ fn render_instrument_task(
     let unique_langs: BTreeSet<LanguageArg> = languages.iter().copied().collect();
     let language_context = if unique_langs.is_empty() {
         "### 2. Detect Language\n\n\
+         **Instrument exactly one language/service per install run.** Do not install Braintrust for multiple languages or multiple services in the same run, even if the repo contains more than one. If more than one candidate exists, stop and ask the user which single service to instrument before doing anything else.\n\n\
          Determine the project language using concrete signals:\n\n\
          - `package.json` -> TypeScript\n\
          - `requirements.txt`, `setup.py` or `pyproject.toml` -> Python\n\
@@ -2849,12 +2850,15 @@ fn render_instrument_task(
          - `go.mod` -> Go\n\
          - `Gemfile` -> Ruby\n\
          - `.csproj` -> C#\n\n\
-         If the language is not obvious from standard build/dependency files:\n\n\
-         - infer it from concrete repo evidence (e.g., entrypoint file extensions, build scripts, framework config)\n\
-         - State the single strongest piece of evidence you used\n\
-         - If still ambiguous (polyglot/monorepo), ask the user which service/app to instrument and wait for the response before proceeding\n\
-         - If the inferred language is not in the supported list, **abort the install**.\n\n\
-         If none match, **abort installation**."
+         **If exactly one of these matches at the repo root and there is no ambiguity, proceed with that language.**\n\n\
+         In every other case, **stop and ask the user** before continuing. Do not guess, do not pick the \"most likely\" language, and do not instrument more than one. Cases that require asking the user:\n\n\
+         - **No standard build/dependency file is present.** Do not infer from loose hints (file extensions, a stray script, a README mention). Ask the user which language/service to instrument.\n\
+         - **More than one of the above files is present** (polyglot repo, monorepo, or a mixed service). Ask the user which single service to instrument, and where it lives in the repo.\n\
+         - **A workspace/monorepo with multiple sub-projects of the same language** (e.g., several `package.json` or several `go.mod` files). Ask the user which sub-project to instrument.\n\
+         - **The inferred language is not in the supported list above.** Do not fall back to a different language or a generic OpenTelemetry setup -- **abort the install** and tell the user which languages are supported.\n\
+         - **Any other ambiguity** about which app/service the user wants traced. Ask.\n\n\
+         When you ask, be specific: list the candidate services/paths/languages you found and have the user pick exactly one. Then state the single strongest piece of evidence (the file they pointed at) before moving on.\n\n\
+         Do not proceed to Step 3 until exactly one language and one service have been confirmed."
             .to_string()
     } else {
         let names: Vec<String> = unique_langs
@@ -2873,8 +2877,8 @@ fn render_instrument_task(
             list
         )
     };
-    let install_sdk_requirements = "- Pin an exact SDK version (resolve via package manager).\n\
-         - Modify only dependency files and a minimal application entry point (e.g., main/bootstrap). \
+    let install_sdk_requirements = "- Install the latest Braintrust SDK via the language's package manager. Do not hard-pin the SDK version unless the user asks. Build-time dependencies called out by the language-specific resource (e.g. Orchestrion for Go) must still be pinned to an exact version.\n\
+         - Modify only dependency files, a minimal application entry point (e.g., main/bootstrap), and any existing build/run scripts or checked-in env/config that must change to keep auto-instrumentation active in normal use. \
          Auto-instrument the app (except for Java and C# which don't support auto-instrumentation).\n\
          - Do not change unrelated code.";
     let install_sdk_context = if unique_langs.is_empty() {


### PR DESCRIPTION
Apply the SDK installation skill improvements from braintrustdata/braintrust#13243 and adapt them for the bt setup instrumentation workflow. The updated guidance clarifies language/service selection, normal package-manager installs, persisted auto-instrumentation launch paths, and short-lived flush behavior.