### PR TITLE
chore: remove signing step for canary bt.exe releases

### DIFF
--- a/.github/workflows/release-canary.yml
+++ b/.github/workflows/release-canary.yml
@@ -112,14 +112,9 @@ jobs:
       matrix: ${{ fromJson(needs.plan.outputs.val).ci.github.artifacts_matrix }}
     runs-on: ${{ matrix.runner }}
     container: ${{ matrix.container && matrix.container.image || null }}
-    # OIDC token subject must match the AAD federated credential scoped to the
-    # `release-canary` environment. That environment has no required reviewers,
-    # so canary signing runs without an approval gate — only claim it on main.
-    environment: ${{ github.ref == 'refs/heads/main' && 'release-canary' || '' }}
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       BUILD_MANIFEST_NAME: target/distrib/${{ join(matrix.targets, '-') }}-dist-manifest.json
-      HAS_AZURE_SIGNING: ${{ secrets.AZURE_CLIENT_ID != '' && secrets.AZURE_TENANT_ID != '' && secrets.AZURE_SUBSCRIPTION_ID != '' }}
     steps:
       - name: Enable windows longpaths
         run: git config --global core.longpaths true
@@ -185,27 +180,6 @@ jobs:
         run: |
           dist build --tag="${{ needs.plan.outputs.dist-tag }}" --print=linkage --output-format=json ${{ matrix.dist_args }} > dist-manifest.json
           echo "dist ran successfully"
-
-      - name: Sign Windows artifacts
-        id: sign
-        if: ${{ runner.os == 'Windows' && env.HAS_AZURE_SIGNING == 'true' }}
-        continue-on-error: true
-        uses: ./.github/actions/sign-windows-artifacts
-        with:
-          client-id: ${{ secrets.AZURE_CLIENT_ID }}
-          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
-          subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
-          endpoint: ${{ vars.AZURE_SIGNING_ENDPOINT }}
-          account-name: ${{ vars.AZURE_SIGNING_ACCOUNT_NAME }}
-          cert-profile: ${{ vars.AZURE_SIGNING_CERT_PROFILE }}
-
-      - name: Verify Windows signature and report
-        if: ${{ runner.os == 'Windows' && env.HAS_AZURE_SIGNING == 'true' && always() }}
-        uses: ./.github/actions/verify-windows-signature
-        with:
-          sign-outcome: ${{ steps.sign.outcome }}
-          targets: ${{ join(matrix.targets, ', ') }}
-          github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - id: dist-files
         name: Post-build


### PR DESCRIPTION
`bt.exe` is now signed through Azure artifact signing.
At the moment releases and canary-releases are signed.
This PR removes the signing step for canary releases.

## TODO by an admin
Remove the AZURE variables/secrets from the release-canary env.