### PR TITLE
feat: package bt for homebrew

### DIFF
--- a/.github/workflows/release-canary.yml
+++ b/.github/workflows/release-canary.yml
@@ -50,7 +50,7 @@ jobs:
 
       - name: Install dist
         shell: bash
-        run: "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/v0.31.0/cargo-dist-installer.sh | sh"
+        run: "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/v0.32.0/cargo-dist-installer.sh | sh"
 
       - name: Cache dist
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -111,7 +111,7 @@ jobs:
       - name: Install dist
         if: steps.resolve-tag.outputs.should_release == 'true'
         shell: bash
-        run: "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/v0.31.0/cargo-dist-installer.sh | sh"
+        run: "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/v0.32.0/cargo-dist-installer.sh | sh"
 
       - name: Cache dist
         if: steps.resolve-tag.outputs.should_release == 'true'
@@ -374,6 +374,60 @@ jobs:
         with:
           name: artifacts-dist-manifest
           path: dist-manifest.json
+
+  publish-homebrew-formula:
+    needs:
+      - plan
+      - host
+    if: ${{ needs.host.result == 'success' && !fromJson(needs.host.outputs.val).announcement_is_prerelease }}
+    runs-on: ubuntu-22.04
+    env:
+      HOST_MANIFEST: ${{ needs.host.outputs.val }}
+    steps:
+      - uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        id: app-token
+        with:
+          app-id: ${{ vars.HOMEBREW_TAP_APP_ID }}
+          private-key: ${{ secrets.HOMEBREW_TAP_APP_PRIVATE_KEY }}
+          owner: braintrustdata
+          repositories: homebrew-tap
+
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          persist-credentials: true
+          repository: braintrustdata/homebrew-tap
+          token: ${{ steps.app-token.outputs.token }}
+
+      - name: Fetch homebrew formula artifact
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        with:
+          name: artifacts-build-global
+          path: Formula/
+
+      - name: Commit formula files
+        shell: bash
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          APP_SLUG: ${{ steps.app-token.outputs.app-slug }}
+        run: |
+          user_id=$(gh api "/users/${APP_SLUG}%5Bbot%5D" --jq .id)
+          git config --global user.name "${APP_SLUG}[bot]"
+          git config --global user.email "${user_id}+${APP_SLUG}[bot]@users.noreply.github.com"
+
+          export PATH="/home/linuxbrew/.linuxbrew/bin:$PATH"
+          brew update
+
+          echo "$HOST_MANIFEST" | jq --compact-output '.releases[] | select([.artifacts[] | endswith(".rb")] | any)' | while IFS= read -r release; do
+            filename=$(echo "$release" | jq '.artifacts[] | select(endswith(".rb"))' --raw-output)
+            name=$(echo "$filename" | sed "s/\.rb$//")
+            version=$(echo "$release" | jq .app_version --raw-output)
+
+            brew style --except-cops FormulaAudit/Homepage,FormulaAudit/Desc,FormulaAuditStrict --fix "Formula/${filename}" || true
+
+            git add "Formula/${filename}"
+            git diff --quiet --cached -- "Formula/${filename}" || git commit -m "${name} ${version}"
+          done
+          git push
 
   announce:
     needs:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ authors = ["Braintrust engineering <eng@braintrust.dev>"]
 description = "The Braintrust command line interface"
 license = "Apache-2.0"
 repository = "https://github.com/braintrustdata/bt"
+homepage = "https://github.com/braintrustdata/bt"
 
 [package.metadata.wix]
 upgrade-guid = "5B558F98-EEBD-4F5E-A0C8-E7A039445139"

--- a/README.md
+++ b/README.md
@@ -8,6 +8,14 @@
 
 ### Unix (macOS / Linux)
 
+Using homebrew:
+
+```bash
+brew install braintrustdata/tap/bt
+```
+
+Using our installer script:
+
 ```bash
 curl -fsSL https://bt.dev/cli/install.sh | bash
 ```
@@ -94,7 +102,8 @@ shasum -a 256 -c "bt-<target>.tar.gz.sha256"
 
 ## Update
 
