### PR TITLE
Python push parameters

### DIFF
--- a/scripts/functions-runner.py
+++ b/scripts/functions-runner.py
@@ -4,7 +4,7 @@ import inspect
 import json
 import os
 import sys
-from contextlib import nullcontext
+from contextlib import nullcontext, redirect_stdout
 from typing import Any
 
 from python_runner_common import (
@@ -42,7 +42,7 @@ def to_json_value(value: Any) -> Any:
     return str(value)
 
 
-def load_framework_globals() -> tuple[Any, Any, Any]:
+def load_framework_globals() -> tuple[Any, Any, Any, Any]:
     # Prefer current SDK layout first:
     # - braintrust.framework2 exposes module-level `global_`
     # - braintrust.framework exposes `_set_lazy_load`
@@ -50,13 +50,19 @@ def load_framework_globals() -> tuple[Any, Any, Any]:
         from braintrust.framework import _set_lazy_load as lazy
         from braintrust.framework2 import global_ as global_state
 
-        return global_state.functions, global_state.prompts, lazy
+        parameters = getattr(global_state, "parameters", [])
+        return global_state.functions, global_state.prompts, parameters, lazy
     except (ImportError, ModuleNotFoundError):
         # Backward compatibility with older SDK layout.
         from braintrust.framework2.global_ import functions, prompts
         from braintrust.framework2.lazy_load import _set_lazy_load as lazy
 
-        return functions, prompts, lazy
+        try:
+            from braintrust.framework2.global_ import parameters
+        except ImportError:
+            parameters = []
+
+        return functions, prompts, parameters, lazy
 
 
 def normalize_project_selector(project: Any) -> tuple[str | None, str | None]:
@@ -284,9 +290,10 @@ async def process_file(file_path: str) -> dict[str, Any]:
         sys.path.insert(0, cwd)
 
     purge_local_modules(cwd, preserve_modules={__name__, "python_runner_common"})
-    functions_registry, prompts_registry, lazy_loader = load_framework_globals()
+    functions_registry, prompts_registry, parameters_registry, lazy_loader = load_framework_globals()
     clear_registry(functions_registry)
     clear_registry(prompts_registry)
+    clear_registry(parameters_registry)
 
     module_name = import_module_name_from_cwd(cwd, abs_path)
     if module_name is None:
@@ -297,8 +304,9 @@ async def process_file(file_path: str) -> dict[str, Any]:
     with lazy_ctx:
         import_file(module_name, abs_path, extra_paths)
         code_entries = collect_code_entries(functions_registry)
-        event_entries = await collect_function_event_entries(prompts_registry)
-        entries = [*code_entries, *event_entries]
+        prompt_event_entries = await collect_function_event_entries(prompts_registry)
+        parameter_event_entries = await collect_function_event_entries(parameters_registry)
+        entries = [*code_entries, *prompt_event_entries, *parameter_event_entries]
         file_manifest: dict[str, Any] = {
             "source_file": abs_path,
             "entries": entries,
@@ -357,6 +365,7 @@ async def process_file(file_path: str) -> dict[str, Any]:
 
     clear_registry(functions_registry)
     clear_registry(prompts_registry)
+    clear_registry(parameters_registry)
     return file_manifest
 
 
@@ -394,7 +403,8 @@ async def main() -> None:
         "baseline_dep_versions": resolve_baseline_dep_versions(),
     }
     for file_path in files:
-        manifest["files"].append(await process_file(file_path))
+        with redirect_stdout(sys.stderr):
+            manifest["files"].append(await process_file(file_path))
 
     sys.stdout.write(json.dumps(manifest))
 

--- a/scripts/functions-runner.py
+++ b/scripts/functions-runner.py
@@ -272,6 +272,8 @@ async def collect_function_event_entries(prompts_registry: Any) -> list[dict[str
                 definition = await definition
             normalized = to_json_value(definition)
             if isinstance(normalized, dict):
+                if normalized.get("if_exists") is None:
+                    normalized.pop("if_exists", None)
                 project_id, project_name = normalize_project_selector(getattr(item, "project", None))
                 event_entry: dict[str, Any] = {"kind": "function_event", "event": normalized}
                 if project_id:

--- a/tests/functions.rs
+++ b/tests/functions.rs
@@ -1524,6 +1524,13 @@ parameters.append(ParameterItem())
             .and_then(Value::as_str),
         Some("parameters")
     );
+    assert!(
+        parameter_entry
+            .get("event")
+            .and_then(|event| event.get("if_exists"))
+            .is_none(),
+        "unset parameter if_exists should be omitted so CLI fallback applies"
+    );
 
     let bundle = file
         .get("python_bundle")

--- a/tests/functions.rs
+++ b/tests/functions.rs
@@ -1373,7 +1373,7 @@ fn functions_python_runner_emits_valid_manifest_with_bundle() {
     std::fs::write(framework_dir.join("__init__.py"), "").expect("write framework __init__");
     std::fs::write(
         framework_dir.join("global_.py"),
-        "functions = []\nprompts = []\n",
+        "functions = []\nprompts = []\nparameters = []\n",
     )
     .expect("write global_.py");
     std::fs::write(
@@ -1385,7 +1385,9 @@ fn functions_python_runner_emits_valid_manifest_with_bundle() {
     let sample_path = tmp.path().join("sample_tool.py");
     std::fs::write(
         &sample_path,
-        r#"from braintrust.framework2.global_ import functions
+        r#"from braintrust.framework2.global_ import functions, parameters
+
+print("import noise")
 
 class TypeEnum:
     value = "tool"
@@ -1404,6 +1406,22 @@ class Item:
         self.preview = "def handler(x):\n    return x"
 
 functions.append(Item())
+
+class ParameterItem:
+    def __init__(self):
+        self.project = "My Project"
+
+    def to_function_definition(self, _if_exists, resolver):
+        return {
+            "project_id": resolver.get(self.project),
+            "name": "py-parameters",
+            "slug": "py-parameters",
+            "function_type": "parameters",
+            "function_data": {"type": "parameters", "data": {}, "__schema": {}},
+            "if_exists": _if_exists,
+        }
+
+parameters.append(ParameterItem())
 "#,
     )
     .expect("write sample_tool.py");
@@ -1428,6 +1446,11 @@ functions.append(Item())
         let stderr = String::from_utf8_lossy(&output.stderr);
         panic!("python functions runner failed:\n{stderr}");
     }
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("import noise"),
+        "import-time stdout should be redirected to stderr"
+    );
 
     let manifest: Value = serde_json::from_slice(&output.stdout).expect("parse manifest JSON");
     assert_eq!(
@@ -1462,8 +1485,12 @@ functions.append(Item())
         .get("entries")
         .and_then(Value::as_array)
         .expect("entries array");
-    assert_eq!(entries.len(), 1, "expected one code entry");
-    let entry = entries[0].as_object().expect("entry object");
+    assert_eq!(entries.len(), 2, "expected code and parameter entries");
+    let entry = entries
+        .iter()
+        .find(|entry| entry.get("kind").and_then(Value::as_str) == Some("code"))
+        .and_then(Value::as_object)
+        .expect("code entry object");
     assert_eq!(entry.get("kind").and_then(Value::as_str), Some("code"));
     assert_eq!(entry.get("name").and_then(Value::as_str), Some("py-tool"));
     assert_eq!(entry.get("slug").and_then(Value::as_str), Some("py-tool"));
@@ -1474,6 +1501,28 @@ functions.append(Item())
     assert_eq!(
         entry.get("preview").and_then(Value::as_str),
         Some("def handler(x):\n    return x")
+    );
+    let parameter_entry = entries
+        .iter()
+        .find(|entry| {
+            entry.get("kind").and_then(Value::as_str) == Some("function_event")
+                && entry
+                    .get("event")
+                    .and_then(|event| event.get("slug"))
+                    .and_then(Value::as_str)
+                    == Some("py-parameters")
+        })
+        .expect("parameter function_event entry");
+    assert_eq!(
+        parameter_entry.get("project_name").and_then(Value::as_str),
+        Some("My Project")
+    );
+    assert_eq!(
+        parameter_entry
+            .get("event")
+            .and_then(|event| event.get("function_type"))
+            .and_then(Value::as_str),
+        Some("parameters")
     );
 
     let bundle = file


### PR DESCRIPTION
support pushing `bt functions push` for parameters in python files


I did `bt functions push eval-config.py`: <details>
```
import braintrust
from pydantic import BaseModel, Field

project = braintrust.projects.create(name="My Project")


class TemperatureParam(BaseModel):
    value: float = Field(default=0.2, description="Sampling temperature")


class SystemPromptParam(BaseModel):
    value: str = Field(
        default="You are a helpful assistant.",
        description="System prompt to use",
    )


project.parameters.create(
    name="Evaluation config-btpy2",
    slug="eval-config-btpy2",
    description="Configuration for model evaluation",
    schema={
        "model": {
            "type": "model",
            "default": "gpt-5-mini",
            "description": "Model to evaluate",
        },
        "temperature": TemperatureParam,
        "system_prompt": SystemPromptParam,
        "eval_prompt": {
            "type": "prompt",
            "description": "Prompt to use for the evaluation task",
            "default": {
                "prompt": {
                    "type": "chat",
                    "messages": [{"role": "user", "content": "{{input}}"}],
                },
                "options": {"model": "gpt-5-mini"},
            },
        },
    },
    metadata={"version": "1.0"},
)
```
</details>