### PR TITLE
Fix a few footguns in topics CLI

### DIFF
--- a/src/topics/api.rs
+++ b/src/topics/api.rs
@@ -2114,13 +2114,31 @@ fn status_progress_time_filter_clause(
 ) -> Option<(String, i64)> {
     let window_seconds = match progress_window_seconds_override {
         Some(window_seconds) => window_seconds,
-        None => backfill_time_range_to_window_seconds(backfill_time_range)
-            .or(runtime_window_seconds)
-            .map(cap_status_progress_window_seconds)?,
+        None => {
+            if let Some(absolute_filter) = absolute_time_filter_clause(backfill_time_range) {
+                return Some(absolute_filter);
+            }
+            backfill_time_range_to_window_seconds(backfill_time_range)
+                .or(runtime_window_seconds)
+                .map(cap_status_progress_window_seconds)?
+        }
     };
     Some((
         created_time_filter_clause_from_window_seconds(Some(window_seconds))?,
         window_seconds,
+    ))
+}
+
+fn absolute_time_filter_clause(value: Option<&Value>) -> Option<(String, i64)> {
+    let value = value?;
+    let map = value.as_object()?;
+    let from_raw = map.get("from")?.as_str()?;
+    let to_raw = map.get("to")?.as_str()?;
+    let from = from_raw.replace('\'', "''");
+    let to = to_raw.replace('\'', "''");
+    Some((
+        format!("created >= '{from}' AND created <= '{to}'"),
+        backfill_time_range_to_window_seconds(Some(value))?,
     ))
 }
 
@@ -2338,6 +2356,22 @@ mod tests {
             Some((
                 "created >= NOW() - INTERVAL 604800 SECOND".to_string(),
                 604800
+            ))
+        );
+    }
+
+    #[test]
+    fn status_progress_time_filter_preserves_absolute_ranges() {
+        let range = json!({
+            "from": "2026-04-13T10:00:00Z",
+            "to": "2026-04-13T11:30:00Z",
+        });
+        assert_eq!(
+            status_progress_time_filter_clause(Some(&range), None, None),
+            Some((
+                "created >= '2026-04-13T10:00:00Z' AND created <= '2026-04-13T11:30:00Z'"
+                    .to_string(),
+                5400
             ))
         );
     }

--- a/src/topics/api.rs
+++ b/src/topics/api.rs
@@ -18,6 +18,7 @@ const DEFAULT_TOPIC_RELABEL_OVERLAP_SECONDS: i64 = 60 * 60;
 const DEFAULT_TOPIC_IDLE_SECONDS: i64 = 10 * 60;
 const DEFAULT_TOPIC_SAMPLING_RATE: f64 = 1.0;
 const DEFAULT_TOPIC_EMBEDDING_MODEL: &str = "brain-embedding-1";
