### PR TITLE
fix: unicode issues with bt sync pull

### DIFF
--- a/src/sync.rs
+++ b/src/sync.rs
@@ -2607,6 +2607,34 @@ fn build_root_spans_query(
     parts.join(" | ")
 }
 
+fn parse_duration_to_seconds(input: &str) -> Result<u64> {
+    let trimmed = input.trim();
+    if trimmed.is_empty() {
+        bail!("duration cannot be empty");
+    }
+    if let Ok(seconds) = trimmed.parse::<u64>() {
+        return Ok(seconds);
+    }
+
+    let suffix = trimmed.chars().last().filter(|ch| ch.is_ascii_alphabetic());
+    let (num_str, unit) = match suffix {
+        Some(unit) => (&trimmed[..trimmed.len() - unit.len_utf8()], unit),
+        None => (trimmed, 's'),
+    };
+    let value: u64 = num_str
+        .trim()
+        .parse()
+        .with_context(|| format!("invalid duration '{input}'"))?;
+    let multiplier = match unit.to_ascii_lowercase() {
+        's' => 1,
+        'm' => 60,
+        'h' => 60 * 60,
+        'd' => 60 * 60 * 24,
+        _ => bail!("invalid duration '{input}'. expected suffix s/m/h/d"),
+    };
+    Ok(value.saturating_mul(multiplier))
+}
+
 fn build_time_filter_clause(window: &str, extra_filter: Option<&str>) -> Result<String> {
     let seconds = parse_duration_to_seconds(window)?;
     let time_clause = format!("created >= NOW() - INTERVAL {seconds} SECOND");
@@ -4267,6 +4295,14 @@ fn spinner_bar(message: &str) -> ProgressBar {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn parse_duration_to_seconds_rejects_non_ascii_suffix_without_panicking() {
+        for input in ["1–", "1é", "1🙂"] {
+            let err = parse_duration_to_seconds(input).expect_err("invalid unicode suffix");
+            assert!(err.to_string().contains("invalid duration"));
+        }
+    }
 
     #[test]
     fn push_checkpoint_line_offset_advances_only_after_commit() {

--- a/src/traces.rs
+++ b/src/traces.rs
@@ -5031,6 +5031,34 @@ fn print_span_text(item: Option<&Map<String, Value>>) {
     }
 }
 
+fn parse_duration_to_seconds(input: &str) -> Result<u64> {
+    let trimmed = input.trim();
+    if trimmed.is_empty() {
+        bail!("duration cannot be empty");
+    }
+    if let Ok(seconds) = trimmed.parse::<u64>() {
+        return Ok(seconds);
+    }
+
+    let suffix = trimmed.chars().last().filter(|ch| ch.is_ascii_alphabetic());
+    let (num_str, unit) = match suffix {
+        Some(unit) => (&trimmed[..trimmed.len() - unit.len_utf8()], unit),
+        None => (trimmed, 's'),
+    };
+    let value: u64 = num_str
+        .trim()
+        .parse()
+        .with_context(|| format!("invalid duration '{input}'"))?;
+    let multiplier = match unit.to_ascii_lowercase() {
+        's' => 1,
+        'm' => 60,
+        'h' => 60 * 60,
+        'd' => 60 * 60 * 24,
+        _ => bail!("invalid duration '{input}'. expected suffix s/m/h/d"),
+    };
+    Ok(value.saturating_mul(multiplier))
+}
+
 fn build_base_filter_clause(
     since: Option<&str>,
     window: &str,
@@ -6153,6 +6181,22 @@ mod tests {
                     "render produced empty buffer at size={size}, iter={i}"
                 );
             }
+        }
+    }
+
+    #[test]
+    fn parse_duration_to_seconds_supports_units() {
+        assert_eq!(parse_duration_to_seconds("90").expect("seconds"), 90);
+        assert_eq!(parse_duration_to_seconds("15m").expect("minutes"), 900);
+        assert_eq!(parse_duration_to_seconds("2h").expect("hours"), 7_200);
+        assert_eq!(parse_duration_to_seconds("1d").expect("days"), 86_400);
+    }
+
+    #[test]
+    fn parse_duration_to_seconds_rejects_non_ascii_suffix_without_panicking() {
+        for input in ["1–", "1é", "1🙂"] {
+            let err = parse_duration_to_seconds(input).expect_err("invalid unicode suffix");
+            assert!(err.to_string().contains("invalid duration"));
         }
     }
 


### PR DESCRIPTION
Fix the thread panic with `bt sync pull --window 1é`:
```
bt sync pull --window 1é
✔ Select project · .....
✔ Select object · .....
thread 'main' (233982) panicked at /rustc/ded5c06cf21d2b93bffd5d884aa6e96934ee4234/library/core/src/str/mod.rs:833:21:
byte index 2 is not a char boundary; it is inside 'é' (bytes 1..3) of `1é`
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

Part of https://github.com/braintrustdata/bt/pull/165