### PR TITLE
chore: dedupe parse_duration_to_seconds across sync and traces

### DIFF
--- a/src/sync.rs
+++ b/src/sync.rs
@@ -26,6 +26,7 @@ use crate::experiments::api::create_experiment;
 use crate::http::ApiClient;
 use crate::projects::api::{create_project, list_projects, Project};
 use crate::ui::{animations_enabled, fuzzy_select, is_quiet};
+use crate::utils::parse_duration_to_seconds;
 
 const STATE_SCHEMA_VERSION: u32 = 1;
 const DEFAULT_PULL_LIMIT: usize = 100;
@@ -2606,34 +2607,6 @@ fn build_root_spans_query(
     parts.join(" | ")
 }
 
-fn parse_duration_to_seconds(input: &str) -> Result<u64> {
-    let trimmed = input.trim();
-    if trimmed.is_empty() {
-        bail!("duration cannot be empty");
-    }
-    if let Ok(seconds) = trimmed.parse::<u64>() {
-        return Ok(seconds);
-    }
-
-    let suffix = trimmed.chars().last().filter(|ch| ch.is_ascii_alphabetic());
-    let (num_str, unit) = match suffix {
-        Some(unit) => (&trimmed[..trimmed.len() - unit.len_utf8()], unit),
-        None => (trimmed, 's'),
-    };
-    let value: u64 = num_str
-        .trim()
-        .parse()
-        .with_context(|| format!("invalid duration '{input}'"))?;
-    let multiplier = match unit.to_ascii_lowercase() {
-        's' => 1,
-        'm' => 60,
-        'h' => 60 * 60,
-        'd' => 60 * 60 * 24,
-        _ => bail!("invalid duration '{input}'. expected suffix s/m/h/d"),
-    };
-    Ok(value.saturating_mul(multiplier))
-}
-
 fn build_time_filter_clause(window: &str, extra_filter: Option<&str>) -> Result<String> {
     let seconds = parse_duration_to_seconds(window)?;
     let time_clause = format!("created >= NOW() - INTERVAL {seconds} SECOND");
@@ -4294,14 +4267,6 @@ fn spinner_bar(message: &str) -> ProgressBar {
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    #[test]
-    fn parse_duration_to_seconds_rejects_non_ascii_suffix_without_panicking() {
-        for input in ["1–", "1é", "1🙂"] {
-            let err = parse_duration_to_seconds(input).expect_err("invalid unicode suffix");
-            assert!(err.to_string().contains("invalid duration"));
-        }
-    }
 
     #[test]
     fn push_checkpoint_line_offset_advances_only_after_commit() {

--- a/src/traces.rs
+++ b/src/traces.rs
@@ -36,6 +36,7 @@ use crate::args::BaseArgs;
 use crate::auth::{self, login};
 use crate::http::ApiClient;
 use crate::ui::{fuzzy_select, is_interactive, with_spinner};
+use crate::utils::parse_duration_to_seconds;
 
 const MAX_TRACE_SPANS: usize = 5000;
 const MAX_BTQL_PAGE_LIMIT: usize = 1000;
@@ -5030,34 +5031,6 @@ fn print_span_text(item: Option<&Map<String, Value>>) {
     }
 }
 
-fn parse_duration_to_seconds(input: &str) -> Result<u64> {
-    let trimmed = input.trim();
-    if trimmed.is_empty() {
-        bail!("duration cannot be empty");
-    }
-    if let Ok(seconds) = trimmed.parse::<u64>() {
-        return Ok(seconds);
-    }
-
-    let suffix = trimmed.chars().last().filter(|ch| ch.is_ascii_alphabetic());
-    let (num_str, unit) = match suffix {
-        Some(unit) => (&trimmed[..trimmed.len() - unit.len_utf8()], unit),
-        None => (trimmed, 's'),
-    };
-    let value: u64 = num_str
-        .trim()
-        .parse()
-        .with_context(|| format!("invalid duration '{input}'"))?;
-    let multiplier = match unit.to_ascii_lowercase() {
-        's' => 1,
-        'm' => 60,
-        'h' => 60 * 60,
-        'd' => 60 * 60 * 24,
-        _ => bail!("invalid duration '{input}'. expected suffix s/m/h/d"),
-    };
-    Ok(value.saturating_mul(multiplier))
-}
-
 fn build_base_filter_clause(
     since: Option<&str>,
     window: &str,
@@ -6180,22 +6153,6 @@ mod tests {
                     "render produced empty buffer at size={size}, iter={i}"
                 );
             }
-        }
-    }
-
-    #[test]
-    fn parse_duration_to_seconds_supports_units() {
-        assert_eq!(parse_duration_to_seconds("90").expect("seconds"), 90);
-        assert_eq!(parse_duration_to_seconds("15m").expect("minutes"), 900);
-        assert_eq!(parse_duration_to_seconds("2h").expect("hours"), 7_200);
-        assert_eq!(parse_duration_to_seconds("1d").expect("days"), 86_400);
-    }
-
-    #[test]
-    fn parse_duration_to_seconds_rejects_non_ascii_suffix_without_panicking() {
-        for input in ["1–", "1é", "1🙂"] {
-            let err = parse_duration_to_seconds(input).expect_err("invalid unicode suffix");
-            assert!(err.to_string().contains("invalid duration"));
         }
     }
 

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -5,6 +5,7 @@ mod ids;
 mod json_object;
 mod plurals;
 
+pub use duration::parse_duration_to_seconds;
 pub use fs_atomic::write_text_atomic;
 pub use git::GitRepo;
 pub(crate) use ids::new_uuid_id;


### PR DESCRIPTION
Re-applies the deduplication from d72671d that was inadvertently undone by the unicode-safety fix in 29191c0. Both `sync.rs` and `traces.rs` now import the canonical implementation from `utils::duration` instead of carrying their own copies, and `utils/mod.rs` re-exports the helper.

Resolves the dead_code warning reported in #180.