### PR TITLE
fix(setup): add post-success verification prompt

### DIFF
--- a/skills/sdk-install/instrument-task.md
+++ b/skills/sdk-install/instrument-task.md
@@ -92,10 +92,12 @@ Summarize:
 
 ---
 
-### 7. Next Steps
+### 7. Post-Success Verification and Next Steps
 
-Tell the user:
+Tell the user exactly how to verify the setup after this run:
 
+- Run the instrumented application path again and open the Braintrust logs link for the configured org/project. If you emitted a specific trace, include the trace permalink from Step 5; otherwise include the project logs URL.
+- If eval code was added or requested, include the Braintrust experiments/evals page URL for the configured org/project.
 - Reusable Braintrust coding-agent skills were not installed by default. The user can opt in later with `bt setup skills`.
 - The Braintrust MCP server can be added explicitly with `bt setup mcp`. More information at https://www.braintrust.dev/docs/integrations/developer-tools/mcp
 - For more information on Braintrust, visit https://www.braintrust.dev/docs

--- a/src/setup/mod.rs
+++ b/src/setup/mod.rs
@@ -13,6 +13,7 @@ use serde::Serialize;
 use serde_json::{Map, Value};
 use tokio::process::Command;
 use toml::Value as TomlValue;
+use urlencoding::encode;
 
 use crate::args::{ArgValueSource, BaseArgs, DEFAULT_API_URL, DEFAULT_APP_URL};
 use crate::auth;
@@ -2204,6 +2205,7 @@ async fn run_instrument_setup(
     if !base.json {
         eprintln!();
         eprintln!("{} Braintrust SDK setup completed.", style("✓").green());
+        print_post_agent_followups(&base);
         if offer_skills_after_success && setup_can_prompt(&base) && !args.yes {
             let term = ui::prompt_term().ok_or_else(|| anyhow!("interactive mode requires TTY"))?;
             let install_skills = Confirm::with_theme(&ColorfulTheme::default())
@@ -2222,6 +2224,45 @@ async fn run_instrument_setup(
         }
     }
     Ok(())
+}
+
+fn print_post_agent_followups(base: &BaseArgs) {
+    eprintln!();
+    eprintln!("Verify your setup in Braintrust:");
+
+    if let Some(logs_url) = setup_project_logs_url(base) {
+        eprintln!("  • Project logs: {logs_url}");
+    }
+    eprintln!("  • Tracing docs: https://www.braintrust.dev/docs/instrument");
+    eprintln!("  • Eval docs: https://www.braintrust.dev/docs/evaluation");
+}
+
+fn setup_project_logs_url(base: &BaseArgs) -> Option<String> {
+    let (org, project) = setup_project_context(base)?;
+    let app_url = base
+        .app_url
+        .as_deref()
+        .unwrap_or(DEFAULT_APP_URL)
+        .trim_end_matches('/');
+    Some(format!(
+        "{}/app/{}/p/{}/logs",
+        app_url,
+        encode(&org),
+        encode(&project)
+    ))
+}
+
+fn setup_project_context(base: &BaseArgs) -> Option<(String, String)> {
+    if let (Some(org), Some(project)) = (base.org_name.as_ref(), base.project.as_ref()) {
+        return Some((org.clone(), project.clone()));
+    }
+
+    let config_path = std::env::current_dir()
+        .ok()?
+        .join(".bt")
+        .join("config.json");
+    let cfg = config::load_file(&config_path);
+    Some((cfg.org?, cfg.project?))
 }
 
 async fn install_reusable_skills_after_setup(base: &BaseArgs, selected: Agent) -> Result<()> {


### PR DESCRIPTION
Update the SDK installation agent task to tell users how to verify setup after a successful run, including logs, evals, and manual instrumentation docs.

resolves https://linear.app/braintrustdata/issue/BT-4945/have-a-step-at-the-end-of-setup-script-that-tells-the-user-how-to