### PR TITLE
feat: add `bt topics btmap` command

### DIFF
--- a/src/topics/api.rs
+++ b/src/topics/api.rs
@@ -863,6 +863,18 @@ pub async fn fetch_topic_map_report_url(
     client.post("/topic-map-report-url", &request).await
 }
 
+pub async fn fetch_topic_map_btmap_url(
+    client: &ApiClient,
+    function_id: &str,
+    version: Option<&str>,
+) -> Result<TopicMapReportUrl> {
+    let request = TopicMapReportUrlRequest {
+        function_id,
+        version,
+    };
+    client.post("/topic-map-btmap-url", &request).await
+}
+
 fn topic_automation_object_id(project_id: &str, data_scope: Option<&Value>) -> Result<String> {
     let data_scope_mapping = data_scope.and_then(Value::as_object);
     let scope_type = string_value(data_scope_mapping.and_then(|scope| scope.get("type")));

--- a/src/topics/btmap.rs
+++ b/src/topics/btmap.rs
@@ -1,0 +1,103 @@
+use std::io::Write;
+use std::path::{Path, PathBuf};
+
+use anyhow::{bail, Context, Result};
+use serde::Serialize;
+
+use crate::{
+    args::BaseArgs,
+    auth::login_read_only,
+    http::{self, ApiClient},
+    ui::{print_command_status, with_spinner, CommandStatus},
+    utils::write_bytes_atomic,
+};
+
+use super::{api, BtmapArgs};
+
+#[derive(Debug, Serialize)]
+struct TopicMapBtmapDownload {
+    function_id: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    version: Option<String>,
+    output: String,
+    bytes: usize,
+}
+
+pub async fn run(base: &BaseArgs, args: &BtmapArgs, json: bool) -> Result<()> {
+    let auth = login_read_only(base).await?;
+    let client = ApiClient::new(&auth)?;
+    let function_id = args.function_id()?;
+
+    let btmap_url = with_spinner(
+        "Requesting topic map URL...",
+        api::fetch_topic_map_btmap_url(&client, function_id, args.version.as_deref()),
+    )
+    .await?;
+
+    let btmap = with_spinner(
+        "Downloading topic map...",
+        download_topic_map_btmap(&btmap_url.url),
+    )
+    .await?;
+
+    let Some(output) = args.output.as_deref() else {
+        std::io::stdout()
+            .write_all(&btmap)
+            .context("failed to write topic map to stdout")?;
+        return Ok(());
+    };
+
+    let output = resolve_output_path(output)?;
+    write_bytes_atomic(&output, &btmap)
+        .with_context(|| format!("failed to write topic map to {}", output.display()))?;
+
+    let downloaded = TopicMapBtmapDownload {
+        function_id: function_id.to_string(),
+        version: args.version.clone(),
+        output: output.display().to_string(),
+        bytes: btmap.len(),
+    };
+
+    if json {
+        println!("{}", serde_json::to_string(&downloaded)?);
+        return Ok(());
+    }
+
+    print_command_status(
+        CommandStatus::Success,
+        &format!(
+            "Downloaded topic map to {} ({} bytes)",
+            downloaded.output, downloaded.bytes
+        ),
+    );
+    Ok(())
+}
+
+async fn download_topic_map_btmap(url: &str) -> Result<Vec<u8>> {
+    let client = http::build_http_client(http::DEFAULT_HTTP_TIMEOUT)
+        .context("failed to build topic map download HTTP client")?;
+    let response = client
+        .get(url)
+        .send()
+        .await
+        .with_context(|| format!("failed to download topic map from {url}"))?;
+    if !response.status().is_success() {
+        let status = response.status();
+        let body = response.text().await.unwrap_or_default();
+        bail!("topic map download failed ({status}): {body}");
+    }
+    Ok(response
+        .bytes()
+        .await
+        .context("failed to read topic map body")?
+        .to_vec())
+}
+
+fn resolve_output_path(path: &Path) -> Result<PathBuf> {
+    if path.is_absolute() {
+        return Ok(path.to_path_buf());
+    }
+    Ok(std::env::current_dir()
+        .context("failed to resolve current directory")?
+        .join(path))
+}

--- a/src/topics/mod.rs
+++ b/src/topics/mod.rs
@@ -5,6 +5,7 @@ use std::path::PathBuf;
 use crate::{args::BaseArgs, project_context::resolve_project_command_context_with_auth_mode};
 
 pub(crate) mod api;
+mod btmap;
 mod config;
 mod formatting;
 mod open;
@@ -31,6 +32,8 @@ Examples:
   bt topics config topic-map set Task --embedding-model brain-embedding-1
   bt topics report fn_123
   bt topics report fn_123 --version 0000000000000001
+  bt topics btmap fn_123
+  bt topics btmap fn_123 --output topic-map.btmap
   bt topics poke
   bt topics rewind 7d
   bt topics open
@@ -52,6 +55,8 @@ enum TopicsCommands {
     Rewind(RewindArgs),
     /// Download a saved topic map report JSON file
     Report(ReportArgs),
+    /// Download the raw topic map (.btmap) artifact
+    Btmap(BtmapArgs),
     /// Open the Topics page in the browser
     Open,
 }
@@ -318,9 +323,46 @@ impl ReportArgs {
     }
 }
 
