### PR TITLE
--json flag doing nothing

### DIFF
--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -273,12 +273,18 @@ pub fn resolve_write_path(global: bool, local: bool) -> Result<PathBuf> {
     }
 }
 
-pub fn save_local(config: &Config, create_dir: bool) -> Result<()> {
-    let dir = std::env::current_dir()?.join(".bt");
+pub fn local_save_path() -> Result<PathBuf> {
+    Ok(std::env::current_dir()?.join(".bt").join("config.json"))
+}
+
+pub fn save_local(config: &Config, create_dir: bool) -> Result<PathBuf> {
+    let path = local_save_path()?;
+    let dir = path.parent().expect(".bt parent directory");
     if create_dir && !dir.exists() {
-        fs::create_dir_all(&dir)?;
+        fs::create_dir_all(dir)?;
     }
-    save_file(&dir.join("config.json"), config)
+    save_file(&path, config)?;
+    Ok(path)
 }
 
 // --- CLI commands ---

--- a/src/init.rs
+++ b/src/init.rs
@@ -19,8 +19,23 @@ pub struct InitArgs {}
 
 pub async fn run(base: BaseArgs, _args: InitArgs) -> Result<()> {
     let bt_dir = std::env::current_dir()?.join(".bt");
-    if bt_dir.join("config.json").exists() {
-        print_command_status(CommandStatus::Warning, "Already Initialized");
+    let config_path = bt_dir.join("config.json");
+    if config_path.exists() {
+        if base.json {
+            let existing = config::load_file(&config_path);
+            println!(
+                "{}",
+                serde_json::json!({
+                    "initialized": false,
+                    "status": "already-initialized",
+                    "org": existing.org,
+                    "project": existing.project,
+                    "path": config_path.display().to_string(),
+                })
+            );
+        } else {
+            print_command_status(CommandStatus::Warning, "Already Initialized");
+        }
         return Ok(());
     }
 
@@ -61,11 +76,24 @@ pub async fn run(base: BaseArgs, _args: InitArgs) -> Result<()> {
 
     config::save_local(&cfg, true)?;
 
-    print_command_status(
-        CommandStatus::Success,
-        &format!("Project linked to {org}/{project}"),
-    );
-    print_command_status(CommandStatus::Success, "Created .bt/config.json");
+    if base.json {
+        println!(
+            "{}",
+            serde_json::json!({
+                "initialized": true,
+                "status": "created",
+                "org": org,
+                "project": project,
+                "path": config_path.display().to_string(),
+            })
+        );
+    } else {
+        print_command_status(
+            CommandStatus::Success,
+            &format!("Project linked to {org}/{project}"),
+        );
+        print_command_status(CommandStatus::Success, "Created .bt/config.json");
+    }
 
     Ok(())
 }

--- a/src/init.rs
+++ b/src/init.rs
@@ -18,21 +18,18 @@ Examples:
 pub struct InitArgs {}
 
 pub async fn run(base: BaseArgs, _args: InitArgs) -> Result<()> {
-    let bt_dir = std::env::current_dir()?.join(".bt");
-    let config_path = bt_dir.join("config.json");
+    let config_path = config::local_save_path()?;
     if config_path.exists() {
         if base.json {
             let existing = config::load_file(&config_path);
-            println!(
-                "{}",
-                serde_json::json!({
-                    "initialized": false,
-                    "status": "already-initialized",
-                    "org": existing.org,
-                    "project": existing.project,
-                    "path": config_path.display().to_string(),
-                })
-            );
+            let payload = serde_json::json!({
+                "initialized": false,
+                "status": "already-initialized",
+                "org": existing.org,
+                "project": existing.project,
+                "path": config_path.display().to_string(),
+            });
+            println!("{}", serde_json::to_string(&payload)?);
         } else {
             print_command_status(CommandStatus::Warning, "Already Initialized");
         }
@@ -74,19 +71,17 @@ pub async fn run(base: BaseArgs, _args: InitArgs) -> Result<()> {
         ..Default::default()
     };
 
-    config::save_local(&cfg, true)?;
+    let written_path = config::save_local(&cfg, true)?;
 
     if base.json {
-        println!(
-            "{}",
-            serde_json::json!({
-                "initialized": true,
-                "status": "created",
-                "org": org,
-                "project": project,
-                "path": config_path.display().to_string(),
-            })
-        );
+        let payload = serde_json::json!({
+            "initialized": true,
+            "status": "created",
+            "org": org,
+            "project": project,
+            "path": written_path.display().to_string(),
+        });
+        println!("{}", serde_json::to_string(&payload)?);
     } else {
         print_command_status(
             CommandStatus::Success,

--- a/src/main.rs
+++ b/src/main.rs
@@ -38,7 +38,7 @@ mod utils;
 use crate::args::{has_explicit_profile_arg, ArgValueSource, BaseArgs, CLIArgs};
 
 const DEFAULT_CANARY_VERSION: &str = concat!(env!("CARGO_PKG_VERSION"), "-canary.dev");
-const CLI_VERSION: &str = match option_env!("BT_VERSION_STRING") {
+pub(crate) const CLI_VERSION: &str = match option_env!("BT_VERSION_STRING") {
     Some(version) => version,
     None => DEFAULT_CANARY_VERSION,
 };
@@ -247,6 +247,23 @@ fn main() {
     std::process::exit(exit_code as i32);
 }
 
+fn handle_version_json(argv: &[OsString]) -> bool {
+    let mut saw_version = false;
+    let mut saw_json = false;
+    for arg in argv.iter().skip(1).filter_map(|a| a.to_str()) {
+        if arg == "--" {
+            break;
+        }
+        saw_version |= arg == "--version" || arg == "-V";
+        saw_json |= arg == "--json";
+    }
+    if !(saw_version && saw_json) {
+        return false;
+    }
+    println!("{}", serde_json::json!({ "version": CLI_VERSION }));
+    true
+}
+
 fn apply_runtime_env_overrides(base: &BaseArgs) {
     // Apply the CLI-owned override once so reqwest and inherited child
     // commands consistently observe BRAINTRUST_CA_CERT/--ca-cert precedence
@@ -259,6 +276,10 @@ fn apply_runtime_env_overrides(base: &BaseArgs) {
 fn try_main() -> Result<()> {
     let argv: Vec<OsString> = std::env::args_os().collect();
     env::bootstrap_from_args(&argv)?;
+
+    if handle_version_json(&argv) {
+        return Ok(());
+    }
 
     let matches = Cli::command().get_matches_from(&argv);
     let mut cli = Cli::from_arg_matches(&matches).expect("clap matches should parse");
@@ -587,5 +608,37 @@ mod tests {
 
         assert!(!cli.command.base().quiet);
         assert!(cli.command.base().verbose);
+    }
+
+    fn argv(parts: &[&str]) -> Vec<OsString> {
+        parts.iter().map(OsString::from).collect()
+    }
+
+    #[test]
+    fn handle_version_json_detects_long_form() {
+        assert!(handle_version_json(&argv(&["bt", "--version", "--json"])));
+        assert!(handle_version_json(&argv(&["bt", "--json", "--version"])));
+    }
+
+    #[test]
+    fn handle_version_json_detects_short_form() {
+        assert!(handle_version_json(&argv(&["bt", "-V", "--json"])));
+    }
+
+    #[test]
+    fn handle_version_json_requires_both_flags() {
+        assert!(!handle_version_json(&argv(&["bt", "--version"])));
+        assert!(!handle_version_json(&argv(&["bt", "--json", "status"])));
+    }
+
+    #[test]
+    fn handle_version_json_ignores_args_after_double_dash() {
+        assert!(!handle_version_json(&argv(&[
+            "bt",
+            "eval",
+            "--",
+            "--version",
+            "--json",
+        ])));
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -247,21 +247,28 @@ fn main() {
     std::process::exit(exit_code as i32);
 }
 
-fn handle_version_json(argv: &[OsString]) -> bool {
-    let mut saw_version = false;
-    let mut saw_json = false;
-    for arg in argv.iter().skip(1).filter_map(|a| a.to_str()) {
-        if arg == "--" {
-            break;
-        }
-        saw_version |= arg == "--version" || arg == "-V";
-        saw_json |= arg == "--json";
+fn handle_version_json(argv: &[OsString]) -> Result<bool> {
+    use clap::{Arg, ArgAction, Command};
+    let preflight = Command::new("bt-version-preflight")
+        .ignore_errors(true)
+        .disable_help_flag(true)
+        .disable_version_flag(true)
+        .arg(
+            Arg::new("version")
+                .long("version")
+                .short('V')
+                .action(ArgAction::Count),
+        )
+        .arg(Arg::new("json").long("json").action(ArgAction::Count));
+    let Ok(matches) = preflight.try_get_matches_from(argv) else {
+        return Ok(false);
+    };
+    if matches.get_count("version") == 0 || matches.get_count("json") == 0 {
+        return Ok(false);
     }
-    if !(saw_version && saw_json) {
-        return false;
-    }
-    println!("{}", serde_json::json!({ "version": CLI_VERSION }));
-    true
+    let payload = serde_json::json!({ "version": CLI_VERSION });
+    println!("{}", serde_json::to_string(&payload)?);
+    Ok(true)
 }
 
 fn apply_runtime_env_overrides(base: &BaseArgs) {
@@ -277,7 +284,7 @@ fn try_main() -> Result<()> {
     let argv: Vec<OsString> = std::env::args_os().collect();
     env::bootstrap_from_args(&argv)?;
 
-    if handle_version_json(&argv) {
+    if handle_version_json(&argv)? {
         return Ok(());
     }
 
@@ -616,29 +623,25 @@ mod tests {
 
     #[test]
     fn handle_version_json_detects_long_form() {
-        assert!(handle_version_json(&argv(&["bt", "--version", "--json"])));
-        assert!(handle_version_json(&argv(&["bt", "--json", "--version"])));
+        assert!(handle_version_json(&argv(&["bt", "--version", "--json"])).unwrap());
+        assert!(handle_version_json(&argv(&["bt", "--json", "--version"])).unwrap());
     }
 
     #[test]
     fn handle_version_json_detects_short_form() {
-        assert!(handle_version_json(&argv(&["bt", "-V", "--json"])));
+        assert!(handle_version_json(&argv(&["bt", "-V", "--json"])).unwrap());
     }
 
     #[test]
     fn handle_version_json_requires_both_flags() {
-        assert!(!handle_version_json(&argv(&["bt", "--version"])));
-        assert!(!handle_version_json(&argv(&["bt", "--json", "status"])));
+        assert!(!handle_version_json(&argv(&["bt", "--version"])).unwrap());
+        assert!(!handle_version_json(&argv(&["bt", "--json", "status"])).unwrap());
     }
 
     #[test]
     fn handle_version_json_ignores_args_after_double_dash() {
-        assert!(!handle_version_json(&argv(&[
-            "bt",
-            "eval",
-            "--",
-            "--version",
-            "--json",
-        ])));
+        assert!(
+            !handle_version_json(&argv(&["bt", "eval", "--", "--version", "--json",])).unwrap()
+        );
     }
 }

--- a/src/self_update.rs
+++ b/src/self_update.rs
@@ -106,7 +106,7 @@ async fn run_update(base: &BaseArgs, args: UpdateArgs) -> Result<()> {
             Ok(release) => {
                 let current = env!("CARGO_PKG_VERSION");
                 if stable_is_up_to_date(current, &release.tag_name) {
-                    print_stable_check(base, current, &release.tag_name);
+                    print_stable_check(base, current, &release.tag_name)?;
                     return Ok(());
                 }
             }
@@ -118,7 +118,14 @@ async fn run_update(base: &BaseArgs, args: UpdateArgs) -> Result<()> {
         }
     }
 
-    run_installer(channel)?;
+    run_installer(base, channel)?;
+    if base.json {
+        let payload = serde_json::json!({
+            "channel": channel.name(),
+            "status": "completed",
+        });
+        println!("{}", serde_json::to_string(&payload)?);
+    }
     Ok(())
 }
 
@@ -142,14 +149,14 @@ async fn check_for_update(base: &BaseArgs, channel: UpdateChannel) -> Result<()>
     let current = env!("CARGO_PKG_VERSION");
 
     match channel {
-        UpdateChannel::Stable => print_stable_check(base, current, &release.tag_name),
-        UpdateChannel::Canary => print_canary_check(base, &release),
+        UpdateChannel::Stable => print_stable_check(base, current, &release.tag_name)?,
+        UpdateChannel::Canary => print_canary_check(base, &release)?,
     }
 
     Ok(())
 }
 
-fn print_stable_check(base: &BaseArgs, current: &str, release_tag: &str) {
+fn print_stable_check(base: &BaseArgs, current: &str, release_tag: &str) -> Result<()> {
     if base.json {
         let payload = serde_json::json!({
             "channel": "stable",
@@ -157,13 +164,14 @@ fn print_stable_check(base: &BaseArgs, current: &str, release_tag: &str) {
             "latest": release_tag,
             "up_to_date": stable_is_up_to_date(current, release_tag),
         });
-        println!("{payload}");
+        println!("{}", serde_json::to_string(&payload)?);
     } else {
         println!("{}", stable_check_message(current, release_tag));
     }
+    Ok(())
 }
 
-fn print_canary_check(base: &BaseArgs, release: &GitHubRelease) {
+fn print_canary_check(base: &BaseArgs, release: &GitHubRelease) -> Result<()> {
     if base.json {
         let payload = serde_json::json!({
             "channel": "canary",
@@ -173,10 +181,11 @@ fn print_canary_check(base: &BaseArgs, release: &GitHubRelease) {
                 release.target_commitish.as_deref(),
             ),
         });
-        println!("{payload}");
+        println!("{}", serde_json::to_string(&payload)?);
     } else {
         println!("{}", canary_check_message(&release.tag_name));
     }
+    Ok(())
 }
 
 async fn fetch_release(_base: &BaseArgs, channel: UpdateChannel) -> Result<GitHubRelease> {
@@ -213,12 +222,21 @@ async fn fetch_release(_base: &BaseArgs, channel: UpdateChannel) -> Result<GitHu
         .context("failed to parse GitHub release response")
 }
 
-fn run_installer(channel: UpdateChannel) -> Result<()> {
+fn run_installer(base: &BaseArgs, channel: UpdateChannel) -> Result<()> {
+    let status_line = |msg: &str| {
+        if base.json {
+            eprintln!("{msg}");
+        } else {
+            println!("{msg}");
+        }
+    };
+    let redirect_stdout = if base.json { " 1>&2" } else { "" };
+
     #[cfg(not(windows))]
     {
         let installer_url = channel.installer_url();
-        println!("updating bt from {} channel...", channel.name());
-        let cmd = format!("curl -fsSL '{installer_url}' | sh");
+        status_line(&format!("updating bt from {} channel...", channel.name()));
+        let cmd = format!("curl -fsSL '{installer_url}' | sh{redirect_stdout}");
         let mut command = Command::new("sh");
         command.arg("-c").arg(cmd);
         let status = command.status().context("failed to execute installer")?;
@@ -227,7 +245,7 @@ fn run_installer(channel: UpdateChannel) -> Result<()> {
             anyhow::bail!("installer exited with status {status}");
         }
 
-        println!("update completed");
+        status_line("update completed");
         Ok(())
     }
 
@@ -241,7 +259,8 @@ fn run_installer(channel: UpdateChannel) -> Result<()> {
                 "https://github.com/braintrustdata/bt/releases/download/canary/bt-installer.ps1"
             }
         };
-        let script = format!("irm {installer_url} | iex");
+        status_line(&format!("updating bt from {} channel...", channel.name()));
+        let script = format!("irm {installer_url} | iex{redirect_stdout}");
         let status = Command::new("powershell")
             .args([
                 "-NoProfile",
@@ -256,7 +275,7 @@ fn run_installer(channel: UpdateChannel) -> Result<()> {
             anyhow::bail!("installer exited with status {status}");
         }
 
-        println!("update completed");
+        status_line("update completed");
         return Ok(());
     }
 }

--- a/src/self_update.rs
+++ b/src/self_update.rs
@@ -80,6 +80,8 @@ const BUILD_UPDATE_CHANNEL: Option<&str> = option_env!("BT_UPDATE_CHANNEL");
 #[derive(Debug, Deserialize)]
 struct GitHubRelease {
     tag_name: String,
+    #[serde(default)]
+    target_commitish: Option<String>,
 }
 
 pub async fn run(base: BaseArgs, args: SelfArgs) -> Result<()> {
@@ -104,7 +106,7 @@ async fn run_update(base: &BaseArgs, args: UpdateArgs) -> Result<()> {
             Ok(release) => {
                 let current = env!("CARGO_PKG_VERSION");
                 if stable_is_up_to_date(current, &release.tag_name) {
-                    println!("{}", stable_check_message(current, &release.tag_name));
+                    print_stable_check(base, current, &release.tag_name);
                     return Ok(());
                 }
             }
@@ -140,15 +142,41 @@ async fn check_for_update(base: &BaseArgs, channel: UpdateChannel) -> Result<()>
     let current = env!("CARGO_PKG_VERSION");
 
     match channel {
-        UpdateChannel::Stable => {
-            println!("{}", stable_check_message(current, &release.tag_name));
-        }
-        UpdateChannel::Canary => {
-            println!("{}", canary_check_message(&release.tag_name));
-        }
+        UpdateChannel::Stable => print_stable_check(base, current, &release.tag_name),
+        UpdateChannel::Canary => print_canary_check(base, &release),
     }
 
     Ok(())
+}
+
+fn print_stable_check(base: &BaseArgs, current: &str, release_tag: &str) {
+    if base.json {
+        let payload = serde_json::json!({
+            "channel": "stable",
+            "current": current,
+            "latest": release_tag,
+            "up_to_date": stable_is_up_to_date(current, release_tag),
+        });
+        println!("{payload}");
+    } else {
+        println!("{}", stable_check_message(current, release_tag));
+    }
+}
+
+fn print_canary_check(base: &BaseArgs, release: &GitHubRelease) {
+    if base.json {
+        let payload = serde_json::json!({
+            "channel": "canary",
+            "latest": release.tag_name,
+            "up_to_date": canary_is_up_to_date(
+                crate::CLI_VERSION,
+                release.target_commitish.as_deref(),
+            ),
+        });
+        println!("{payload}");
+    } else {
+        println!("{}", canary_check_message(&release.tag_name));
+    }
 }
 
 async fn fetch_release(_base: &BaseArgs, channel: UpdateChannel) -> Result<GitHubRelease> {
@@ -329,6 +357,16 @@ fn stable_check_message(current: &str, release_tag: &str) -> String {
     format!("update available on stable channel: current={current}, latest={release_tag}")
 }
 
+fn canary_is_up_to_date(current_version: &str, target_commitish: Option<&str>) -> bool {
+    let Some((_, local_sha)) = current_version.rsplit_once("-canary.") else {
+        return false;
+    };
+    if local_sha.is_empty() || local_sha == "dev" {
+        return false;
+    }
+    target_commitish.is_some_and(|target| target.starts_with(local_sha))
+}
+
 fn stable_is_up_to_date(current: &str, release_tag: &str) -> bool {
     let latest = release_tag.trim_start_matches('v');
     latest == current
@@ -430,6 +468,28 @@ mod tests {
         assert!(msg.contains("update available"));
         assert!(msg.contains("current=0.1.0"));
         assert!(msg.contains("latest=v0.2.0"));
+    }
+
+    #[test]
+    fn canary_up_to_date_matches_target_commitish() {
+        assert!(canary_is_up_to_date(
+            "0.1.0-canary.abc123def456",
+            Some("abc123def456789012345678901234567890aaaa"),
+        ));
+        assert!(!canary_is_up_to_date(
+            "0.1.0-canary.abc123def456",
+            Some("ffffffffffffffffffffffffffffffffffffffff"),
+        ));
+    }
+
+    #[test]
+    fn canary_up_to_date_false_for_dev_or_stable_builds() {
+        assert!(!canary_is_up_to_date("0.1.0-canary.dev", Some("abc")));
+        assert!(!canary_is_up_to_date(
+            "0.1.0",
+            Some("abc123def456789012345678901234567890aaaa"),
+        ));
+        assert!(!canary_is_up_to_date("0.1.0-canary.abc123def456", None));
     }
 
     #[test]

--- a/src/self_update.rs
+++ b/src/self_update.rs
@@ -104,9 +104,8 @@ async fn run_update(base: &BaseArgs, args: UpdateArgs) -> Result<()> {
     if channel == UpdateChannel::Stable {
         match fetch_release(base, channel).await {
             Ok(release) => {
-                let current = env!("CARGO_PKG_VERSION");
-                if stable_is_up_to_date(current, &release.tag_name) {
-                    print_stable_check(base, current, &release.tag_name)?;
+                if stable_is_up_to_date(env!("CARGO_PKG_VERSION"), &release.tag_name) {
+                    print_check(base, channel, &release)?;
                     return Ok(());
                 }
             }
@@ -146,44 +145,41 @@ fn ensure_installer_managed_install() -> Result<()> {
 
 async fn check_for_update(base: &BaseArgs, channel: UpdateChannel) -> Result<()> {
     let release = fetch_release(base, channel).await?;
-    let current = env!("CARGO_PKG_VERSION");
-
-    match channel {
-        UpdateChannel::Stable => print_stable_check(base, current, &release.tag_name)?,
-        UpdateChannel::Canary => print_canary_check(base, &release)?,
-    }
-
-    Ok(())
+    print_check(base, channel, &release)
 }
 
-fn print_stable_check(base: &BaseArgs, current: &str, release_tag: &str) -> Result<()> {
+fn print_check(base: &BaseArgs, channel: UpdateChannel, release: &GitHubRelease) -> Result<()> {
+    let (current, latest, up_to_date, message) = match channel {
+        UpdateChannel::Stable => {
+            let current = env!("CARGO_PKG_VERSION").to_string();
+            let latest = release.tag_name.clone();
+            let up_to_date = stable_is_up_to_date(&current, &latest);
+            let message = stable_check_message(&current, &latest);
+            (current, latest, up_to_date, message)
+        }
+        UpdateChannel::Canary => {
+            // `current` is built by build.rs as `{CARGO_PKG_VERSION}-canary.{short_sha}`.
+            // Construct `latest` in the same shape so the two are comparable.
+            // The canary tag itself is always literally "canary"; the meaningful
+            // identifier is the commit it points at (target_commitish).
+            let current = crate::CLI_VERSION.to_string();
+            let latest = format_canary_version(release.target_commitish.as_deref());
+            let up_to_date = current == latest;
+            let message = canary_check_message(&latest);
+            (current, latest, up_to_date, message)
+        }
+    };
+
     if base.json {
         let payload = serde_json::json!({
-            "channel": "stable",
+            "channel": channel.name(),
             "current": current,
-            "latest": release_tag,
-            "up_to_date": stable_is_up_to_date(current, release_tag),
+            "latest": latest,
+            "up_to_date": up_to_date,
         });
         println!("{}", serde_json::to_string(&payload)?);
     } else {
-        println!("{}", stable_check_message(current, release_tag));
-    }
-    Ok(())
-}
-
-fn print_canary_check(base: &BaseArgs, release: &GitHubRelease) -> Result<()> {
-    if base.json {
-        let payload = serde_json::json!({
-            "channel": "canary",
-            "latest": release.tag_name,
-            "up_to_date": canary_is_up_to_date(
-                crate::CLI_VERSION,
-                release.target_commitish.as_deref(),
-            ),
-        });
-        println!("{}", serde_json::to_string(&payload)?);
-    } else {
-        println!("{}", canary_check_message(&release.tag_name));
+        println!("{message}");
     }
     Ok(())
 }
@@ -376,14 +372,15 @@ fn stable_check_message(current: &str, release_tag: &str) -> String {
     format!("update available on stable channel: current={current}, latest={release_tag}")
 }
 
-fn canary_is_up_to_date(current_version: &str, target_commitish: Option<&str>) -> bool {
-    let Some((_, local_sha)) = current_version.rsplit_once("-canary.") else {
-        return false;
-    };
-    if local_sha.is_empty() || local_sha == "dev" {
-        return false;
-    }
-    target_commitish.is_some_and(|target| target.starts_with(local_sha))
+/// Format a canary version string to match the shape that `build.rs` bakes into
+/// `CLI_VERSION`: `{CARGO_PKG_VERSION}-canary.{short_sha}`. Falls back to a
+/// `dev`-style suffix when `target_commitish` is missing so an unparseable
+/// release never accidentally compares equal to a local canary build.
+fn format_canary_version(target_commitish: Option<&str>) -> String {
+    let short_sha = target_commitish
+        .map(|sha| &sha[..sha.len().min(12)])
+        .unwrap_or("unknown");
+    format!("{}-canary.{}", env!("CARGO_PKG_VERSION"), short_sha)
 }
 
 fn stable_is_up_to_date(current: &str, release_tag: &str) -> bool {
@@ -391,10 +388,8 @@ fn stable_is_up_to_date(current: &str, release_tag: &str) -> bool {
     latest == current
 }
 
-fn canary_check_message(release_tag: &str) -> String {
-    format!(
-        "latest canary release tag: {release_tag}\nrun `bt self update --channel canary` to install it"
-    )
+fn canary_check_message(latest: &str) -> String {
+    format!("latest canary release: {latest}\nrun `bt self update --channel canary` to install it")
 }
 
 fn parse_update_channel(raw: Option<&str>) -> Option<UpdateChannel> {
@@ -490,31 +485,22 @@ mod tests {
     }
 
     #[test]
-    fn canary_up_to_date_matches_target_commitish() {
-        assert!(canary_is_up_to_date(
-            "0.1.0-canary.abc123def456",
-            Some("abc123def456789012345678901234567890aaaa"),
-        ));
-        assert!(!canary_is_up_to_date(
-            "0.1.0-canary.abc123def456",
-            Some("ffffffffffffffffffffffffffffffffffffffff"),
-        ));
+    fn format_canary_version_matches_cli_version_shape() {
+        let pkg = env!("CARGO_PKG_VERSION");
+        let formatted = format_canary_version(Some("abc123def456789012345678901234567890aaaa"));
+        assert_eq!(formatted, format!("{pkg}-canary.abc123def456"));
     }
 
     #[test]
-    fn canary_up_to_date_false_for_dev_or_stable_builds() {
-        assert!(!canary_is_up_to_date("0.1.0-canary.dev", Some("abc")));
-        assert!(!canary_is_up_to_date(
-            "0.1.0",
-            Some("abc123def456789012345678901234567890aaaa"),
-        ));
-        assert!(!canary_is_up_to_date("0.1.0-canary.abc123def456", None));
+    fn format_canary_version_falls_back_when_commitish_missing() {
+        let pkg = env!("CARGO_PKG_VERSION");
+        assert_eq!(format_canary_version(None), format!("{pkg}-canary.unknown"));
     }
 
     #[test]
     fn canary_check_message_contains_guidance() {
-        let msg = canary_check_message("canary-deadbeef");
-        assert!(msg.contains("canary-deadbeef"));
+        let msg = canary_check_message("0.10.0-canary.abc123def456");
+        assert!(msg.contains("0.10.0-canary.abc123def456"));
         assert!(msg.contains("bt self update --channel canary"));
     }
 

--- a/src/setup/mod.rs
+++ b/src/setup/mod.rs
@@ -2352,7 +2352,7 @@ async fn select_project_for_auth_context(
 }
 
 fn maybe_init(org: &str, project: &crate::projects::api::Project) -> Result<()> {
-    let config_path = std::env::current_dir()?.join(".bt").join("config.json");
+    let config_path = config::local_save_path()?;
     let mut cfg = if config_path.exists() {
         let existing = config::load_file(&config_path);
         let matches = existing.org.as_deref() == Some(org)

--- a/src/switch.rs
+++ b/src/switch.rs
@@ -141,13 +141,7 @@ pub async fn run(base: BaseArgs, args: SwitchArgs) -> Result<()> {
     } else if args.global {
         (config::global_path()?, "global")
     } else if interactive && config::local_path().is_some() {
-        let chosen = select_scope()?;
-        let scope = if chosen == config::global_path()? {
-            "global"
-        } else {
-            "local"
-        };
-        (chosen, scope)
+        select_scope()?
     } else {
         (config::global_path()?, "global")
     };
@@ -169,7 +163,7 @@ pub async fn run(base: BaseArgs, args: SwitchArgs) -> Result<()> {
             "scope": scope,
             "path": path.display().to_string(),
         });
-        println!("{payload}");
+        println!("{}", serde_json::to_string(&payload)?);
         return Ok(());
     }
 
@@ -182,7 +176,7 @@ pub async fn run(base: BaseArgs, args: SwitchArgs) -> Result<()> {
     Ok(())
 }
 
-fn select_scope() -> Result<std::path::PathBuf> {
+fn select_scope() -> Result<(std::path::PathBuf, &'static str)> {
     let global = config::global_path()?;
     let local = config::local_path().unwrap();
     let options = [
@@ -225,9 +219,9 @@ fn select_scope() -> Result<std::path::PathBuf> {
         .default(1)
         .interact()?;
     if idx == 0 {
-        Ok(global)
+        Ok((global, "global"))
     } else {
-        Ok(local)
+        Ok((local, "local"))
     }
 }
 

--- a/src/switch.rs
+++ b/src/switch.rs
@@ -129,18 +129,27 @@ pub async fn run(base: BaseArgs, args: SwitchArgs) -> Result<()> {
         }
     };
 
-    let path = if args.local {
-        config::local_path().ok_or_else(|| {
-            anyhow::anyhow!(
-                "No local .bt directory found. Use bt init to initialize this directory."
-            )
-        })?
+    let (path, scope) = if args.local {
+        (
+            config::local_path().ok_or_else(|| {
+                anyhow::anyhow!(
+                    "No local .bt directory found. Use bt init to initialize this directory."
+                )
+            })?,
+            "local",
+        )
     } else if args.global {
-        config::global_path()?
+        (config::global_path()?, "global")
     } else if interactive && config::local_path().is_some() {
-        select_scope()?
+        let chosen = select_scope()?;
+        let scope = if chosen == config::global_path()? {
+            "global"
+        } else {
+            "local"
+        };
+        (chosen, scope)
     } else {
-        config::global_path()?
+        (config::global_path()?, "global")
     };
 
     let mut cfg = config::load_file(&path);
@@ -150,6 +159,19 @@ pub async fn run(base: BaseArgs, args: SwitchArgs) -> Result<()> {
     apply_switch_config(&mut cfg, config_profile.as_deref(), &org_name, &project);
     config::save_file(&path, &cfg)
         .context(format!("Could not save config to {}", path.display()))?;
+
+    if base.json {
+        let payload = serde_json::json!({
+            "org": org_name,
+            "project": project.name,
+            "project_id": project.id,
+            "profile": config_profile,
+            "scope": scope,
+            "path": path.display().to_string(),
+        });
+        println!("{payload}");
+        return Ok(());
+    }
 
     let display = format!("{org_name}/{}", project.name);
     print_command_status(CommandStatus::Success, &format!("Switched to {display}"));


### PR DESCRIPTION
`bt --version`, `bt self update --check`, `bt init` and `bt switch` did not respect `--json`.

Output after the fix:
```
bt --version --json
{"version":"0.10.0-canary.8bac725966d7"}
```

```
bt init --json
{"initialized":false,"org":"-/","path":"/path/to/repo/.bt/config.json","project":"My Project","status":"already-initialized"}
```

```
bt switch --json
✔ Select project · My Project
✔ Save to · Local (bt-output-not-json/.bt)
{"org":"-/","path":"/Users/cedric@braintrustdata.com/repos/bt-output-not-json/.bt/config.json","profile":"-/","project":"My Project","project_id":"e043bad5-7e28-48d9-acf9-bddb05a93394","scope":"local"}
```

`self update` outputs different flags depending on whether `--check` is passed. I think this is fine since the goal of the 2 commands is quite different.
```
bt self update --json --check
{"channel":"canary","current":"0.10.0-canary.47fd220f51c3","latest":"0.10.0-canary.4a8d89492987","up_to_date":false}

bt self update --json
{"channel":"canary","status":"completed"}
```

New behavior:
`bt --version --json anything-subcommand-flags-whatever` acts the same as `bt --version --json`.