### PR TITLE
fix: handle RemoteEvalParameters in eval dev /list endpoint

### DIFF
--- a/scripts/eval-runner.py
+++ b/scripts/eval-runner.py
@@ -26,7 +26,7 @@ try:
         set_thread_pool_max_workers,
     )
     from braintrust.logger import Dataset, init as init_logger_experiment, parent_context, _internal_get_global_state
-    from braintrust.parameters import parameters_to_json_schema, validate_parameters
+    from braintrust.parameters import RemoteEvalParameters, parameters_to_json_schema, validate_parameters
     from braintrust.util import eprint
     from braintrust.span_identifier_v4 import parse_parent
 except Exception as exc:  # pragma: no cover - runtime guard
@@ -566,8 +566,14 @@ def build_eval_definitions(evaluator_instances: list[EvaluatorInstance]) -> dict
     for evaluator_instance in evaluator_instances:
         evaluator = evaluator_instance.evaluator
         scores = [{"name": getattr(score, "__name__", f"scorer_{i}")} for i, score in enumerate(evaluator.scores)]
+        if isinstance(evaluator.parameters, RemoteEvalParameters):
+            parameters_schema: dict[str, Any] = evaluator.parameters.schema or {}
+        elif evaluator.parameters:
+            parameters_schema = parameters_to_json_schema(evaluator.parameters)
+        else:
+            parameters_schema = {}
         definitions[evaluator.eval_name] = {
-            "parameters": parameters_to_json_schema(evaluator.parameters) if evaluator.parameters else {},
+            "parameters": parameters_schema,
             "scores": scores,
         }
     return definitions


### PR DESCRIPTION
## Summary
- Fix `AttributeError: 'RemoteEvalParameters' object has no attribute 'items'` raised by `build_eval_definitions` when an `Eval(...)` is declared with `parameters=load_parameters(...)`.
- The dev server's `/list` endpoint was masking this as a generic 500 (`Eval runner exited with an error.`), so the Playground Remote evals settings page just said "could not connect to the dev server" with no actionable trace.
- Branch on `RemoteEvalParameters` in the runner and pass through its already-resolved `.schema`, matching what the SDK itself does at `braintrust/framework.py:1515` and `braintrust/parameters.py:357`.

## Bug path

1. Customer calls `params = load_parameters(project=..., slug=...)` → returns a `RemoteEvalParameters` object.
2. Customer passes `parameters=params` into `Eval(...)`.
3. UI hits `/list` on the dev server → bt spawns `eval-runner.py` with `BT_EVAL_DEV_MODE=list`.
4. `build_eval_definitions` (was `eval-runner.py:570`) calls `parameters_to_json_schema(evaluator.parameters)` unconditionally; that helper calls `parameters.items()`, which `RemoteEvalParameters` does not implement → uncaught `AttributeError`.
5. Runner exits non-zero. Rust `dev_server_list` returns a generic 500 with no error detail (the traceback goes to stderr, not through `sse.send(\"error\", ...)`).

## Verification (local)

- `BT_EVAL_DEV_MODE=list python scripts/eval-runner.py eval_repro_15895.py --local` against the same `Eval(..., parameters=load_parameters(project=\"repro-15895\", slug=\"eval-config\"))` repro: previously crashed with the `AttributeError` at line 570 → now emits the correctly-serialized JSON schema.
- Built `cargo build --release` and ran the patched binary against the same eval file. `curl http://localhost:8301/list` (with `Authorization: Bearer` + `x-bt-org-name`) previously returned `500 {\"error\":\"Eval runner exited with an error.\"}`; now returns `200` with the full param schema (model + eval_prompt + temperature + system_prompt all resolved).

## Test plan
- [ ] CI green
- [ ] Manual repro from Pylon #15895: `bt eval <file>.py --language=python --dev --dev-port 8301` against an `Eval(..., parameters=load_parameters(...))` no longer crashes the dev server, and the Playground Remote evals settings page lists the eval with all saved parameters visible
- [ ] Sanity: existing inline `Eval(parameters={\"prefix\": PrefixParam, \"main\": {\"type\": \"prompt\", ...}})` flow is unchanged

Pylon: #15895

🤖 Generated with [Claude Code](https://claude.com/claude-code)