+#[derive(Debug, Clone, Args)]
+struct BtmapArgs {
+    /// Topic map function ID
+    #[arg(value_name = "FUNCTION_ID")]
+    function_id_positional: Option<String>,
+
+    /// Topic map function ID
+    #[arg(long = "id", env = "BT_TOPICS_BTMAP_FUNCTION_ID")]
+    id: Option<String>,
+
+    /// Specific topic map version/xact ID
+    #[arg(long, env = "BT_TOPICS_BTMAP_VERSION")]
+    version: Option<String>,
+
+    /// Output file path. Omit to write the .btmap bytes to stdout.
+    #[arg(long, env = "BT_TOPICS_BTMAP_OUTPUT")]
+    output: Option<PathBuf>,
+}
+
+impl BtmapArgs {
+    fn function_id(&self) -> Result<&str> {
+        match (self.function_id_positional.as_deref(), self.id.as_deref()) {
+            (Some(_), Some(_)) => {
+                anyhow::bail!("use either --id or a positional function id, not both")
+            }
+            (Some(id), None) | (None, Some(id)) => Ok(id),
+            (None, None) => {
+                anyhow::bail!("topic map function id required. Use: bt topics btmap <function-id>")
+            }
+        }
+    }
+}
+
 pub async fn run(base: BaseArgs, args: TopicsArgs) -> Result<()> {
     if let Some(TopicsCommands::Report(report_args)) = args.command.as_ref() {
         return report::run(&base, report_args, base.json).await;
+    }
+
+    if let Some(TopicsCommands::Btmap(btmap_args)) = args.command.as_ref() {
+        return btmap::run(&base, btmap_args, base.json).await;
     }
 
     let read_only = match args.command.as_ref() {
@@ -338,7 +380,9 @@ pub async fn run(base: BaseArgs, args: TopicsArgs) -> Result<()> {
             | Some(ConfigCommands::Set(_)) => false,
         },
         Some(TopicsCommands::Poke) | Some(TopicsCommands::Rewind(_)) => false,
-        Some(TopicsCommands::Report(_)) => unreachable!("handled before project resolution"),
+        Some(TopicsCommands::Report(_)) | Some(TopicsCommands::Btmap(_)) => {
+            unreachable!("handled before project resolution")
+        }
     };
     let ctx = resolve_project_command_context_with_auth_mode(&base, read_only).await?;
 
@@ -438,7 +482,9 @@ pub async fn run(base: BaseArgs, args: TopicsArgs) -> Result<()> {
         Some(TopicsCommands::Rewind(rewind_args)) => {
             rewind::run(&ctx, &rewind_args, base.json).await
         }
-        Some(TopicsCommands::Report(_)) => unreachable!("handled before project resolution"),
+        Some(TopicsCommands::Report(_)) | Some(TopicsCommands::Btmap(_)) => {
+            unreachable!("handled before project resolution")
+        }
         Some(TopicsCommands::Open) => open::run(&ctx).await,
     }
 }
@@ -485,7 +531,7 @@ mod tests {
                 | Some(ConfigCommands::Set(_)) => false,
             },
             Some(TopicsCommands::Poke) | Some(TopicsCommands::Rewind(_)) => false,
-            Some(TopicsCommands::Report(_)) => true,
+            Some(TopicsCommands::Report(_)) | Some(TopicsCommands::Btmap(_)) => true,
         }
     }
 

--- a/src/utils/fs_atomic.rs
+++ b/src/utils/fs_atomic.rs
@@ -3,6 +3,10 @@ use std::path::Path;
 use anyhow::{Context, Result};
 
 pub fn write_text_atomic(path: &Path, contents: &str) -> Result<()> {
+    write_bytes_atomic(path, contents.as_bytes())
+}
+
+pub fn write_bytes_atomic(path: &Path, contents: &[u8]) -> Result<()> {
     let parent = path.parent().ok_or_else(|| {
         anyhow::anyhow!(
             "cannot atomically write {} because it has no parent directory",

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -6,7 +6,7 @@ mod json_object;
 mod plurals;
 
 pub use duration::parse_duration_to_seconds;
-pub use fs_atomic::write_text_atomic;
+pub use fs_atomic::{write_bytes_atomic, write_text_atomic};
 pub use git::GitRepo;
 pub(crate) use ids::new_uuid_id;
 pub(crate) use json_object::lookup_object_path;


### PR DESCRIPTION
## Summary

Adds `bt topics btmap`, which downloads the raw topic map (`.btmap`) artifact, mirroring the existing `bt topics report` command. It requests a signed URL from the new `/topic-map-btmap-url` endpoint and writes the artifact to stdout or `--output`.

```
bt topics btmap <function-id>
bt topics btmap <function-id> --output topic-map.btmap
```

## Changes

- `src/topics/api.rs` — `fetch_topic_map_btmap_url()` POSTs `{function_id, version}` to `/topic-map-btmap-url`, reusing the `TopicMapReportUrl { url }` response shape.
- `src/topics/btmap.rs` — new handler.
- `src/topics/mod.rs` — `Btmap` subcommand variant, args, dispatch (before project resolution, like `report`), and help examples.
- `src/utils/fs_atomic.rs` / `mod.rs` — new `write_bytes_atomic()`; `write_text_atomic` now delegates to it.

## Note: byte-based, unlike `report`

`report` downloads as text (`response.text()` / `print!` / `write_text_atomic`). `btmap` is byte-based (`response.bytes()` / `stdout().write_all()` / `write_bytes_atomic`) so binary artifacts are handled losslessly rather than corrupted through a UTF-8 `String`.

## Testing

- `cargo check` / `cargo test --no-run` clean.
- `bt topics btmap --help` renders.
