### PR TITLE
feat: Inject eval sample rate into SDK runtime with `bt eval <...> --sample 5`

### DIFF
--- a/scripts/eval-runner-impl.ts
+++ b/scripts/eval-runner-impl.ts
@@ -173,7 +173,7 @@ declare global {
   // eslint-disable-next-line no-var
   var __inherited_braintrust_state: unknown;
   // eslint-disable-next-line no-var
-  var __bt_eval_sample_rate: number | undefined;
+  var __bt_eval_internal_btql: Record<string, unknown> | undefined;
 }
 
 function isObject(value: unknown): value is Record<string, unknown> {
@@ -431,9 +431,11 @@ function readRunnerConfig(): RunnerConfig {
   };
 }
 
-// This looks very funny right now because it is only one value but the assumption is that we will inject more values over time
+// Runtime values consumed by SDKs. Currently only --sample sets internal BTQL,
+// but this can carry more _internal_btql options over time.
 function injectRuntimeValues(config: RunnerConfig) {
-  globalThis.__bt_eval_sample_rate = config.sample ?? undefined; // Used with `bt eval <...> --sample 5`
+  globalThis.__bt_eval_internal_btql =
+    config.sample === null ? undefined : { sample: config.sample };
 }
 
 const runtimeRequire = createRequire(

--- a/scripts/eval-runner-impl.ts
+++ b/scripts/eval-runner-impl.ts
@@ -172,6 +172,8 @@ declare global {
   var _lazy_load: boolean | undefined;
   // eslint-disable-next-line no-var
   var __inherited_braintrust_state: unknown;
+  // eslint-disable-next-line no-var
+  var __bt_eval_sample_rate: number | undefined;
 }
 
 function isObject(value: unknown): value is Record<string, unknown> {
@@ -427,6 +429,11 @@ function readRunnerConfig(): RunnerConfig {
     params: parseParamsJson(process.env.BT_EVAL_PARAMS_JSON),
     matrix: parseMatrixJson(process.env.BT_EVAL_MATRIX_JSON),
   };
+}
+
+// This looks very funny right now because it is only one value but the assumption is that we will inject more values over time
+function injectRuntimeValues(config: RunnerConfig) {
+  globalThis.__bt_eval_sample_rate = config.sample ?? undefined; // Used with `bt eval <...> --sample 5`
 }
 
 const runtimeRequire = createRequire(
@@ -2424,6 +2431,7 @@ export async function main() {
   }
   collectStaticLocalDependencies(normalized);
   ensureBraintrustAvailable();
+  injectRuntimeValues(config);
   const braintrust = await loadBraintrust();
   propagateInheritedBraintrustState(braintrust);
   initRegistry();

--- a/scripts/eval-runner.py
+++ b/scripts/eval-runner.py
@@ -282,15 +282,14 @@ def read_runner_config() -> RunnerConfig:
     )
 
 
-# This looks very funny right now because it is only one value, but the
-# assumption is that we will inject more values over time.
+# Runtime values consumed by SDKs. Currently only --sample sets internal BTQL,
+# but this can carry more _internal_btql options over time.
 def inject_runtime_values(config: RunnerConfig) -> None:
     if config.sample is None:
-        if hasattr(builtins, "__bt_eval_sample_rate"):
-            delattr(builtins, "__bt_eval_sample_rate")
+        if hasattr(builtins, "__bt_eval_internal_btql"):
+            delattr(builtins, "__bt_eval_internal_btql")
         return
-    # Used with `bt eval <...> --sample 5`.
-    setattr(builtins, "__bt_eval_sample_rate", config.sample)
+    setattr(builtins, "__bt_eval_internal_btql", {"sample": config.sample})
 
 
 def _to_mapping(value: Any) -> Any:

--- a/scripts/eval-runner.py
+++ b/scripts/eval-runner.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 import argparse
 import asyncio
+import builtins
 import fnmatch
 import importlib.util
 import inspect
@@ -279,6 +280,17 @@ def read_runner_config() -> RunnerConfig:
         params=parse_params_json(os.getenv("BT_EVAL_PARAMS_JSON")),
         matrix=parse_matrix_json(os.getenv("BT_EVAL_MATRIX_JSON")),
     )
+
+
+# This looks very funny right now because it is only one value, but the
+# assumption is that we will inject more values over time.
+def inject_runtime_values(config: RunnerConfig) -> None:
+    if config.sample is None:
+        if hasattr(builtins, "__bt_eval_sample_rate"):
+            delattr(builtins, "__bt_eval_sample_rate")
+        return
+    # Used with `bt eval <...> --sample 5`.
+    setattr(builtins, "__bt_eval_sample_rate", config.sample)
 
 
 def _to_mapping(value: Any) -> Any:
