### PR TITLE
Broken bump release flow

### DIFF
--- a/.github/workflows/release-bump-pr.yml
+++ b/.github/workflows/release-bump-pr.yml
@@ -67,8 +67,24 @@ jobs:
               raise SystemExit("failed to find version in Cargo.toml")
           cargo_toml.write_text("".join(lines))
 
+          cargo_lock = Path("Cargo.lock")
+          lock_lines = cargo_lock.read_text().splitlines(keepends=True)
+          in_bt = False
+          updated = False
+          for i, line in enumerate(lock_lines):
+              stripped = line.strip()
+              if stripped == "[[package]]":
+                  in_bt = False
+              elif stripped == 'name = "bt"':
+                  in_bt = True
+              elif in_bt and line.startswith("version = "):
+                  lock_lines[i] = f'version = "{version}"\n'
+                  updated = True
+                  break
+          if not updated:
+              raise SystemExit("failed to find bt package version in Cargo.lock")
+          cargo_lock.write_text("".join(lock_lines))
           PY
-          cargo update --workspace --offline
 
       - name: Commit and push
         shell: bash

--- a/.github/workflows/release-canary.yml
+++ b/.github/workflows/release-canary.yml
@@ -429,7 +429,7 @@ jobs:
 
           marker="<!-- bt-pr-canary-install-comment -->"
           run_url="https://github.com/${REPO}/actions/runs/${RUN_ID}"
-          artifacts="$(gh api --method GET "repos/${REPO}/actions/runs/${RUN_ID}/artifacts?per_page=100" | jq -r '.artifacts[] | select(.expired == false) | .name' | sed 's/^/- `&`/' || true)"
+          artifacts="$(gh api --method GET "repos/${REPO}/actions/runs/${RUN_ID}/artifacts?per_page=100" | jq -r '.artifacts[] | select(.expired == false) | .name' | sed 's/.*/- `&`/' || true)"
           if [ -z "$artifacts" ]; then
             artifacts="- (no artifacts found)"
           fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,6 +13,10 @@ on:
         required: true
         type: string
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
 permissions:
   contents: write
   id-token: write

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -73,11 +73,6 @@ jobs:
             elif git ls-remote --exit-code --tags origin "refs/tags/${tag}" >/dev/null 2>&1; then
               echo "Tag ${tag} already exists; nothing to release."
               should_release=false
-            else
-              git config user.name "github-actions[bot]"
-              git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-              git tag -a "$tag" -m "Release $tag" "$GITHUB_SHA"
-              git push origin "refs/tags/$tag"
             fi
           fi
 


### PR DESCRIPTION
https://github.com/braintrustdata/bt/actions/workflows/release-bump-pr.yml
`cargo update --workspace --offline` crashed due to lack of cache, crashing the CI.
Replaces it with python.

I think commit e539dd8a68cb94235b31fca6b9d48a832351d97b is self-explanatory? Comments like  https://github.com/braintrustdata/bt/pull/218#issuecomment-4598660704 are badly formatted.

60a80b9ac1f2ed9cad418dddc18861be27a1e694 and 72e32ce073910ec8e27d81a5e017e085633ba807 fix potential issues that haven't happened yet.
Prevents having multiple release workflow running at once and publish the tag only after the build has been completed so we don't have empty tags with no associated binaries.