### PR TITLE
Dedicated CI environnement for canary releases

### DIFF
--- a/.github/workflows/release-canary.yml
+++ b/.github/workflows/release-canary.yml
@@ -111,9 +111,10 @@ jobs:
       matrix: ${{ fromJson(needs.plan.outputs.val).ci.github.artifacts_matrix }}
     runs-on: ${{ matrix.runner }}
     container: ${{ matrix.container && matrix.container.image || null }}
-    # OIDC token subject must match the AAD federated credential, which is
-    # scoped to the `release` environment — only claim it on main.
-    environment: ${{ github.ref == 'refs/heads/main' && 'release' || '' }}
+    # OIDC token subject must match the AAD federated credential scoped to the
+    # `release-canary` environment. That environment has no required reviewers,
+    # so canary signing runs without an approval gate — only claim it on main.
+    environment: ${{ github.ref == 'refs/heads/main' && 'release-canary' || '' }}
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       BUILD_MANIFEST_NAME: target/distrib/${{ join(matrix.targets, '-') }}-dist-manifest.json


### PR DESCRIPTION
Currently, canary releases use the `release` env for their `AZURE` secrets.
However this env requires manual approving, which in practice block all canary releases.

This PR make canary releases use a new env, release-canary, so they can be deployed without manual approval. This env will also have the `AZURE` secrets once they exist.

## TODO before merging:
- create a `release-canary` env, restricted to `main`. No variable/secrets needed. The `AZURE`-related secrets/variables will be added later once it's ready.