### PR TITLE
add warning/alert when there are provider keys older than 6 months

### DIFF
--- a/src/auth.rs
+++ b/src/auth.rs
@@ -33,6 +33,7 @@ const KEYCHAIN_SERVICE: &str = "com.braintrust.bt.cli";
 const OAUTH_SCOPE: &str = "mcp";
 const OAUTH_CALLBACK_TIMEOUT: Duration = Duration::from_secs(300);
 const OAUTH_REFRESH_SAFETY_WINDOW_SECONDS: u64 = 60;
+const AI_PROVIDER_KEY_STALENESS_CHECK_INTERVAL_SECONDS: i64 = 24 * 60 * 60;
 static SECRET_STORE_FALLBACK_WARNED: AtomicBool = AtomicBool::new(false);
 static AI_PROVIDER_KEY_STALENESS_WARNED: AtomicBool = AtomicBool::new(false);
 
@@ -570,6 +571,8 @@ struct AiProviderSecret {
 struct AiProviderKeyStalenessWarningState {
     #[serde(default)]
     warned: BTreeSet<String>,
+    #[serde(default)]
+    last_checked_at: BTreeMap<String, String>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -667,6 +670,35 @@ fn unwarned_stale_ai_provider_secrets(
         .collect()
 }
 
+fn should_check_ai_provider_key_staleness(
+    state: &AiProviderKeyStalenessWarningState,
+    org_id: &str,
+    now: DateTime<Utc>,
+) -> bool {
+    let Some(last_checked_at) = state
+        .last_checked_at
+        .get(org_id)
+        .and_then(|value| parse_ai_provider_secret_timestamp(Some(value)))
+    else {
+        return true;
+    };
+    if last_checked_at > now {
+        return true;
+    }
+    now.signed_duration_since(last_checked_at).num_seconds()
+        >= AI_PROVIDER_KEY_STALENESS_CHECK_INTERVAL_SECONDS
+}
+
+fn record_ai_provider_key_staleness_check(
+    state: &mut AiProviderKeyStalenessWarningState,
+    org_id: &str,
+    now: DateTime<Utc>,
+) {
+    state
+        .last_checked_at
+        .insert(org_id.to_string(), now.to_rfc3339());
+}
+
 fn ai_provider_key_staleness_warning_message(secret_name: &str) -> String {
     format!(
         "We recommend disabling and rotating AI provider secrets periodically. {secret_name} has not been rotated in over 6 months."
@@ -698,6 +730,14 @@ async fn warn_ai_provider_key_staleness(ctx: &LoginContext) -> Result<()> {
         .login
         .org_id()
         .context("login state missing organization id")?;
+    let now = Utc::now();
+    let mut state = load_ai_provider_warning_state();
+    if !should_check_ai_provider_key_staleness(&state, &org_id, now) {
+        return Ok(());
+    }
+    record_ai_provider_key_staleness_check(&mut state, &org_id, now);
+    let _ = save_ai_provider_warning_state(&state);
+
     let client = build_http_client(crate::http::DEFAULT_HTTP_TIMEOUT)?;
     let response = client
         .post(&url)
@@ -715,11 +755,10 @@ async fn warn_ai_provider_key_staleness(ctx: &LoginContext) -> Result<()> {
         .json::<Vec<AiProviderSecret>>()
         .await
         .context("failed to parse AI provider secrets response")?;
-    let stale = stale_ai_provider_secrets(&org_id, &secrets, Utc::now());
+    let stale = stale_ai_provider_secrets(&org_id, &secrets, now);
     if stale.is_empty() {
         return Ok(());
     }
-    let mut state = load_ai_provider_warning_state();
     let to_warn = unwarned_stale_ai_provider_secrets(stale, &state);
     if to_warn.is_empty() {
         return Ok(());
@@ -3371,6 +3410,7 @@ mod tests {
         };
         let state = AiProviderKeyStalenessWarningState {
             warned: BTreeSet::from([already_warned.warning_key.clone()]),
+            last_checked_at: BTreeMap::new(),
         };
 
         let unwarned =
@@ -3384,6 +3424,61 @@ mod tests {
         assert_eq!(
             ai_provider_key_staleness_warning_message("OPENAI_API_KEY"),
             "We recommend disabling and rotating AI provider secrets periodically. OPENAI_API_KEY has not been rotated in over 6 months."
+        );
+    }
+
+    #[test]
+    fn should_check_ai_provider_key_staleness_at_most_once_per_day_per_org() {
+        let state = AiProviderKeyStalenessWarningState {
+            warned: BTreeSet::new(),
+            last_checked_at: BTreeMap::from([
+                (
+                    "org-id".to_string(),
+                    "2026-05-12T12:00:00+00:00".to_string(),
+                ),
+                (
+                    "other-org-id".to_string(),
+                    "2026-05-13T11:00:00+00:00".to_string(),
+                ),
+            ]),
+        };
+
+        assert!(!should_check_ai_provider_key_staleness(
+            &state,
+            "org-id",
+            dt("2026-05-13T11:59:59Z")
+        ));
+        assert!(should_check_ai_provider_key_staleness(
+            &state,
+            "org-id",
+            dt("2026-05-13T12:00:00Z")
+        ));
+        assert!(should_check_ai_provider_key_staleness(
+            &state,
+            "new-org-id",
+            dt("2026-05-13T11:00:00Z")
+        ));
+    }
+
+    #[test]
+    fn record_ai_provider_key_staleness_check_updates_org_timestamp() {
+        let mut state = AiProviderKeyStalenessWarningState {
+            warned: BTreeSet::new(),
+            last_checked_at: BTreeMap::from([(
+                "other-org-id".to_string(),
+                "2026-05-13T11:00:00+00:00".to_string(),
+            )]),
+        };
+
+        record_ai_provider_key_staleness_check(&mut state, "org-id", dt("2026-05-13T12:00:00Z"));
+
+        assert_eq!(
+            state.last_checked_at.get("org-id"),
+            Some(&"2026-05-13T12:00:00+00:00".to_string())
+        );
+        assert_eq!(
+            state.last_checked_at.get("other-org-id"),
+            Some(&"2026-05-13T11:00:00+00:00".to_string())
         );
     }
 
@@ -3401,6 +3496,10 @@ mod tests {
                 "org-id:openai-secret:2025-11-12T00:00:00Z".to_string(),
                 "org-id:anthropic-secret:2025-11-10T00:00:00Z".to_string(),
             ]),
+            last_checked_at: BTreeMap::from([(
+                "org-id".to_string(),
+                "2026-05-13T12:00:00+00:00".to_string(),
+            )]),
         };
 
         save_ai_provider_warning_state(&state).expect("save warning state");
@@ -3410,6 +3509,7 @@ mod tests {
         restore_env_var("APPDATA", previous_appdata);
 
         assert_eq!(loaded.warned, state.warned);
+        assert_eq!(loaded.last_checked_at, state.last_checked_at);
     }
 
     fn env_test_lock() -> &'static Mutex<()> {

--- a/src/auth.rs
+++ b/src/auth.rs
@@ -1,4 +1,4 @@
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, BTreeSet};
 use std::error::Error as StdError;
 use std::fs;
 use std::io::{IsTerminal, Write};
@@ -551,6 +551,8 @@ pub async fn login(base: &BaseArgs) -> Result<LoginContext> {
 
 #[derive(Debug, Deserialize)]
 struct AiProviderSecret {
+    #[serde(default)]
+    id: Option<String>,
     name: String,
     #[serde(default)]
     r#type: Option<String>,
@@ -564,6 +566,18 @@ struct AiProviderSecret {
     created: Option<String>,
 }
 
+#[derive(Debug, Default, Deserialize, Serialize)]
+struct AiProviderKeyStalenessWarningState {
+    #[serde(default)]
+    warned: BTreeSet<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct StaleAiProviderSecret {
+    name: String,
+    warning_key: String,
+}
+
 fn parse_ai_provider_secret_timestamp(value: Option<&str>) -> Option<DateTime<Utc>> {
     let value = value?.trim();
     if value.is_empty() {
@@ -574,12 +588,44 @@ fn parse_ai_provider_secret_timestamp(value: Option<&str>) -> Option<DateTime<Ut
         .map(|parsed| parsed.with_timezone(&Utc))
 }
 
-fn stale_ai_provider_secret_names(secrets: &[AiProviderSecret], now: DateTime<Utc>) -> Vec<String> {
+fn ai_provider_warning_state_path() -> Result<PathBuf> {
+    Ok(crate::config::global_config_dir()?.join("ai_provider_key_warnings.json"))
+}
+
+fn load_ai_provider_warning_state() -> AiProviderKeyStalenessWarningState {
+    let Ok(path) = ai_provider_warning_state_path() else {
+        return AiProviderKeyStalenessWarningState::default();
+    };
+    let Ok(contents) = fs::read_to_string(path) else {
+        return AiProviderKeyStalenessWarningState::default();
+    };
+    serde_json::from_str(&contents).unwrap_or_default()
+}
+
+fn save_ai_provider_warning_state(state: &AiProviderKeyStalenessWarningState) -> Result<()> {
+    let path = ai_provider_warning_state_path()?;
+    let parent = path.parent().unwrap_or_else(|| Path::new("."));
+    fs::create_dir_all(parent)?;
+
+    let json = serde_json::to_string_pretty(state)?;
+    let mut file = tempfile::NamedTempFile::new_in(parent)?;
+    file.write_all(json.as_bytes())?;
+    file.write_all(b"\n")?;
+    file.as_file().sync_all()?;
+    file.persist(path)?;
+    Ok(())
+}
+
+fn stale_ai_provider_secrets(
+    org_id: &str,
+    secrets: &[AiProviderSecret],
+    now: DateTime<Utc>,
+) -> Vec<StaleAiProviderSecret> {
     let Some(cutoff) = now.checked_sub_months(Months::new(6)) else {
         return Vec::new();
     };
 
-    let mut stale_names = secrets
+    let mut stale = secrets
         .iter()
         .filter(|secret| {
             secret
@@ -588,29 +634,47 @@ fn stale_ai_provider_secret_names(secrets: &[AiProviderSecret], now: DateTime<Ut
                 .is_some_and(|preview| !preview.trim().is_empty())
         })
         .filter_map(|secret| {
-            let updated_at = parse_ai_provider_secret_timestamp(
-                secret
-                    .secret_updated_at
-                    .as_deref()
-                    .or(secret.updated_at.as_deref())
-                    .or(secret.created.as_deref()),
-            )?;
-            (updated_at < cutoff).then(|| {
-                secret
-                    .r#type
-                    .as_deref()
-                    .filter(|value| !value.trim().is_empty())
-                    .unwrap_or(&secret.name)
-                    .to_string()
-            })
+            let updated_at_raw = secret
+                .secret_updated_at
+                .as_deref()
+                .or(secret.updated_at.as_deref())
+                .or(secret.created.as_deref())?;
+            let updated_at = parse_ai_provider_secret_timestamp(Some(updated_at_raw))?;
+            if updated_at >= cutoff {
+                return None;
+            }
+            let identity = secret
+                .id
+                .as_deref()
+                .or(secret.r#type.as_deref())
+                .unwrap_or(&secret.name);
+            let name = secret.name.clone();
+            let warning_key = format!("{org_id}:{identity}:{updated_at_raw}");
+            Some(StaleAiProviderSecret { name, warning_key })
         })
         .collect::<Vec<_>>();
-    stale_names.sort();
-    stale_names
+    stale.sort_by(|a, b| a.name.cmp(&b.name));
+    stale
+}
+
+fn unwarned_stale_ai_provider_secrets(
+    stale: Vec<StaleAiProviderSecret>,
+    state: &AiProviderKeyStalenessWarningState,
+) -> Vec<StaleAiProviderSecret> {
+    stale
+        .into_iter()
+        .filter(|secret| !state.warned.contains(&secret.warning_key))
+        .collect()
 }
 
 async fn maybe_warn_ai_provider_key_staleness(base: &BaseArgs, ctx: &LoginContext) {
-    if base.json || ui::is_quiet() || ctx.login.org_id().is_none_or(|org_id| org_id.trim().is_empty()) {
+    if base.json
+        || ui::is_quiet()
+        || ctx
+            .login
+            .org_id()
+            .is_none_or(|org_id| org_id.trim().is_empty())
+    {
         return;
     }
     if AI_PROVIDER_KEY_STALENESS_WARNED.swap(true, Ordering::Relaxed) {
@@ -645,23 +709,29 @@ async fn warn_ai_provider_key_staleness(ctx: &LoginContext) -> Result<()> {
         .json::<Vec<AiProviderSecret>>()
         .await
         .context("failed to parse AI provider secrets response")?;
-    let stale_names = stale_ai_provider_secret_names(&secrets, Utc::now());
-    if stale_names.is_empty() {
+    let stale = stale_ai_provider_secrets(&org_id, &secrets, Utc::now());
+    if stale.is_empty() {
+        return Ok(());
+    }
+    let mut state = load_ai_provider_warning_state();
+    let to_warn = unwarned_stale_ai_provider_secrets(stale, &state);
+    if to_warn.is_empty() {
         return Ok(());
     }
 
-    let label = if stale_names.len() == 1 {
-        "key has"
-    } else {
-        "keys have"
-    };
-    ui::print_command_status(
-        ui::CommandStatus::Warning,
-        &format!(
-            "The following AI provider {label} not been rotated in over 6 months: {}",
-            stale_names.join(", ")
-        ),
-    );
+    for secret in &to_warn {
+        ui::print_command_status(
+            ui::CommandStatus::Warning,
+            &format!(
+                "We recommend disabling and rotating AI provider secrets periodically. This {} has not been rotated in over 6 months.",
+                secret.name
+            ),
+        );
+    }
+    state
+        .warned
+        .extend(to_warn.into_iter().map(|secret| secret.warning_key));
+    let _ = save_ai_provider_warning_state(&state);
     Ok(())
 }
 
@@ -3155,6 +3225,75 @@ mod tests {
             ca_cert: None,
             env_file: None,
         }
+    }
+
+    fn dt(value: &str) -> DateTime<Utc> {
+        DateTime::parse_from_rfc3339(value)
+            .expect("timestamp")
+            .with_timezone(&Utc)
+    }
+
+    #[test]
+    fn stale_ai_provider_secrets_returns_configured_keys_older_than_six_months() {
+        let secrets = vec![
+            AiProviderSecret {
+                id: Some("openai-secret".to_string()),
+                name: "OPENAI_API_KEY".to_string(),
+                r#type: Some("openai".to_string()),
+                preview_secret: Some("********".to_string()),
+                secret_updated_at: Some("2025-11-12T00:00:00Z".to_string()),
+                updated_at: None,
+                created: None,
+            },
+            AiProviderSecret {
+                id: Some("anthropic-secret".to_string()),
+                name: "ANTHROPIC_API_KEY".to_string(),
+                r#type: Some("anthropic".to_string()),
+                preview_secret: Some("********".to_string()),
+                secret_updated_at: Some("2025-11-14T00:00:00Z".to_string()),
+                updated_at: None,
+                created: None,
+            },
+            AiProviderSecret {
+                id: Some("gemini-secret".to_string()),
+                name: "GEMINI_API_KEY".to_string(),
+                r#type: Some("google".to_string()),
+                preview_secret: None,
+                secret_updated_at: Some("2025-01-01T00:00:00Z".to_string()),
+                updated_at: None,
+                created: None,
+            },
+        ];
+
+        let stale = stale_ai_provider_secrets("org-id", &secrets, dt("2026-05-13T00:00:00Z"));
+
+        assert_eq!(
+            stale,
+            vec![StaleAiProviderSecret {
+                name: "OPENAI_API_KEY".to_string(),
+                warning_key: "org-id:openai-secret:2025-11-12T00:00:00Z".to_string(),
+            }]
+        );
+    }
+
+    #[test]
+    fn unwarned_stale_ai_provider_secrets_skips_previously_warned_key_versions() {
+        let already_warned = StaleAiProviderSecret {
+            name: "openai".to_string(),
+            warning_key: "org-id:secret-id:2025-11-12T00:00:00Z".to_string(),
+        };
+        let newly_stale = StaleAiProviderSecret {
+            name: "openai".to_string(),
+            warning_key: "org-id:secret-id:2026-05-13T00:00:00Z".to_string(),
+        };
+        let state = AiProviderKeyStalenessWarningState {
+            warned: BTreeSet::from([already_warned.warning_key.clone()]),
+        };
+
+        let unwarned =
+            unwarned_stale_ai_provider_secrets(vec![already_warned, newly_stale.clone()], &state);
+
+        assert_eq!(unwarned, vec![newly_stale]);
     }
 
     fn env_test_lock() -> &'static Mutex<()> {

--- a/src/auth.rs
+++ b/src/auth.rs
@@ -10,6 +10,7 @@ use std::time::Duration;
 use anyhow::{bail, Context, Result};
 use base64::Engine as _;
 use braintrust_sdk_rust::{BraintrustClient, LoginState};
+use chrono::{DateTime, Months, Utc};
 use clap::{Args, Subcommand};
 use crossterm::event::{self, Event, KeyCode, KeyEventKind};
 use dialoguer::{Confirm, Input, Password};
@@ -18,6 +19,7 @@ use oauth2::{
     AuthUrl, ClientId, CsrfToken, PkceCodeChallenge, PkceCodeVerifier, RedirectUrl, Scope, TokenUrl,
 };
 use serde::{Deserialize, Serialize};
+use serde_json::json;
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::net::TcpListener;
 
@@ -32,6 +34,7 @@ const OAUTH_SCOPE: &str = "mcp";
 const OAUTH_CALLBACK_TIMEOUT: Duration = Duration::from_secs(300);
 const OAUTH_REFRESH_SAFETY_WINDOW_SECONDS: u64 = 60;
 static SECRET_STORE_FALLBACK_WARNED: AtomicBool = AtomicBool::new(false);
+static AI_PROVIDER_KEY_STALENESS_WARNED: AtomicBool = AtomicBool::new(false);
 
 #[derive(Clone)]
 pub struct LoginContext {
@@ -537,11 +540,129 @@ pub async fn login(base: &BaseArgs) -> Result<LoginContext> {
         .clone()
         .unwrap_or_else(|| DEFAULT_APP_URL.to_string());
 
-    Ok(LoginContext {
+    let ctx = LoginContext {
         login,
         api_url,
         app_url,
-    })
+    };
+    maybe_warn_ai_provider_key_staleness(base, &ctx).await;
+    Ok(ctx)
+}
+
+#[derive(Debug, Deserialize)]
+struct AiProviderSecret {
+    name: String,
+    #[serde(default)]
+    r#type: Option<String>,
+    #[serde(default)]
+    preview_secret: Option<String>,
+    #[serde(default)]
+    secret_updated_at: Option<String>,
+    #[serde(default)]
+    updated_at: Option<String>,
+    #[serde(default)]
+    created: Option<String>,
+}
+
+fn parse_ai_provider_secret_timestamp(value: Option<&str>) -> Option<DateTime<Utc>> {
+    let value = value?.trim();
+    if value.is_empty() {
+        return None;
+    }
+    DateTime::parse_from_rfc3339(value)
+        .ok()
+        .map(|parsed| parsed.with_timezone(&Utc))
+}
+
+fn stale_ai_provider_secret_names(secrets: &[AiProviderSecret], now: DateTime<Utc>) -> Vec<String> {
+    let Some(cutoff) = now.checked_sub_months(Months::new(6)) else {
+        return Vec::new();
+    };
+
+    let mut stale_names = secrets
+        .iter()
+        .filter(|secret| {
+            secret
+                .preview_secret
+                .as_deref()
+                .is_some_and(|preview| !preview.trim().is_empty())
+        })
+        .filter_map(|secret| {
+            let updated_at = parse_ai_provider_secret_timestamp(
+                secret
+                    .secret_updated_at
+                    .as_deref()
+                    .or(secret.updated_at.as_deref())
+                    .or(secret.created.as_deref()),
+            )?;
+            (updated_at < cutoff).then(|| {
+                secret
+                    .r#type
+                    .as_deref()
+                    .filter(|value| !value.trim().is_empty())
+                    .unwrap_or(&secret.name)
+                    .to_string()
+            })
+        })
+        .collect::<Vec<_>>();
+    stale_names.sort();
+    stale_names
+}
+
+async fn maybe_warn_ai_provider_key_staleness(base: &BaseArgs, ctx: &LoginContext) {
+    if base.json || ui::is_quiet() || ctx.login.org_id().is_none_or(|org_id| org_id.trim().is_empty()) {
+        return;
+    }
+    if AI_PROVIDER_KEY_STALENESS_WARNED.swap(true, Ordering::Relaxed) {
+        return;
+    }
+
+    let _ = warn_ai_provider_key_staleness(ctx).await;
+}
+
+async fn warn_ai_provider_key_staleness(ctx: &LoginContext) -> Result<()> {
+    let app_url = ctx.app_url.trim_end_matches('/');
+    let url = format!("{app_url}/api/ai_secret/get");
+    let api_key = ctx.login.api_key().context("login state missing API key")?;
+    let org_id = ctx
+        .login
+        .org_id()
+        .context("login state missing organization id")?;
+    let client = build_http_client(crate::http::DEFAULT_HTTP_TIMEOUT)?;
+    let response = client
+        .post(&url)
+        .bearer_auth(api_key)
+        .json(&json!({ "org_id": org_id }))
+        .send()
+        .await
+        .with_context(|| format!("failed to call AI provider secrets endpoint {url}"))?;
+
+    if !response.status().is_success() {
+        return Ok(());
+    }
+
+    let secrets = response
+        .json::<Vec<AiProviderSecret>>()
+        .await
+        .context("failed to parse AI provider secrets response")?;
+    let stale_names = stale_ai_provider_secret_names(&secrets, Utc::now());
+    if stale_names.is_empty() {
+        return Ok(());
+    }
+
+    let label = if stale_names.len() == 1 {
+        "key has"
+    } else {
+        "keys have"
+    };
+    ui::print_command_status(
+        ui::CommandStatus::Warning,
+        &format!(
+            "The following AI provider {label} not been rotated in over 6 months: {}",
+            stale_names.join(", ")
+        ),
+    );
+    Ok(())
 }
 
 fn has_cached_project_id(base: &BaseArgs) -> bool {

--- a/src/auth.rs
+++ b/src/auth.rs
@@ -667,6 +667,12 @@ fn unwarned_stale_ai_provider_secrets(
         .collect()
 }
 
+fn ai_provider_key_staleness_warning_message(secret_name: &str) -> String {
+    format!(
+        "We recommend disabling and rotating AI provider secrets periodically. {secret_name} has not been rotated in over 6 months."
+    )
+}
+
 async fn maybe_warn_ai_provider_key_staleness(base: &BaseArgs, ctx: &LoginContext) {
     if base.json
         || ui::is_quiet()
@@ -722,10 +728,7 @@ async fn warn_ai_provider_key_staleness(ctx: &LoginContext) -> Result<()> {
     for secret in &to_warn {
         ui::print_command_status(
             ui::CommandStatus::Warning,
-            &format!(
-                "We recommend disabling and rotating AI provider secrets periodically. This {} has not been rotated in over 6 months.",
-                secret.name
-            ),
+            &ai_provider_key_staleness_warning_message(&secret.name),
         );
     }
     state
@@ -3233,36 +3236,56 @@ mod tests {
             .with_timezone(&Utc)
     }
 
+    fn ai_provider_secret(
+        id: Option<&str>,
+        name: &str,
+        secret_type: Option<&str>,
+        preview_secret: Option<&str>,
+        secret_updated_at: Option<&str>,
+        updated_at: Option<&str>,
+        created: Option<&str>,
+    ) -> AiProviderSecret {
+        AiProviderSecret {
+            id: id.map(str::to_string),
+            name: name.to_string(),
+            r#type: secret_type.map(str::to_string),
+            preview_secret: preview_secret.map(str::to_string),
+            secret_updated_at: secret_updated_at.map(str::to_string),
+            updated_at: updated_at.map(str::to_string),
+            created: created.map(str::to_string),
+        }
+    }
+
     #[test]
     fn stale_ai_provider_secrets_returns_configured_keys_older_than_six_months() {
         let secrets = vec![
-            AiProviderSecret {
-                id: Some("openai-secret".to_string()),
-                name: "OPENAI_API_KEY".to_string(),
-                r#type: Some("openai".to_string()),
-                preview_secret: Some("********".to_string()),
-                secret_updated_at: Some("2025-11-12T00:00:00Z".to_string()),
-                updated_at: None,
-                created: None,
-            },
-            AiProviderSecret {
-                id: Some("anthropic-secret".to_string()),
-                name: "ANTHROPIC_API_KEY".to_string(),
-                r#type: Some("anthropic".to_string()),
-                preview_secret: Some("********".to_string()),
-                secret_updated_at: Some("2025-11-14T00:00:00Z".to_string()),
-                updated_at: None,
-                created: None,
-            },
-            AiProviderSecret {
-                id: Some("gemini-secret".to_string()),
-                name: "GEMINI_API_KEY".to_string(),
-                r#type: Some("google".to_string()),
-                preview_secret: None,
-                secret_updated_at: Some("2025-01-01T00:00:00Z".to_string()),
-                updated_at: None,
-                created: None,
-            },
+            ai_provider_secret(
+                Some("openai-secret"),
+                "OPENAI_API_KEY",
+                Some("openai"),
+                Some("********"),
+                Some("2025-11-12T00:00:00Z"),
+                None,
+                None,
+            ),
+            ai_provider_secret(
+                Some("anthropic-secret"),
+                "ANTHROPIC_API_KEY",
+                Some("anthropic"),
+                Some("********"),
+                Some("2025-11-14T00:00:00Z"),
+                None,
+                None,
+            ),
+            ai_provider_secret(
+                Some("gemini-secret"),
+                "GEMINI_API_KEY",
+                Some("google"),
+                None,
+                Some("2025-01-01T00:00:00Z"),
+                None,
+                None,
+            ),
         ];
 
         let stale = stale_ai_provider_secrets("org-id", &secrets, dt("2026-05-13T00:00:00Z"));
@@ -3274,6 +3297,66 @@ mod tests {
                 warning_key: "org-id:openai-secret:2025-11-12T00:00:00Z".to_string(),
             }]
         );
+    }
+
+    #[test]
+    fn stale_ai_provider_secrets_uses_timestamp_fallbacks_and_ignores_invalid_dates() {
+        let secrets = vec![
+            ai_provider_secret(
+                None,
+                "OPENAI_API_KEY",
+                Some("openai"),
+                Some("********"),
+                None,
+                Some("2025-11-12T00:00:00Z"),
+                None,
+            ),
+            ai_provider_secret(
+                None,
+                "ANTHROPIC_API_KEY",
+                Some("anthropic"),
+                Some("********"),
+                None,
+                Some("not-a-date"),
+                Some("2025-01-01T00:00:00Z"),
+            ),
+            ai_provider_secret(
+                None,
+                "GEMINI_API_KEY",
+                Some("google"),
+                Some("********"),
+                None,
+                None,
+                None,
+            ),
+        ];
+
+        let stale = stale_ai_provider_secrets("org-id", &secrets, dt("2026-05-13T00:00:00Z"));
+
+        assert_eq!(
+            stale,
+            vec![StaleAiProviderSecret {
+                name: "OPENAI_API_KEY".to_string(),
+                warning_key: "org-id:openai:2025-11-12T00:00:00Z".to_string(),
+            }]
+        );
+    }
+
+    #[test]
+    fn stale_ai_provider_secrets_does_not_treat_exact_six_month_cutoff_as_stale() {
+        let secrets = vec![ai_provider_secret(
+            Some("openai-secret"),
+            "OPENAI_API_KEY",
+            Some("openai"),
+            Some("********"),
+            Some("2025-11-13T00:00:00Z"),
+            None,
+            None,
+        )];
+
+        let stale = stale_ai_provider_secrets("org-id", &secrets, dt("2026-05-13T00:00:00Z"));
+
+        assert!(stale.is_empty());
     }
 
     #[test]
@@ -3294,6 +3377,39 @@ mod tests {
             unwarned_stale_ai_provider_secrets(vec![already_warned, newly_stale.clone()], &state);
 
         assert_eq!(unwarned, vec![newly_stale]);
+    }
+
+    #[test]
+    fn ai_provider_key_staleness_warning_message_includes_key_name() {
+        assert_eq!(
+            ai_provider_key_staleness_warning_message("OPENAI_API_KEY"),
+            "We recommend disabling and rotating AI provider secrets periodically. OPENAI_API_KEY has not been rotated in over 6 months."
+        );
+    }
+
+    #[tokio::test]
+    async fn ai_provider_warning_state_round_trips_through_global_config_dir() {
+        let _guard = env_test_lock().lock().await;
+        let previous_xdg_config_home = env::var_os("XDG_CONFIG_HOME");
+        let previous_appdata = env::var_os("APPDATA");
+        let config_dir = TempDir::new().expect("create temp config dir");
+        env::set_var("XDG_CONFIG_HOME", config_dir.path());
+        env::set_var("APPDATA", config_dir.path());
+
+        let state = AiProviderKeyStalenessWarningState {
+            warned: BTreeSet::from([
+                "org-id:openai-secret:2025-11-12T00:00:00Z".to_string(),
+                "org-id:anthropic-secret:2025-11-10T00:00:00Z".to_string(),
+            ]),
+        };
+
+        save_ai_provider_warning_state(&state).expect("save warning state");
+        let loaded = load_ai_provider_warning_state();
+
+        restore_env_var("XDG_CONFIG_HOME", previous_xdg_config_home);
+        restore_env_var("APPDATA", previous_appdata);
+
+        assert_eq!(loaded.warned, state.warned);
     }
 
     fn env_test_lock() -> &'static Mutex<()> {


### PR DESCRIPTION
We have this in the product UI (configs page) but the CLI should also probably surface some sort of notification when a provider key is older than 6 months. This can be displayed just once and check daily for newly stale keys