### PR TITLE
chore: update doc and comments following bt.exe successful azure artifact signing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -200,6 +200,8 @@ jobs:
       - name: Install dependencies
         run: ${{ matrix.packages_install }}
 
+        # https://github.com/azure/artifact-signing-action
+        # As of 2026-06-23, windows arm runners are not supported so the compilation and signing of bt.exe for aarch64 windows needs to happend on x64 windows
       - name: Set up MSVC cross-compilation for Windows ARM64
         if: ${{ contains(matrix.targets, 'aarch64-pc-windows-msvc') }}
         uses: ilammy/msvc-dev-cmd@0b201ec74fa43914dc39ae48a89fd1d8cb592756 # v1.13.0

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -142,11 +142,16 @@ Notes:
 
 ## Windows Release Signing
 
-Release and canary workflows can Authenticode-sign Windows artifacts when these GitHub Actions repository secrets are configured:
+Release workflows Authenticode-sign Windows artifacts via [Azure Trusted Signing](https://learn.microsoft.com/azure/trusted-signing/) (the `sign-windows-artifacts` composite action). Signing runs when these GitHub Actions repository secrets are configured:
 
-- `SSLDOTCOM_USERNAME`
-- `SSLDOTCOM_PASSWORD`
-- `SSLDOTCOM_CREDENTIAL_ID`
-- `SSLDOTCOM_TOTP_SECRET`
+- `AZURE_CLIENT_ID`
+- `AZURE_TENANT_ID`
+- `AZURE_SUBSCRIPTION_ID`
 
-If those secrets are absent, `cargo-dist` skips Windows signing and the published `bt.exe` remains unsigned.
+The signing account is selected by these repository variables:
+
+- `AZURE_SIGNING_ENDPOINT`
+- `AZURE_SIGNING_ACCOUNT_NAME`
+- `AZURE_SIGNING_CERT_PROFILE`
+
+If the secrets are absent (for example, on forks or PRs without access), the signing step is skipped and published `bt.exe` remains unsigned. The `verify-windows-signature` action surfaces unsigned builds via a neutral check run rather than failing the job.

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ bt self update --check
 bt self update --channel canary
 ```
 
-If `bt` was installed via another package manager (Homebrew, apt, choco, etc), use that package manager to update instead.
+If `bt` was installed via npm, use that to update instead.
 
 ## Uninstall
 
@@ -103,7 +103,7 @@ Remove-Item -Recurse -Force (Join-Path $env:APPDATA "bt") -ErrorAction SilentlyC
 ## Troubleshooting
 
 - If `bt` is not found after install, start a new shell or add `${XDG_BIN_HOME:-$HOME/.local/bin}` to your `PATH`.
-- If `bt self update --check` hits GitHub API limits in CI, set `GITHUB_TOKEN` in the environment.
+- If `bt self update --check --json` hits GitHub API limits in CI, set `GITHUB_TOKEN` in the environment.
 - If your network blocks GitHub asset downloads, install from a machine with direct access or configure your proxy/firewall to allow `github.com` and `api.github.com`.
 
 ## Commands


### PR DESCRIPTION
Removes mentions of ssl.com, fix a slop comment, explain why bt.exe for aarch64 is cross-compiled from x64 windows instead of being compiled on aarch64 windows.