### PR TITLE
chore(security): bump rustls-webpki to 0.103.13

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2633,9 +2633,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.9"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7df23109aa6c1567d1c575b9952556388da57401e4ace1d15f79eedad0d8f53"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "ring",
  "rustls-pki-types",


### PR DESCRIPTION
Resolves [4 RustSec advisories](https://crates.io/crates/rustls-webpki/security) on rustls-webpki 0.103.9 surfaced by `cargo audit`:

- RUSTSEC-2026-0049 (CRLs not authoritative by Distribution Point)
- RUSTSEC-2026-0098 (URI name constraints incorrectly accepted)
- RUSTSEC-2026-0099 (wildcard name constraints incorrectly accepted)
- RUSTSEC-2026-0104 (reachable panic in CRL parsing)

Lockfile-only change.

Haven't checked if we are vulnerable or not but there's nothing to lose by doing this.