### PR TITLE
feat: suggest --json in bt view trace text output

### DIFF
--- a/src/traces.rs
+++ b/src/traces.rs
@@ -4994,12 +4994,7 @@ fn print_trace_text(
         );
     }
     println!(
-        "\nTrace output is truncated. Use `bt view span{} --object-ref {} --id <row-id>` for full span data.",
-        profile_flag_suffix(profile),
-        object_ref
-    );
-    println!(
-        "For the full trace payload in one call, re-run with --json: `bt view trace --json{} --object-ref {} --trace-id {}`.",
+        "\nTrace output is truncated. Re-run with --json for the full trace (`bt view trace --json{0} --object-ref {1} --trace-id {2}`), or fetch a single span with `bt view span{0} --object-ref {1} --id <row-id>`.",
         profile_flag_suffix(profile),
         object_ref,
         trace_id

--- a/src/traces.rs
+++ b/src/traces.rs
@@ -4998,6 +4998,12 @@ fn print_trace_text(
         profile_flag_suffix(profile),
         object_ref
     );
+    println!(
+        "For the full trace payload in one call, re-run with --json: `bt view trace --json{} --object-ref {} --trace-id {}`.",
+        profile_flag_suffix(profile),
+        object_ref,
+        trace_id
+    );
     if let Some(cursor) = next_cursor {
         let limit_suffix = if limit != 50 {
             format!(" --limit {limit}")


### PR DESCRIPTION
The non-JSON text output of `bt view trace` only hinted at `bt view span --id <row-id>` for full data, which requires N per-span calls. Agents running `bt view trace` to analyze a trace would either fan out N requests or pivot to the web UI's CSV export. Add a hint pointing at `--json` so the full trace payload is reachable in one copy-pasteable command, alongside the existing next-page hint.

Fix https://github.com/braintrustdata/bt/issues/178