### PR TITLE
fix(setup): clarify default project selection

### DIFF
--- a/src/setup/mod.rs
+++ b/src/setup/mod.rs
@@ -1771,7 +1771,7 @@ async fn select_project_for_setup(
         client,
         None,
         Some("Select project"),
-        ui::ProjectSelectMode::AllowCreate,
+        ui::ProjectSelectMode::AllowCreateWithDefaultProjectNote,
     )
     .await
 }

--- a/src/ui/select.rs
+++ b/src/ui/select.rs
@@ -16,7 +16,7 @@ use crate::{
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ProjectSelectMode {
     ExistingOnly,
-    AllowCreate,
+    AllowCreateWithDefaultProjectNote,
 }
 
 /// Open a Term for interactive prompts.
@@ -82,7 +82,6 @@ pub async fn select_project(
     mode: ProjectSelectMode,
 ) -> Result<api::Project> {
     let mut projects = with_spinner("Loading projects...", api::list_projects(client)).await?;
-
     projects.sort_by(|a, b| a.name.cmp(&b.name));
 
     let names = project_selection_labels(&projects, mode);
@@ -90,7 +89,7 @@ pub async fn select_project(
     let label = select_label.unwrap_or("Select project");
     let selection = fuzzy_select(label, &names, default)?;
 
-    if matches!(mode, ProjectSelectMode::AllowCreate) && selection == 0 {
+    if mode_allows_create(mode) && selection == 0 {
         let default_name = default_new_project_name();
         let name: String = Input::with_theme(&ColorfulTheme::default())
             .with_prompt("Project name")
@@ -115,9 +114,17 @@ pub async fn select_project(
 }
 
 fn project_selection_labels(projects: &[api::Project], mode: ProjectSelectMode) -> Vec<String> {
-    if matches!(mode, ProjectSelectMode::AllowCreate) {
+    if mode_allows_create(mode) {
         let mut labels = vec!["+ Create new project".to_string()];
-        labels.extend(projects.iter().map(|project| project.name.clone()));
+        labels.extend(projects.iter().map(|project| {
+            if matches!(mode, ProjectSelectMode::AllowCreateWithDefaultProjectNote)
+                && project.name == "My Project"
+            {
+                "My Project (default starter project)".to_string()
+            } else {
+                project.name.clone()
+            }
+        }));
         return labels;
     }
     projects
@@ -132,7 +139,7 @@ fn default_project_selection(
     mode: ProjectSelectMode,
 ) -> Result<usize> {
     if projects.is_empty() {
-        if matches!(mode, ProjectSelectMode::AllowCreate) {
+        if mode_allows_create(mode) {
             return Ok(0);
         }
         bail!("no projects found");
@@ -141,7 +148,7 @@ fn default_project_selection(
     Ok(current
         .and_then(|c| projects.iter().position(|project| project.name == c))
         .map(|idx| {
-            if matches!(mode, ProjectSelectMode::AllowCreate) {
+            if mode_allows_create(mode) {
                 idx + 1
             } else {
                 idx
@@ -151,11 +158,15 @@ fn default_project_selection(
 }
 
 fn selected_project_index(selection: usize, mode: ProjectSelectMode) -> usize {
-    if matches!(mode, ProjectSelectMode::AllowCreate) {
+    if mode_allows_create(mode) {
         selection - 1
     } else {
         selection
     }
+}
+
+fn mode_allows_create(mode: ProjectSelectMode) -> bool {
+    matches!(mode, ProjectSelectMode::AllowCreateWithDefaultProjectNote)
 }
 
 fn default_new_project_name() -> String {
@@ -216,7 +227,10 @@ mod tests {
 
     #[test]
     fn allow_create_adds_create_option() {
-        let labels = project_selection_labels(&[project("alpha")], ProjectSelectMode::AllowCreate);
+        let labels = project_selection_labels(
+            &[project("alpha")],
+            ProjectSelectMode::AllowCreateWithDefaultProjectNote,
+        );
         assert_eq!(
             labels,
             vec!["+ Create new project".to_string(), "alpha".to_string()]
@@ -230,10 +244,30 @@ mod tests {
     }
 
     #[test]
+    fn allow_create_with_default_project_note_annotates_my_project() {
+        let labels = project_selection_labels(
+            &[project("My Project"), project("alpha")],
+            ProjectSelectMode::AllowCreateWithDefaultProjectNote,
+        );
+        assert_eq!(
+            labels,
+            vec![
+                "+ Create new project".to_string(),
+                "My Project (default starter project)".to_string(),
+                "alpha".to_string(),
+            ]
+        );
+    }
+
+    #[test]
     fn allow_create_defaults_to_create_when_project_list_is_empty() {
         assert_eq!(
-            default_project_selection(&[], None, ProjectSelectMode::AllowCreate)
-                .expect("default selection"),
+            default_project_selection(
+                &[],
+                None,
+                ProjectSelectMode::AllowCreateWithDefaultProjectNote,
+            )
+            .expect("default selection"),
             0
         );
     }
@@ -245,7 +279,10 @@ mod tests {
 
     #[test]
     fn allow_create_project_selection_skips_create_row() {
-        assert_eq!(selected_project_index(1, ProjectSelectMode::AllowCreate), 0);
+        assert_eq!(
+            selected_project_index(1, ProjectSelectMode::AllowCreateWithDefaultProjectNote),
+            0
+        );
     }
 
     #[test]

--- a/src/ui/select.rs
+++ b/src/ui/select.rs
@@ -115,11 +115,15 @@ pub async fn select_project(
 
 fn project_selection_labels(projects: &[api::Project], mode: ProjectSelectMode) -> Vec<String> {
     if mode_allows_create(mode) {
+        let show_default_project_note = matches!(
+            mode,
+            ProjectSelectMode::AllowCreateWithDefaultProjectNote
+        ) && projects.len() == 1
+            && projects[0].name == "My Project";
+
         let mut labels = vec!["+ Create new project".to_string()];
         labels.extend(projects.iter().map(|project| {
-            if matches!(mode, ProjectSelectMode::AllowCreateWithDefaultProjectNote)
-                && project.name == "My Project"
-            {
+            if show_default_project_note && project.name == "My Project" {
                 "My Project (default starter project)".to_string()
             } else {
                 project.name.clone()
@@ -244,7 +248,22 @@ mod tests {
     }
 
     #[test]
-    fn allow_create_with_default_project_note_annotates_my_project() {
+    fn allow_create_with_default_project_note_annotates_my_project_when_it_is_the_only_project() {
+        let labels = project_selection_labels(
+            &[project("My Project")],
+            ProjectSelectMode::AllowCreateWithDefaultProjectNote,
+        );
+        assert_eq!(
+            labels,
+            vec![
+                "+ Create new project".to_string(),
+                "My Project (default starter project)".to_string(),
+            ]
+        );
+    }
+
+    #[test]
+    fn allow_create_with_default_project_note_hides_note_when_there_are_multiple_projects() {
         let labels = project_selection_labels(
             &[project("My Project"), project("alpha")],
             ProjectSelectMode::AllowCreateWithDefaultProjectNote,
@@ -253,7 +272,7 @@ mod tests {
             labels,
             vec![
                 "+ Create new project".to_string(),
-                "My Project (default starter project)".to_string(),
+                "My Project".to_string(),
                 "alpha".to_string(),
             ]
         );

--- a/src/ui/select.rs
+++ b/src/ui/select.rs
@@ -115,11 +115,10 @@ pub async fn select_project(
 
 fn project_selection_labels(projects: &[api::Project], mode: ProjectSelectMode) -> Vec<String> {
     if mode_allows_create(mode) {
-        let show_default_project_note = matches!(
-            mode,
-            ProjectSelectMode::AllowCreateWithDefaultProjectNote
-        ) && projects.len() == 1
-            && projects[0].name == "My Project";
+        let show_default_project_note =
+            matches!(mode, ProjectSelectMode::AllowCreateWithDefaultProjectNote)
+                && projects.len() == 1
+                && projects[0].name == "My Project";
 
         let mut labels = vec!["+ Create new project".to_string()];
         labels.extend(projects.iter().map(|project| {


### PR DESCRIPTION
fixes https://linear.app/braintrustdata/issue/BT-4949/when-using-the-setup-script-right-after-creating-a-fresh-org-just

Update the setup project selector so users in a fresh org can either create an intentional project immediately or continue with the starter project. Instead of showing a bare "My Project" entry, the interactive selector now renders:

```
+ Create new project
My Project (default starter project)
```

The annotation is part of the displayed fuzzy-select label, so users can match it by typing terms like "default" or "starter". Selecting "+ Create new project" prompts for a project name and creates it. Selecting "My Project (default starter project)" uses the existing starter project. Other setup flows that only allow existing projects are unchanged.