### PR TITLE
release: v0.9.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -498,7 +498,7 @@ dependencies = [
 
 [[package]]
 name = "bt"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "actix-web",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bt"
-version = "0.9.0"
+version = "0.9.1"
 edition = "2021"
 rust-version = "1.86.0"
 authors = ["Braintrust engineering <eng@braintrust.dev>"]


### PR DESCRIPTION
Features:
- 96242fa6720b29370051fc3f5bfd1a6a2518543f Warn the user about provider keys older than 6 months
- 80bc84e5273285fccc503ab57c519c4a6db6976d improve readability of `bt view trace` by llms
- c07e9706b17bcf0afcceafcb77ee7d1f82da7b5a Support pagination keys in the xact utils

Performance improvements:
- af4341da2675dd3369b3034e8b423875b39d65f6 More efficient data reading in `bt sync push`

Bug fix:
- 1af95e5973abb3ce3c4a2b6a1cb053eda6414d8a `--verbose` was defaulting to true for `bt sync pull`
- 6d5c23ece9131dd11d532b757345bb572d281194 `bt datasets view --full` was broken, fixed the btql 