### PR TITLE
fix(datasets): Fix btql select for datasets

### DIFF
--- a/src/datasets/api.rs
+++ b/src/datasets/api.rs
@@ -247,7 +247,12 @@ fn build_dataset_rows_query(
 fn dataset_rows_select_fields() -> Vec<Value> {
     DATASET_RECORD_FIELDS
         .iter()
-        .map(|field| json!({"op": "ident", "name": [field]}))
+        .map(|field| {
+            json!({
+                "alias": field,
+                "expr": {"op": "ident", "name": [field]}
+            })
+        })
         .collect()
 }
 
@@ -267,12 +272,12 @@ mod tests {
             query,
             serde_json::json!({
                 "select": [
-                    {"op": "ident", "name": ["id"]},
-                    {"op": "ident", "name": ["input"]},
-                    {"op": "ident", "name": ["expected"]},
-                    {"op": "ident", "name": ["metadata"]},
-                    {"op": "ident", "name": ["tags"]},
-                    {"op": "ident", "name": ["origin"]}
+                    {"alias": "id", "expr": {"op": "ident", "name": ["id"]}},
+                    {"alias": "input", "expr": {"op": "ident", "name": ["input"]}},
+                    {"alias": "expected", "expr": {"op": "ident", "name": ["expected"]}},
+                    {"alias": "metadata", "expr": {"op": "ident", "name": ["metadata"]}},
+                    {"alias": "tags", "expr": {"op": "ident", "name": ["tags"]}},
+                    {"alias": "origin", "expr": {"op": "ident", "name": ["origin"]}}
                 ],
                 "from": {
                     "op": "function",

--- a/tests/datasets.rs
+++ b/tests/datasets.rs
@@ -320,24 +320,16 @@ fn mock_btql_select_fields(body: &[u8]) -> Option<Vec<String>> {
         if item.get("op").and_then(Value::as_str) == Some("star") {
             return None;
         }
-        let Some(expr) = item.get("expr").and_then(Value::as_object) else {
-            return None;
-        };
+        let expr = item.get("expr").and_then(Value::as_object)?;
         if expr.get("op").and_then(Value::as_str) != Some("ident") {
             return None;
         }
-        let Some(name) = expr.get("name").and_then(Value::as_array) else {
-            return None;
-        };
+        let name = expr.get("name").and_then(Value::as_array)?;
         if name.len() != 1 {
             return None;
         }
-        if item.get("alias").and_then(Value::as_str).is_none() {
-            return None;
-        }
-        let Some(field) = name.first().and_then(Value::as_str) else {
-            return None;
-        };
+        item.get("alias").and_then(Value::as_str)?;
+        let field = name.first().and_then(Value::as_str)?;
         fields.push(field.to_string());
     }
     Some(fields)

--- a/tests/datasets.rs
+++ b/tests/datasets.rs
@@ -320,10 +320,19 @@ fn mock_btql_select_fields(body: &[u8]) -> Option<Vec<String>> {
         if item.get("op").and_then(Value::as_str) == Some("star") {
             return None;
         }
-        let Some(name) = item.get("name").and_then(Value::as_array) else {
+        let Some(expr) = item.get("expr").and_then(Value::as_object) else {
+            return None;
+        };
+        if expr.get("op").and_then(Value::as_str) != Some("ident") {
+            return None;
+        }
+        let Some(name) = expr.get("name").and_then(Value::as_array) else {
             return None;
         };
         if name.len() != 1 {
+            return None;
+        }
+        if item.get("alias").and_then(Value::as_str).is_none() {
             return None;
         }
         let Some(field) = name.first().and_then(Value::as_str) else {


### PR DESCRIPTION
Fix `bt datasets view` row loading by emitting structured BTQL `select` items as aliased expressions instead of raw identifiers.

The backend expects `select` entries to be either `{ alias, expr }` or `{ op: "star" }`. The dataset view path was sending `{ op: "ident", name: [...] }`, which caused `/btql` to reject the request with a 400.