### PR TITLE
release: v0.11.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -498,7 +498,7 @@ dependencies = [
 
 [[package]]
 name = "bt"
-version = "0.11.0"
+version = "0.11.1"
 dependencies = [
  "actix-web",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bt"
-version = "0.11.0"
+version = "0.11.1"
 edition = "2021"
 rust-version = "1.86.0"
 authors = ["Braintrust engineering <eng@braintrust.dev>"]


### PR DESCRIPTION
Bug fix:
- c3ef50fef02a5877766470a83efe78d1bbac0b20 `npm` publishing failed due to a CI failure

The main goal of this version bump is to trigger the publish-npm job of the release workflow.

In the future we will have (thanks to David) test apps and test npm packages we could publish to test our workflows, for now we have to make a real release.