### PR TITLE
chore: remove obsolete NPM_TOKEN config

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -532,8 +532,6 @@ jobs:
             --out-dir npm/dist
 
       - name: Publish platform packages
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         shell: bash
         run: |
           set -euo pipefail
@@ -554,5 +552,5 @@ jobs:
               continue
             fi
             echo "Publishing $name@$version"
-            (cd "$dir" && npm publish --access public --provenance)
+            (cd "$dir" && npm publish --access public)
           done

--- a/npm/scripts/build-platform-packages.mjs
+++ b/npm/scripts/build-platform-packages.mjs
@@ -101,10 +101,6 @@ for (const [target, spec] of Object.entries(targets)) {
     files: ["bin/"],
     os: [spec.os],
     cpu: [spec.cpu],
-    publishConfig: {
-      access: "public",
-      provenance: true,
-    },
     preferUnplugged: true,
   };
   if (spec.libc) platformPkg.libc = [spec.libc];


### PR DESCRIPTION
Forgot to push this before merging https://github.com/braintrustdata/bt/pull/208

Remove NPM_TOKEN from the github action since we are using trusted publishing.