### PR TITLE
fix: release message, bt not packaged for brew

### DIFF
--- a/dist-workspace.toml
+++ b/dist-workspace.toml
@@ -15,7 +15,7 @@ create-release = true
 pr-run-mode = "plan"
 ssldotcom-windows-sign = "test"
 # The installers to generate for each app
-installers = ["shell", "powershell", "homebrew"]
+installers = ["shell", "powershell"]
 homepage = "https://github.com/braintrustdata/bt"
 # Target platforms to build apps for (Rust target-triple syntax)
 targets = ["aarch64-apple-darwin", "aarch64-unknown-linux-gnu", "aarch64-pc-windows-msvc", "x86_64-apple-darwin", "x86_64-unknown-linux-gnu", "x86_64-unknown-linux-musl", "x86_64-pc-windows-msvc"]


### PR DESCRIPTION
Previously added `homebrew` to the list of installers in `dist-workspace.toml` even though `bt` ins't packaged for `homebrew`.
This commit removes it.