@@ -1421,6 +1433,7 @@ def main(argv: list[str] | None = None) -> int:
     config = read_runner_config()
     local = args.local or env_flag("BT_EVAL_LOCAL") or env_flag("BT_EVAL_NO_SEND_LOGS")
     files = args.files or ["."]
+    inject_runtime_values(config)
     if config.num_workers is not None:
         set_thread_pool_max_workers(config.num_workers)
 

--- a/tests/evals/js/eval-sample-init-dataset/fixture.json
+++ b/tests/evals/js/eval-sample-init-dataset/fixture.json
@@ -1,0 +1,4 @@
+{
+  "files": ["sample-init-dataset.eval.cjs"],
+  "args": ["--sample", "5"]
+}

--- a/tests/evals/js/eval-sample-init-dataset/local-braintrust/dist/index.js
+++ b/tests/evals/js/eval-sample-init-dataset/local-braintrust/dist/index.js
@@ -18,12 +18,12 @@ function datasetArgs(projectOrOptions, options) {
 }
 
 function internalBtqlWithDefaultSample(value) {
-  const sample = globalThis.__bt_eval_sample_rate;
-  if (sample === undefined) {
+  const cliBtql = globalThis.__bt_eval_internal_btql;
+  if (cliBtql === undefined) {
     return value;
   }
   if (value === undefined) {
-    return { sample };
+    return cliBtql;
   }
   if (value === null || typeof value !== "object" || Array.isArray(value)) {
     return value;
@@ -31,7 +31,7 @@ function internalBtqlWithDefaultSample(value) {
   if (Object.prototype.hasOwnProperty.call(value, "sample")) {
     return value;
   }
-  return { ...value, sample };
+  return { ...value, ...cliBtql };
 }
 
 async function Eval(projectName, evaluator) {

--- a/tests/evals/js/eval-sample-init-dataset/local-braintrust/dist/index.js
+++ b/tests/evals/js/eval-sample-init-dataset/local-braintrust/dist/index.js
@@ -1,0 +1,119 @@
+"use strict";
+
+function makeRecords(count, prefix) {
+  return Array.from({ length: count }, (_, index) => ({
+    input: `${prefix}-${index}`,
+    expected: `${prefix}-${index}`,
+  }));
+}
+
+function datasetArgs(projectOrOptions, options) {
+  if (typeof projectOrOptions === "string") {
+    return {
+      project: projectOrOptions,
+      ...(options || {}),
+    };
+  }
+  return projectOrOptions || {};
+}
+
+function internalBtqlWithDefaultSample(value) {
+  const sample = globalThis.__bt_eval_sample_rate;
+  if (sample === undefined) {
+    return value;
+  }
+  if (value === undefined) {
+    return { sample };
+  }
+  if (value === null || typeof value !== "object" || Array.isArray(value)) {
+    return value;
+  }
+  if (Object.prototype.hasOwnProperty.call(value, "sample")) {
+    return value;
+  }
+  return { ...value, sample };
+}
+
+async function Eval(projectName, evaluator) {
+  const evalName = evaluator.evalName || projectName;
+  if (globalThis._lazy_load) {
+    globalThis._evals.evaluators[evalName] = {
+      evaluator: { evalName, projectName, ...evaluator },
+    };
+    return;
+  }
+
+  const data =
+    typeof evaluator.data === "function"
+      ? await evaluator.data.call(evaluator)
+      : await evaluator.data;
+  const results = [];
+  for (const item of data) {
+    try {
+      const output = await evaluator.task(item.input);
+      const scores = [];
+      for (const scorer of evaluator.scores || []) {
+        scores.push(
+          await scorer({
+            input: item.input,
+            output,
+            expected: item.expected,
+          }),
+        );
+      }
+      results.push({ output, scores });
+    } catch (error) {
+      results.push({ error });
+    }
+  }
+  return {
+    results,
+    summary: { projectName, experimentName: evaluator.experimentName },
+  };
+}
+
+async function login() {}
+
+function initDataset(projectOrOptions, options) {
+  const args = datasetArgs(projectOrOptions, options);
+  const btql = internalBtqlWithDefaultSample(args._internal_btql);
+  if (args.dataset === "auto-object" || args.dataset === "auto-string") {
+    if (!btql || btql.sample !== 5) {
+      throw new Error(
+        `expected automatic sample 5 for ${args.dataset}, received ${JSON.stringify(btql)}`,
+      );
+    }
+    return makeRecords(5, args.dataset);
+  }
+
+  if (args.dataset === "explicit-sample") {
+    if (!btql || btql.sample !== 2) {
+      throw new Error(
+        `expected explicit sample 2 to be preserved, received ${JSON.stringify(btql)}`,
+      );
+    }
+    if (btql.filter !== "metadata.kind = 'synthetic'") {
+      throw new Error(
+        `expected explicit filter to be preserved, received ${JSON.stringify(btql)}`,
+      );
+    }
+    return makeRecords(2, args.dataset);
+  }
+
+  throw new Error(`unexpected dataset ${args.dataset}`);
+}
+
+function invoke() {}
+
+const api = {
+  Eval,
+  login,
+  initDataset,
+  invoke,
+};
+
+exports.default = api;
+exports.Eval = Eval;
+exports.login = login;
+exports.initDataset = initDataset;
+exports.invoke = invoke;

--- a/tests/evals/js/eval-sample-init-dataset/local-braintrust/package.json
+++ b/tests/evals/js/eval-sample-init-dataset/local-braintrust/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "braintrust",
+  "version": "0.0.0-local",
+  "main": "./dist/index.js",
+  "exports": {
+    ".": "./dist/index.js"
+  }
+}

--- a/tests/evals/js/eval-sample-init-dataset/package.json
+++ b/tests/evals/js/eval-sample-init-dataset/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "bt-eval-sample-init-dataset",
+  "private": true,
+  "dependencies": {
+    "braintrust": "link:./local-braintrust"
+  },
+  "devDependencies": {
+    "tsx": "^4.16.2"
+  }
+}

--- a/tests/evals/js/eval-sample-init-dataset/sample-init-dataset.eval.cjs
+++ b/tests/evals/js/eval-sample-init-dataset/sample-init-dataset.eval.cjs
@@ -1,0 +1,35 @@
+const { Eval, initDataset } = require("braintrust");
+
+function exactMatch({ output, expected }) {
+  return { name: "exact_match", score: output === expected ? 1 : 0 };
+}
+
+Eval("auto-sample-init-dataset-object", {
+  data: initDataset({
+    project: "test-project",
+    dataset: "auto-object",
+  }),
+  task: async (input) => input,
+  scores: [exactMatch],
+});
+
+Eval("auto-sample-init-dataset-string", {
+  data: initDataset("test-project", {
+    dataset: "auto-string",
+  }),
+  task: async (input) => input,
+  scores: [exactMatch],
+});
+
+Eval("preserve-explicit-init-dataset-sample", {
+  data: initDataset({
+    project: "test-project",
+    dataset: "explicit-sample",
+    _internal_btql: {
+      filter: "metadata.kind = 'synthetic'",
+      sample: 2,
+    },
+  }),
+  task: async (input) => input,
+  scores: [exactMatch],
+});

--- a/tests/evals/py/eval_sample_runtime_value/eval_sample_runtime_value.py
+++ b/tests/evals/py/eval_sample_runtime_value/eval_sample_runtime_value.py
@@ -1,0 +1,24 @@
+import builtins
+
+from braintrust import Eval
+
+
+sample = getattr(builtins, "__bt_eval_sample_rate", None)
+if sample != 5:
+    raise RuntimeError(f"expected sample runtime value 5, received {sample!r}")
+
+
+def data():
+    return [{"input": "synthetic", "expected": "synthetic"}]
+
+
+def task(value, hooks=None):
+    return value
+
+
+Eval(
+    "cli-python-sample-runtime-value",
+    data=data,
+    task=task,
+    scores=[],
+)

--- a/tests/evals/py/eval_sample_runtime_value/eval_sample_runtime_value.py
+++ b/tests/evals/py/eval_sample_runtime_value/eval_sample_runtime_value.py
@@ -3,9 +3,11 @@ import builtins
 from braintrust import Eval
 
 
-sample = getattr(builtins, "__bt_eval_sample_rate", None)
-if sample != 5:
-    raise RuntimeError(f"expected sample runtime value 5, received {sample!r}")
+internal_btql = getattr(builtins, "__bt_eval_internal_btql", None)
+if internal_btql != {"sample": 5}:
+    raise RuntimeError(
+        f"expected internal BTQL runtime value {{'sample': 5}}, received {internal_btql!r}"
+    )
 
 
 def data():

--- a/tests/evals/py/eval_sample_runtime_value/fixture.json
+++ b/tests/evals/py/eval_sample_runtime_value/fixture.json
@@ -1,0 +1,5 @@
+{
+  "runtime": "python",
+  "files": ["eval_sample_runtime_value.py"],
+  "args": ["--sample", "5"]
+}


### PR DESCRIPTION
Uses https://github.com/braintrustdata/braintrust-sdk-javascript/pull/2165 from JS