-`bt` can update itself when installed via the official installer.
+`bt` can self-update when installed via the official installer.
+If bt was installed via another package manager (Homebrew, cargo, npm...), use that package manager to update instead.
 
 ```bash
 # update on the current build channel (canary for local/dev builds, stable for official releases)
@@ -106,8 +115,6 @@ bt update --check
 # switch/update to latest mainline canary
 bt update --channel canary
 ```
-
-If `bt` was installed via npm, use that to update instead.
 
 ## Uninstall
 

--- a/dist-workspace.toml
+++ b/dist-workspace.toml
@@ -4,9 +4,10 @@ members = ["cargo:."]
 # Config for 'dist'
 [dist]
 # Skip checking whether the specified configuration files are up to date
+# In our case, since we have heavily customised ci, prevent cargo dist from erasing our changes.
 allow-dirty = ["ci"]
 # The preferred dist version to use in CI (Cargo.toml SemVer syntax)
-cargo-dist-version = "0.31.0"
+cargo-dist-version = "0.32.0"
 # CI backends to support
 ci = "github"
 # Whether dist should create a Github Release or use an existing draft
@@ -15,7 +16,12 @@ create-release = true
 pr-run-mode = "plan"
 # The installers to generate for each app
 installers = ["shell", "powershell"]
-homepage = "https://github.com/braintrustdata/bt"
+# Homebrew tap to publish the formula to (repo: github.com/braintrustdata/homebrew-tap)
+tap = "braintrustdata/homebrew-tap"
+formula = "bt"
+# Technically does nothing as we allow dirty ci, which prevents `dist generate` from updating `.github/workflows/release.yml`
+# Added in case we move our customization of the ci to another file and can use the auto-generated ci instead.
+publish-jobs = ["homebrew"]
 # Target platforms to build apps for (Rust target-triple syntax)
 targets = ["aarch64-apple-darwin", "aarch64-unknown-linux-gnu", "aarch64-pc-windows-msvc", "x86_64-apple-darwin", "x86_64-unknown-linux-gnu", "x86_64-unknown-linux-musl", "x86_64-pc-windows-msvc"]
 # Path that installers should place binaries in

--- a/src/self_update.rs
+++ b/src/self_update.rs
@@ -195,7 +195,7 @@ fn ensure_installer_managed_executable(exe: &Path) -> Result<()> {
     }
 
     anyhow::bail!(
-        "update is only supported for official installer installs.\ncurrent executable: {}\nif this was installed with npm, update with npm; otherwise reinstall with the official installer",
+        "update is only supported for official installer installs.\ncurrent executable: {}\nif this was installed with Homebrew/npm, update with that package manager; otherwise reinstall with the official installer",
         exe.display()
     );
 }


### PR DESCRIPTION
# Keep this PR to conserve the instructions to publish bt if we need it one day.

Package `bt` for homebrew, as a third-party package.
[`bt` is not eligible for maintainance by the homebrew team](https://docs.brew.sh/Acceptable-Formulae#niche-or-self-submitted-stuff).

`bt` will be available with `brew install braintrustdata/tap/bt` or `brew tap braintrustdata/tap && brew install bt`.

### TODO
- [X] ~Create a `braintrustdata/homebrew-tap` repo, check we can push directly on main~ https://github.com/braintrustdata/homebrew-tap
  - [X] ~Add other admins?~ Added Abhi and Stephen.
  - [ ]  Make the repo public.
- [ ] Create a `braintrust-homebrew-tap` GitHub App for automated formula publishing:
   - Permissions: `Contents: read and write`
   - Installation scope: `braintrustdata/homebrew-tap`
   - Configure in `braintrustdata/tap` repo settings:
     - `vars.HOMEBREW_TAP_APP_ID` - the App's numeric ID
     - `secrets.HOMEBREW_TAP_APP_PRIVATE_KEY` - the App's PEM private key
- [ ] Cut a `bt` release, verify the `publish-homebrew-formula` job pushes a commit to `homebrew-tap` authored by `braintrust-homebrew-tap[bot]`

Once `bt` is publicly available and we have our own tap (braintrustdata/homebrew-tap), it will be easier to package other software for homebrew since we could reuse https://github.com/braintrustdata/homebrew-tap.