+const MAX_STATUS_PROGRESS_WINDOW_SECONDS: i64 = 24 * 60 * 60;
 
 #[derive(Debug, Clone, Serialize)]
 pub struct TopicsStatusReport {
@@ -76,6 +77,8 @@ pub struct TopicAutomationStatus {
     pub idle_seconds: Option<i64>,
     pub configured_facets: usize,
     pub configured_topic_maps: usize,
+    pub progress_loaded: bool,
+    pub progress_window_seconds: Option<i64>,
     pub processing_lag_label: Option<String>,
     pub processing_lag_seconds: Option<i64>,
     pub total_traces: usize,
@@ -350,14 +353,25 @@ struct BtqlValueRequest<'a> {
     brainstore_realtime: bool,
 }
 
-pub async fn fetch_topics_status(ctx: &ProjectContext) -> Result<TopicsStatusReport> {
+pub async fn fetch_topics_status(
+    ctx: &ProjectContext,
+    include_progress: bool,
+    progress_window_seconds_override: Option<i64>,
+) -> Result<TopicsStatusReport> {
     let rows = list_topic_automation_rows(&ctx.client, &ctx.project.id).await?;
     let mut function_cache = HashMap::new();
     let mut automations = Vec::with_capacity(rows.len());
     for row in &rows {
         automations.push(
-            build_topic_automation_status(&ctx.client, &ctx.project.id, row, &mut function_cache)
-                .await?,
+            build_topic_automation_status(
+                &ctx.client,
+                &ctx.project.id,
+                row,
+                include_progress,
+                progress_window_seconds_override,
+                &mut function_cache,
+            )
+            .await?,
         );
     }
     automations.sort_by(|left, right| left.name.cmp(&right.name).then(left.id.cmp(&right.id)));
@@ -1177,6 +1191,8 @@ async fn build_topic_automation_status(
     client: &ApiClient,
     project_id: &str,
     row: &Value,
+    include_progress: bool,
+    progress_window_seconds_override: Option<i64>,
     function_cache: &mut HashMap<String, Value>,
 ) -> Result<TopicAutomationStatus> {
     let config = row
@@ -1199,36 +1215,40 @@ async fn build_topic_automation_status(
             .await?;
     let facet_functions =
         summarize_function_refs(client, function_cache, config.get("facet_functions")).await?;
-    let topic_bars = build_topic_status_bars(client, function_cache, &config).await?;
-    let facet_bars = build_facet_status_bars(client, function_cache, &config, &topic_bars).await?;
 
     let mut total_traces = 0;
     let mut facet_current_count = 0;
     let mut facets = Vec::new();
     let mut topics = Vec::new();
-    let time_filter_clause =
-        created_time_filter_clause(config.get("backfill_time_range")).or_else(|| {
-            created_time_filter_clause_from_window_seconds(
-                object_cursor
-                    .topic_runtime
-                    .as_ref()
-                    .and_then(|runtime| runtime.selected_window_seconds),
+    let mut progress_window_seconds = None;
+    if include_progress {
+        let topic_bars = build_topic_status_bars(client, function_cache, &config).await?;
+        let facet_bars =
+            build_facet_status_bars(client, function_cache, &config, &topic_bars).await?;
+        let runtime_window_seconds = object_cursor
+            .topic_runtime
+            .as_ref()
+            .and_then(|runtime| runtime.selected_window_seconds);
+        if let Some((time_filter_clause, window_seconds)) = status_progress_time_filter_clause(
+            config.get("backfill_time_range"),
+            runtime_window_seconds,
+            progress_window_seconds_override,
+        ) {
+            progress_window_seconds = Some(window_seconds);
+            let progress = fetch_topic_automation_progress(
+                client,
+                project_id,
+                &time_filter_clause,
+                &cursor,
+                &facet_bars,
+                &topic_bars,
             )
-        });
-    if let Some(time_filter_clause) = time_filter_clause {
-        let progress = fetch_topic_automation_progress(
-            client,
-            project_id,
-            &time_filter_clause,
-            &cursor,
-            &facet_bars,
-            &topic_bars,
-        )
-        .await?;
-        total_traces = progress.total_traces;
-        facet_current_count = progress.facet_current_count;
-        facets = progress.facets;
-        topics = progress.topics;
+            .await?;
+            total_traces = progress.total_traces;
+            facet_current_count = progress.facet_current_count;
+            facets = progress.facets;
+            topics = progress.topics;
+        }
     }
 
     Ok(TopicAutomationStatus {
@@ -1249,6 +1269,8 @@ async fn build_topic_automation_status(
             .get("topic_map_functions")
             .and_then(Value::as_array)
             .map_or(0, Vec::len),
+        progress_loaded: include_progress,
+        progress_window_seconds,
         processing_lag_label: format_processing_lag_from_xact_range(
             cursor.pending_min_executed_xact_id.as_deref(),
             cursor.pending_max_compacted_xact_id.as_deref(),
@@ -2076,26 +2098,6 @@ fn escape_btql_ident_path(parts: &[&str]) -> String {
         .join(".")
 }
 
-fn created_time_filter_clause(value: Option<&Value>) -> Option<String> {
-    let value = value?;
-    if let Some(value) = value.as_str() {
-        if let Some(interval_ms) = value.strip_prefix("interval_ms:") {
-            let interval_ms = interval_ms.parse::<i64>().ok()?;
-            return Some(format!(
-                "created >= NOW() - INTERVAL {} SECOND",
-                std::cmp::max(1, (interval_ms as f64 / 1000.0).round() as i64)
-            ));
-        }
-        return parse_duration_to_seconds(value)
-            .map(|seconds| format!("created >= NOW() - INTERVAL {seconds} SECOND"));
-    }
-
-    let map = value.as_object()?;
-    let from = map.get("from")?.as_str()?.replace('\'', "''");
-    let to = map.get("to")?.as_str()?.replace('\'', "''");
-    Some(format!("created >= '{from}' AND created <= '{to}'"))
-}
-
 fn created_time_filter_clause_from_window_seconds(window_seconds: Option<i64>) -> Option<String> {
     window_seconds.map(|window_seconds| {
         format!(
@@ -2103,6 +2105,27 @@ fn created_time_filter_clause_from_window_seconds(window_seconds: Option<i64>) -
             std::cmp::max(1, window_seconds)
         )
     })
+}
+
+fn status_progress_time_filter_clause(
+    backfill_time_range: Option<&Value>,
+    runtime_window_seconds: Option<i64>,
+    progress_window_seconds_override: Option<i64>,
+) -> Option<(String, i64)> {
+    let window_seconds = match progress_window_seconds_override {
+        Some(window_seconds) => window_seconds,
+        None => backfill_time_range_to_window_seconds(backfill_time_range)
+            .or(runtime_window_seconds)
+            .map(cap_status_progress_window_seconds)?,
+    };
+    Some((
+        created_time_filter_clause_from_window_seconds(Some(window_seconds))?,
+        window_seconds,
+    ))
+}
+
+fn cap_status_progress_window_seconds(window_seconds: i64) -> i64 {
+    window_seconds.clamp(1, MAX_STATUS_PROGRESS_WINDOW_SECONDS)
 }
 
 fn processing_lag_seconds_from_xact_range(
@@ -2280,6 +2303,42 @@ mod tests {
         assert_eq!(
             backfill_time_range_to_window_seconds(Some(&json!("interval_ms:90000"))),
             Some(90)
+        );
+    }
+
+    #[test]
+    fn status_progress_time_filter_caps_to_one_day() {
+        assert_eq!(
+            status_progress_time_filter_clause(Some(&json!("7d")), None, None),
+            Some((
+                "created >= NOW() - INTERVAL 86400 SECOND".to_string(),
+                86400
+            ))
+        );
+        assert_eq!(
+            status_progress_time_filter_clause(Some(&json!("6h")), None, None),
+            Some((
+                "created >= NOW() - INTERVAL 21600 SECOND".to_string(),
+                21600
+            ))
+        );
+        assert_eq!(
+            status_progress_time_filter_clause(None, Some(604800), None),
+            Some((
+                "created >= NOW() - INTERVAL 86400 SECOND".to_string(),
+                86400
+            ))
+        );
+    }
+
+    #[test]
+    fn status_progress_time_filter_allows_explicit_override() {
+        assert_eq!(
+            status_progress_time_filter_clause(Some(&json!("1d")), None, Some(604800)),
+            Some((
+                "created >= NOW() - INTERVAL 604800 SECOND".to_string(),
+                604800
+            ))
         );
     }
 

--- a/src/topics/config.rs
+++ b/src/topics/config.rs
@@ -35,6 +35,56 @@ pub async fn run_view(
     Ok(())
 }
 
+pub async fn run_view_target(
+    ctx: &ResolvedContext,
+    automation_id: Option<&str>,
+    target: &str,
+    json: bool,
+) -> Result<()> {
+    let report = with_spinner(
+        "Loading Topics config...",
+        api::fetch_topics_config(ctx, automation_id),
+    )
+    .await?;
+    let target = normalize_target(target)?;
+
+    if let Some(automation) = resolve_automation_config_target(&report, target)? {
+        if json {
+            println!("{}", serde_json::to_string(automation)?);
+            return Ok(());
+        }
+
+        print_with_pager(&render_single_config(
+            &format_project_header(
+                &report.project.name,
+                &report.project.id,
+                &report.project.org_name,
+            ),
+            automation,
+        ))?;
+        return Ok(());
+    }
+
+    let resolved = resolve_topic_map_config_target(&report, target)?;
+    print_topic_map_view(&report, resolved, json)
+}
+
+pub async fn run_topic_map_view(
+    ctx: &ResolvedContext,
+    automation_id: Option<&str>,
+    topic_map: &str,
+    json: bool,
+) -> Result<()> {
+    let report = with_spinner(
+        "Loading Topics topic map config...",
+        api::fetch_topics_config(ctx, automation_id),
+    )
+    .await?;
+    let topic_map = normalize_target(topic_map)?;
+    let resolved = resolve_topic_map_config_target(&report, topic_map)?;
+    print_topic_map_view(&report, resolved, json)
+}
+
 pub async fn run_set(ctx: &ResolvedContext, args: &ConfigSetArgs, json: bool) -> Result<()> {
     let patch = args.to_patch()?;
     let updated = with_spinner(
@@ -190,6 +240,20 @@ fn render_single_topic_map_update(header: &str, updated: &TopicMapConfigUpdate) 
     output
 }
 
+fn render_single_topic_map_config(
+    header: &str,
+    automation: &TopicAutomationConfig,
+    topic_map: &FunctionSummary,
+) -> String {
+    let mut output = String::new();
+    output.push_str(header);
+    output.push('\n');
+    output.push('\n');
+    output.push_str(&render_topic_map_config_block(automation, topic_map));
+    output.push('\n');
+    output
+}
+
 fn render_delete_report(report: &TopicsDeleteReport) -> String {
     let mut output = format_project_header(
         &report.project.name,
@@ -307,23 +371,169 @@ fn render_config_block(automation: &TopicAutomationConfig) -> String {
 }
 
 fn render_topic_map_update_block(automation: &TopicAutomationConfig, topic_map_id: &str) -> String {
-    let mut lines = vec![format!("{} ({})", automation.name, automation.id)];
     let Some(topic_map) = automation
         .topic_map_functions
         .iter()
         .find(|function| function.id.as_deref() == Some(topic_map_id))
     else {
+        let mut lines = vec![format!("{} ({})", automation.name, automation.id)];
         lines.push(format!("  topic map id: {topic_map_id}"));
         lines.push("  details: unavailable after update".to_string());
         return lines.join("\n");
     };
 
+    render_topic_map_config_block(automation, topic_map)
+}
+
+fn render_topic_map_config_block(
+    automation: &TopicAutomationConfig,
+    topic_map: &FunctionSummary,
+) -> String {
+    let mut lines = vec![format!("{} ({})", automation.name, automation.id)];
     lines.push(format!(
         "  topic map: {}",
         format_function_identity(topic_map)
     ));
     push_topic_map_details(&mut lines, topic_map, "    ");
     lines.join("\n")
+}
+
+#[derive(Debug, Clone, Copy)]
+struct TopicMapConfigMatch<'a> {
+    automation: &'a TopicAutomationConfig,
+    topic_map: &'a FunctionSummary,
+}
+
+fn print_topic_map_view(
+    report: &TopicsConfigReport,
+    resolved: TopicMapConfigMatch<'_>,
+    json: bool,
+) -> Result<()> {
+    if json {
+        let value = serde_json::json!({
+            "project": &report.project,
+            "automation": resolved.automation,
+            "topic_map": resolved.topic_map,
+        });
+        println!("{}", serde_json::to_string(&value)?);
+        return Ok(());
+    }
+
+    print_with_pager(&render_single_topic_map_config(
+        &format_project_header(
+            &report.project.name,
+            &report.project.id,
+            &report.project.org_name,
+        ),
+        resolved.automation,
+        resolved.topic_map,
+    ))?;
+    Ok(())
+}
+
+fn normalize_target(target: &str) -> Result<&str> {
+    let target = target.trim();
+    if target.is_empty() {
+        bail!("target cannot be empty");
+    }
+    Ok(target)
+}
+
+fn resolve_automation_config_target<'a>(
+    report: &'a TopicsConfigReport,
+    target: &str,
+) -> Result<Option<&'a TopicAutomationConfig>> {
+    let id_matches = report
+        .automations
+        .iter()
+        .filter(|automation| automation.id == target)
+        .collect::<Vec<_>>();
+    if !id_matches.is_empty() {
+        return Ok(Some(single_automation_match(id_matches, target)?));
+    }
+
+    let name_matches = report
+        .automations
+        .iter()
+        .filter(|automation| automation.name.eq_ignore_ascii_case(target))
+        .collect::<Vec<_>>();
+    if name_matches.is_empty() {
+        return Ok(None);
+    }
+
+    Ok(Some(single_automation_match(name_matches, target)?))
+}
+
+fn single_automation_match<'a>(
+    matches: Vec<&'a TopicAutomationConfig>,
+    target: &str,
+) -> Result<&'a TopicAutomationConfig> {
+    if matches.len() == 1 {
+        return Ok(matches[0]);
+    }
+
+    let choices = matches
+        .iter()
+        .map(|automation| format!("{} ({})", automation.name, automation.id))
+        .collect::<Vec<_>>()
+        .join(", ");
+    bail!(
+        "topic automation '{target}' matched multiple entries ({choices}); re-run with --automation-id"
+    )
+}
+
+fn resolve_topic_map_config_target<'a>(
+    report: &'a TopicsConfigReport,
+    target: &str,
+) -> Result<TopicMapConfigMatch<'a>> {
+    let mut id_matches = Vec::new();
+    let mut name_matches = Vec::new();
+
+    for automation in &report.automations {
+        for topic_map in &automation.topic_map_functions {
+            if topic_map.id.as_deref() == Some(target) {
+                id_matches.push(TopicMapConfigMatch {
+                    automation,
+                    topic_map,
+                });
+            }
+            if topic_map.name.eq_ignore_ascii_case(target) {
+                name_matches.push(TopicMapConfigMatch {
+                    automation,
+                    topic_map,
+                });
+            }
+        }
+    }
+
+    let matches = if id_matches.is_empty() {
+        name_matches
+    } else {
+        id_matches
+    };
+    if matches.is_empty() {
+        bail!(
+            "topic automation or topic map '{target}' was not found; run `bt topics config` to list IDs"
+        );
+    }
+    if matches.len() == 1 {
+        return Ok(matches[0]);
+    }
+
+    let choices = matches
+        .iter()
+        .map(|item| {
+            let topic_map_id = item.topic_map.id.as_deref().unwrap_or("unknown");
+            format!(
+                "{} (topic map id: {}, automation: {} [{}])",
+                item.topic_map.name, topic_map_id, item.automation.name, item.automation.id
+            )
+        })
+        .collect::<Vec<_>>()
+        .join(", ");
+    bail!(
+        "topic map '{target}' matched multiple entries ({choices}); re-run with --automation-id or the topic map function ID"
+    )
 }
 
 fn resolve_single_automation_for_action(
@@ -767,6 +977,19 @@ mod tests {
         }
     }
 
+    fn sample_report() -> TopicsConfigReport {
+        TopicsConfigReport {
+            project: TopicsProjectSummary {
+                id: "proj_123".to_string(),
+                name: "demo-project".to_string(),
+                org_name: "demo-org".to_string(),
+                topics_url: "https://app.example.com/app/demo-org/p/demo-project/topics"
+                    .to_string(),
+            },
+            automations: vec![sample_config()],
+        }
+    }
+
     #[test]
     fn render_config_block_includes_meanings() {
         let output = render_config_block(&sample_config());
@@ -788,6 +1011,32 @@ mod tests {
             "generation: algorithm hdbscan | reduction umap | min cluster size 25 | min samples 10"
         ));
         assert!(output.contains("distance threshold: 0.35"));
+    }
+
+    #[test]
+    fn render_topic_map_config_block_includes_settings() {
+        let config = sample_config();
+        let topic_map = config.topic_map_functions.first().expect("topic map");
+        let output = render_single_topic_map_config(
+            "Project: demo-org / demo-project (proj_123)",
+            &config,
+            topic_map,
+        );
+
+        assert!(output.contains("Topics (auto_123)"));
+        assert!(output.contains("topic map: Task (id: func_1)"));
+        assert!(output.contains("source facet: Task"));
+        assert!(output.contains("embedding model: brain-embedding-1"));
+        assert!(output.contains("distance threshold: 0.35"));
+    }
+
+    #[test]
+    fn resolve_topic_map_config_target_matches_id() {
+        let report = sample_report();
+        let resolved = resolve_topic_map_config_target(&report, "func_1").expect("topic map");
+
+        assert_eq!(resolved.automation.id, "auto_123");
+        assert_eq!(resolved.topic_map.name, "Task");
     }
 
     #[test]

--- a/src/topics/mod.rs
+++ b/src/topics/mod.rs
@@ -1,4 +1,4 @@
-use anyhow::Result;
+use anyhow::{bail, Result};
 use clap::{Args, Subcommand};
 
 use crate::{args::BaseArgs, project_context::resolve_project_command_context_with_auth_mode};
@@ -21,9 +21,11 @@ Examples:
   bt topics status --full
   bt topics status --watch
   bt topics config
+  bt topics config <automation-or-topic-map-id>
   bt topics config enable
   bt topics config delete
   bt topics config set --topic-window 1h --generation-cadence 1d
+  bt topics config topic-map <topic-map-id>
   bt topics config topic-map set Task --embedding-model brain-embedding-1
   bt topics poke
   bt topics rewind 7d
@@ -50,9 +52,17 @@ enum TopicsCommands {
 
 #[derive(Debug, Clone, Args)]
 struct StatusArgs {
-    /// Show expanded diagnostics, including the state machine
+    /// Show expanded diagnostics and progress counts
     #[arg(long)]
     full: bool,
+
+    /// Window for status progress counts, for example 1h or 7d
+    #[arg(
+        long = "progress-window",
+        env = "BT_TOPICS_STATUS_PROGRESS_WINDOW",
+        value_name = "WINDOW"
+    )]
+    progress_window: Option<String>,
 
     /// Refresh every 2 seconds until interrupted
     #[arg(long)]
@@ -64,6 +74,10 @@ struct ConfigArgs {
     /// Specific automation ID to show
     #[arg(long = "automation-id")]
     automation_id: Option<String>,
+
+    /// Automation ID/name or topic map name/function ID to show
+    #[arg(value_name = "TARGET")]
+    target: Option<String>,
 
     #[command(subcommand)]
     command: Option<ConfigCommands>,
@@ -77,7 +91,7 @@ enum ConfigCommands {
     Delete(ConfigDeleteArgs),
     /// Update editable Topics config fields
     Set(ConfigSetArgs),
-    /// Edit per-topic-map settings
+    /// View or edit per-topic-map settings
     #[command(name = "topic-map")]
     TopicMap(TopicMapArgs),
 }
@@ -158,14 +172,35 @@ struct ConfigDeleteArgs {
 
 #[derive(Debug, Clone, Args)]
 struct TopicMapArgs {
+    /// Topic map name or function ID to show
+    #[arg(value_name = "TOPIC_MAP")]
+    topic_map: Option<String>,
+
+    /// Specific automation ID to search within
+    #[arg(long = "automation-id")]
+    automation_id: Option<String>,
+
     #[command(subcommand)]
-    command: TopicMapCommands,
+    command: Option<TopicMapCommands>,
 }
 
 #[derive(Debug, Clone, Subcommand)]
 enum TopicMapCommands {
+    /// Show a configured Topics topic map by name or function ID
+    #[command(alias = "view")]
+    Show(TopicMapViewArgs),
     /// Update a configured Topics topic map by name or function ID
     Set(TopicMapSetArgs),
+}
+
+#[derive(Debug, Clone, Args)]
+struct TopicMapViewArgs {
+    /// Specific automation ID to search within
+    #[arg(long = "automation-id")]
+    automation_id: Option<String>,
+
+    /// Topic map name or function ID
+    topic_map: String,
 }
 
 #[derive(Debug, Clone, Args)]
@@ -247,7 +282,18 @@ struct RewindArgs {
 pub async fn run(base: BaseArgs, args: TopicsArgs) -> Result<()> {
     let read_only = match args.command.as_ref() {
         None | Some(TopicsCommands::Status(_)) | Some(TopicsCommands::Open) => true,
-        Some(TopicsCommands::Config(config_args)) => config_args.command.is_none(),
+        Some(TopicsCommands::Config(config_args)) => match config_args.command.as_ref() {
+            None => true,
+            Some(ConfigCommands::TopicMap(topic_map_args)) => {
+                matches!(
+                    topic_map_args.command,
+                    None | Some(TopicMapCommands::Show(_))
+                )
+            }
+            Some(ConfigCommands::Enable(_))
+            | Some(ConfigCommands::Delete(_))
+            | Some(ConfigCommands::Set(_)) => false,
+        },
         Some(TopicsCommands::Poke) | Some(TopicsCommands::Rewind(_)) => false,
     };
     let ctx = resolve_project_command_context_with_auth_mode(&base, read_only).await?;
@@ -258,6 +304,7 @@ pub async fn run(base: BaseArgs, args: TopicsArgs) -> Result<()> {
                 &ctx,
                 StatusArgs {
                     full: false,
+                    progress_window: None,
                     watch: false,
                 },
                 base.json,
@@ -269,8 +316,22 @@ pub async fn run(base: BaseArgs, args: TopicsArgs) -> Result<()> {
         }
         Some(TopicsCommands::Config(config_args)) => {
             let parent_automation_id = config_args.automation_id;
+            let target = config_args.target;
             match config_args.command {
-                None => config::run_view(&ctx, parent_automation_id.as_deref(), base.json).await,
+                None => match target {
+                    Some(target) => {
+                        config::run_view_target(
+                            &ctx,
+                            parent_automation_id.as_deref(),
+                            &target,
+                            base.json,
+                        )
+                        .await
+                    }
+                    None => {
+                        config::run_view(&ctx, parent_automation_id.as_deref(), base.json).await
+                    }
+                },
                 Some(ConfigCommands::Enable(enable_args)) => {
                     config::run_enable(&ctx, &enable_args, base.json).await
                 }
@@ -290,12 +351,43 @@ pub async fn run(base: BaseArgs, args: TopicsArgs) -> Result<()> {
                     set_args.automation_id = set_args.automation_id.or(parent_automation_id);
                     config::run_set(&ctx, &set_args, base.json).await
                 }
-                Some(ConfigCommands::TopicMap(topic_map_args)) => match topic_map_args.command {
-                    TopicMapCommands::Set(mut set_args) => {
-                        set_args.automation_id = set_args.automation_id.or(parent_automation_id);
-                        config::run_topic_map_set(&ctx, &set_args, base.json).await
+                Some(ConfigCommands::TopicMap(topic_map_args)) => {
+                    let topic_map_automation_id =
+                        topic_map_args.automation_id.or(parent_automation_id);
+                    match topic_map_args.command {
+                        None => {
+                            let Some(topic_map) = topic_map_args.topic_map else {
+                                bail!(
+                                    "topic map name or function ID is required; try `bt topics config topic-map <topic-map-id>`"
+                                );
+                            };
+                            config::run_topic_map_view(
+                                &ctx,
+                                topic_map_automation_id.as_deref(),
+                                &topic_map,
+                                base.json,
+                            )
+                            .await
+                        }
+                        Some(TopicMapCommands::Show(view_args)) => {
+                            config::run_topic_map_view(
+                                &ctx,
+                                view_args
+                                    .automation_id
+                                    .or(topic_map_automation_id)
+                                    .as_deref(),
+                                &view_args.topic_map,
+                                base.json,
+                            )
+                            .await
+                        }
+                        Some(TopicMapCommands::Set(mut set_args)) => {
+                            set_args.automation_id =
+                                set_args.automation_id.or(topic_map_automation_id);
+                            config::run_topic_map_set(&ctx, &set_args, base.json).await
+                        }
                     }
-                },
+                }
             }
         }
         Some(TopicsCommands::Poke) => poke::run(&ctx, base.json).await,
@@ -335,7 +427,18 @@ mod tests {
     fn topics_command_is_read_only(command: Option<&TopicsCommands>) -> bool {
         match command {
             None | Some(TopicsCommands::Status(_)) | Some(TopicsCommands::Open) => true,
-            Some(TopicsCommands::Config(config_args)) => config_args.command.is_none(),
+            Some(TopicsCommands::Config(config_args)) => match config_args.command.as_ref() {
+                None => true,
+                Some(ConfigCommands::TopicMap(topic_map_args)) => {
+                    matches!(
+                        topic_map_args.command,
+                        None | Some(TopicMapCommands::Show(_))
+                    )
+                }
+                Some(ConfigCommands::Enable(_))
+                | Some(ConfigCommands::Delete(_))
+                | Some(ConfigCommands::Set(_)) => false,
+            },
             Some(TopicsCommands::Poke) | Some(TopicsCommands::Rewind(_)) => false,
         }
     }
@@ -354,6 +457,14 @@ mod tests {
         };
         assert!(status.full);
         assert!(status.watch);
+        assert_eq!(status.progress_window, None);
+
+        let parsed = parse(&["topics", "status", "--progress-window", "7d"]).expect("parse");
+        let Some(TopicsCommands::Status(status)) = parsed.command.as_ref() else {
+            panic!("expected status command");
+        };
+        assert_eq!(status.progress_window.as_deref(), Some("7d"));
+        assert!(topics_command_is_read_only(parsed.command.as_ref()));
 
         let parsed = parse(&["topics", "open"]).expect("parse");
         assert!(topics_command_is_read_only(parsed.command.as_ref()));
@@ -374,6 +485,32 @@ mod tests {
     #[test]
     fn topics_config_view_uses_read_only_auth() {
         let parsed = parse(&["topics", "config"]).expect("parse");
+        assert!(topics_command_is_read_only(parsed.command.as_ref()));
+
+        let parsed = parse(&["topics", "config", "func_1"]).expect("parse");
+        assert!(topics_command_is_read_only(parsed.command.as_ref()));
+
+        let Some(TopicsCommands::Config(config_args)) = parsed.command.as_ref() else {
+            panic!("expected config command");
+        };
+        assert_eq!(config_args.target.as_deref(), Some("func_1"));
+    }
+
+    #[test]
+    fn topics_config_topic_map_view_uses_read_only_auth() {
+        let parsed = parse(&["topics", "config", "topic-map", "func_1"]).expect("parse");
+        assert!(topics_command_is_read_only(parsed.command.as_ref()));
+
+        let Some(TopicsCommands::Config(config_args)) = parsed.command.as_ref() else {
+            panic!("expected config command");
+        };
+        let Some(ConfigCommands::TopicMap(topic_map_args)) = config_args.command.as_ref() else {
+            panic!("expected topic-map command");
+        };
+        assert_eq!(topic_map_args.topic_map.as_deref(), Some("func_1"));
+        assert!(topic_map_args.command.is_none());
+
+        let parsed = parse(&["topics", "config", "topic-map", "show", "func_1"]).expect("parse");
         assert!(topics_command_is_read_only(parsed.command.as_ref()));
     }
 
@@ -536,7 +673,9 @@ mod tests {
         let Some(ConfigCommands::TopicMap(topic_map_args)) = config_args.command.as_ref() else {
             panic!("expected topic-map set command");
         };
-        let TopicMapCommands::Set(set_args) = &topic_map_args.command;
+        let Some(TopicMapCommands::Set(set_args)) = &topic_map_args.command else {
+            panic!("expected topic-map set command");
+        };
 
         assert_eq!(set_args.topic_map, "Task");
         assert_eq!(

--- a/src/topics/status.rs
+++ b/src/topics/status.rs
@@ -6,7 +6,10 @@ use anyhow::{bail, Result};
 use chrono::{DateTime, Utc};
 use dialoguer::console;
 
-use crate::ui::{print_with_pager, with_spinner};
+use crate::{
+    ui::{print_with_pager, with_spinner},
+    utils::parse_duration_to_seconds,
+};
 
 use super::{
     api::{self, TopicAutomationStatus, TopicRuntimeSnapshot, TopicsStatusReport},
@@ -22,11 +25,18 @@ pub async fn run(ctx: &ResolvedContext, args: StatusArgs, json: bool) -> Result<
         bail!("--watch is not supported with --json");
     }
 
+    let progress_window_seconds = resolve_progress_window_seconds(args.progress_window.as_deref())?;
+    let include_progress = args.full || progress_window_seconds.is_some();
+
     if args.watch {
-        return watch(ctx, args.full).await;
+        return watch(ctx, args.full, include_progress, progress_window_seconds).await;
     }
 
-    let report = with_spinner("Loading Topics status...", api::fetch_topics_status(ctx)).await?;
+    let report = with_spinner(
+        "Loading Topics status...",
+        api::fetch_topics_status(ctx, include_progress, progress_window_seconds),
+    )
+    .await?;
     if json {
         println!("{}", serde_json::to_string(&report)?);
         return Ok(());
@@ -37,7 +47,12 @@ pub async fn run(ctx: &ResolvedContext, args: StatusArgs, json: bool) -> Result<
     Ok(())
 }
 
-async fn watch(ctx: &ResolvedContext, full: bool) -> Result<()> {
+async fn watch(
+    ctx: &ResolvedContext,
+    full: bool,
+    include_progress: bool,
+    progress_window_seconds: Option<i64>,
+) -> Result<()> {
     let is_tty = io::stdout().is_terminal();
     let mut first_frame = true;
     let mut ctrl_c = std::pin::pin!(tokio::signal::ctrl_c());
@@ -50,7 +65,7 @@ async fn watch(ctx: &ResolvedContext, full: bool) -> Result<()> {
                 }
                 break;
             }
-            report = api::fetch_topics_status(ctx) => report?,
+            report = api::fetch_topics_status(ctx, include_progress, progress_window_seconds) => report?,
         };
         let output = render_report(&report, full);
 
@@ -79,6 +94,19 @@ async fn watch(ctx: &ResolvedContext, full: bool) -> Result<()> {
     }
 
     Ok(())
+}
+
+fn resolve_progress_window_seconds(value: Option<&str>) -> Result<Option<i64>> {
+    let Some(value) = value else {
+        return Ok(None);
+    };
+    let seconds = parse_duration_to_seconds(value)?;
+    if seconds == 0 {
+        bail!("progress window must be greater than zero");
+    }
+    let seconds =
+        i64::try_from(seconds).map_err(|_| anyhow::anyhow!("progress window is too large"))?;
+    Ok(Some(seconds))
 }
 
 fn render_report(report: &TopicsStatusReport, full: bool) -> String {
@@ -130,19 +158,26 @@ fn write_automation_summary(
     if let Some(error) = format_last_error_summary(automation) {
         writeln!(output, "{error}")?;
     }
-    writeln!(
-        output,
-        "coverage: {}",
-        format_coverage_summary(automation, &progress_window)
-    )?;
-    writeln!(output, "labels: {}", format_label_summary(automation))?;
+    if automation.progress_loaded {
+        writeln!(
+            output,
+            "coverage: {}",
+            format_coverage_summary(automation, &progress_window)
+        )?;
+        writeln!(output, "labels: {}", format_label_summary(automation))?;
+    } else {
+        writeln!(
+            output,
+            "progress: not loaded (run `bt topics status --full` or set `--progress-window` for trace counts)"
+        )?;
+    }
     writeln!(
         output,
         "facets: {}",
         format_facet_processing_status(automation)
     )?;
 
-    if !automation.facets.is_empty() && automation.total_traces > 0 {
+    if automation.progress_loaded && !automation.facets.is_empty() && automation.total_traces > 0 {
         writeln!(output)?;
         writeln!(output, "facet progress:")?;
         for line in render_progress_lines(
@@ -160,7 +195,7 @@ fn write_automation_summary(
             writeln!(output, "{line}")?;
         }
     }
-    if !automation.topics.is_empty() && automation.total_traces > 0 {
+    if automation.progress_loaded && !automation.topics.is_empty() && automation.total_traces > 0 {
         writeln!(output)?;
         writeln!(output, "topic progress:")?;
         for line in render_progress_lines(
@@ -318,29 +353,35 @@ fn render_transition_requirements(
             lines
         }
         "backfilling_topic_classifications" => {
-            let eligible = automation
-                .topics
-                .iter()
-                .map(|item| item.matched_count)
-                .sum::<usize>();
-            let checked = automation
-                .topics
-                .iter()
-                .map(|item| item.checked_count)
-                .sum::<usize>();
-            let labeled = automation
-                .topics
-                .iter()
-                .map(|item| item.completed_count)
-                .sum::<usize>();
-            let mut lines = vec![
-                "  - segment replay must catch up through the recompute snapshot".to_string(),
+            let label_progress = if automation.progress_loaded {
+                let eligible = automation
+                    .topics
+                    .iter()
+                    .map(|item| item.matched_count)
+                    .sum::<usize>();
+                let checked = automation
+                    .topics
+                    .iter()
+                    .map(|item| item.checked_count)
+                    .sum::<usize>();
+                let labeled = automation
+                    .topics
+                    .iter()
+                    .map(|item| item.completed_count)
+                    .sum::<usize>();
                 format!(
                     "  - current replay progress: {}/{} checked ({} labeled)",
                     format_count(checked),
                     format_count(eligible),
                     format_count(labeled)
-                ),
+                )
+            } else {
+                "  - current replay progress: not loaded; run `bt topics status --full` or set `--progress-window` for trace counts"
+                    .to_string()
+            };
+            let mut lines = vec![
+                "  - segment replay must catch up through the recompute snapshot".to_string(),
+                label_progress,
                 format!(
                     "  - pending segments: {}",
                     automation.cursor.pending_segments
@@ -577,7 +618,8 @@ fn format_reason(reason: &str) -> String {
 
 fn format_progress_window_label(automation: &TopicAutomationStatus) -> String {
     automation
-        .window_seconds
+        .progress_window_seconds
+        .or(automation.window_seconds)
         .or_else(|| {
             automation
                 .object_cursor
@@ -585,7 +627,17 @@ fn format_progress_window_label(automation: &TopicAutomationStatus) -> String {
                 .as_ref()
                 .and_then(|runtime| runtime.selected_window_seconds)
         })
-        .map(|seconds| format!("{} topic window", format_duration_compact(Some(seconds))))
+        .map(|seconds| {
+            let prefix = if automation.progress_loaded
+                && automation.progress_window_seconds.is_some()
+                && automation.progress_window_seconds != automation.window_seconds
+            {
+                "status window"
+            } else {
+                "topic window"
+            };
+            format!("{} {prefix}", format_duration_compact(Some(seconds)))
+        })
         .unwrap_or_else(|| "current topic window".to_string())
 }
 
@@ -758,6 +810,10 @@ mod tests {
     }
 
     fn sample_report() -> TopicsStatusReport {
+        sample_report_with_progress(true)
+    }
+
+    fn sample_report_with_progress(progress_loaded: bool) -> TopicsStatusReport {
         TopicsStatusReport {
             project: TopicsProjectSummary {
                 id: "proj_123".to_string(),
@@ -778,6 +834,8 @@ mod tests {
                 idle_seconds: Some(600),
                 configured_facets: 3,
                 configured_topic_maps: 2,
+                progress_loaded,
+                progress_window_seconds: progress_loaded.then_some(86400),
                 processing_lag_label: Some("4m behind".to_string()),
                 processing_lag_seconds: Some(240),
                 total_traces: 1010,
@@ -906,20 +964,20 @@ mod tests {
     }
 
     #[test]
-    fn compact_report_includes_summary_details() {
-        let output = strip_ansi(&render_report(&sample_report(), false));
+    fn compact_report_skips_trace_counts_when_progress_is_not_loaded() {
+        let output = strip_ansi(&render_report(&sample_report_with_progress(false), false));
         assert!(output.contains("Project:"));
         assert!(!output.contains("Topic automations: 1"));
         assert!(output.contains("demo-project (proj_123)"));
         assert!(output.contains("status: idle"));
-        assert!(output
-            .contains("coverage: 1,004/1,010 traces have facet labels in the 1d topic window"));
-        assert!(output.contains("labels: 920/1,076 considered | 698 labeled"));
+        assert!(output.contains(
+            "progress: not loaded (run `bt topics status --full` or set `--progress-window` for trace counts)"
+        ));
         assert!(output.contains("facets: "));
-        assert!(output.contains("facet progress:"));
-        assert!(output.contains("topic progress:"));
-        assert!(output.contains("considered | matched | running | errors"));
-        assert!(output.contains("considered | labeled | running | errors"));
+        assert!(!output.contains("coverage: 1,004/1,010 traces"));
+        assert!(!output.contains("labels: 920/1,076 considered"));
+        assert!(!output.contains("facet progress:"));
+        assert!(!output.contains("topic progress:"));
         assert!(!output.contains("processing:"));
         assert!(!output.contains("state machine:"));
     }
@@ -927,6 +985,13 @@ mod tests {
     #[test]
     fn full_report_includes_diagnostics_and_flow() {
         let output = strip_ansi(&render_report(&sample_report(), true));
+        assert!(output
+            .contains("coverage: 1,004/1,010 traces have facet labels in the 1d topic window"));
+        assert!(output.contains("labels: 920/1,076 considered | 698 labeled"));
+        assert!(output.contains("facet progress:"));
+        assert!(output.contains("topic progress:"));
+        assert!(output.contains("considered | matched | running | errors"));
+        assert!(output.contains("considered | labeled | running | errors"));
         assert!(output.contains("details:"));
         assert!(output.contains("  scope: trace"));
         assert!(output.contains("  state since: "));
@@ -1001,6 +1066,31 @@ mod tests {
         let report = sample_report();
         let label = format_progress_window_label(&report.automations[0]);
         assert_eq!(label, "1d topic window");
+    }
+
+    #[test]
+    fn progress_window_label_mentions_status_window_when_capped() {
+        let mut report = sample_report();
+        let automation = report.automations.first_mut().expect("automation");
+        automation.window_seconds = Some(7 * 24 * 60 * 60);
+        automation.progress_window_seconds = Some(24 * 60 * 60);
+
+        let label = format_progress_window_label(automation);
+        assert_eq!(label, "1d status window");
+    }
+
+    #[test]
+    fn resolve_progress_window_seconds_accepts_duration() {
+        assert_eq!(
+            resolve_progress_window_seconds(Some("7d")).expect("window"),
+            Some(7 * 24 * 60 * 60)
+        );
+    }
+
+    #[test]
+    fn resolve_progress_window_seconds_rejects_zero() {
+        let error = resolve_progress_window_seconds(Some("0")).expect_err("expected error");
+        assert!(error.to_string().contains("greater than zero"));
     }
 
     #[test]


### PR DESCRIPTION
* Constrain status queries to 24h by default. Users can provide a larger window explicitly
* Don't run expensive queries in the default status check