### PR TITLE
Fix switch and oauth org precedence

### DIFF
--- a/src/auth.rs
+++ b/src/auth.rs
@@ -1176,11 +1176,17 @@ where
             api_key,
             api_url: base.api_url.clone().or_else(|| profile.api_url.clone()),
             app_url: base.app_url.clone().or_else(|| profile.app_url.clone()),
-            org_name: base
-                .org_name
-                .clone()
-                .or_else(|| cfg_org.clone())
-                .or_else(|| profile.org_name.clone()),
+            org_name: if is_oauth {
+                base.org_name
+                    .clone()
+                    .or_else(|| profile.org_name.clone())
+                    .or_else(|| cfg_org.clone())
+            } else {
+                base.org_name
+                    .clone()
+                    .or_else(|| cfg_org.clone())
+                    .or_else(|| profile.org_name.clone())
+            },
             is_oauth,
         });
     }
@@ -4536,6 +4542,34 @@ mod tests {
         .expect("resolve");
         assert_eq!(resolved.api_key.as_deref(), Some("profile-key"));
         assert_eq!(resolved.org_name.as_deref(), Some("local-org"));
+    }
+
+    #[test]
+    fn resolve_auth_oauth_profile_org_overrides_stale_config_org() {
+        let mut base = make_base();
+        base.profile = Some("default-profile".to_string());
+
+        let mut store = AuthStore::default();
+        store.profiles.insert(
+            "default-profile".into(),
+            AuthProfile {
+                auth_kind: AuthKind::Oauth,
+                org_name: Some("profile-org".into()),
+                oauth_client_id: Some("bt_cli_default".to_string()),
+                ..Default::default()
+            },
+        );
+        let cfg_org = Some("local-org".to_string());
+
+        let resolved = resolve_auth_from_store_with_secret_lookup(
+            &base,
+            &store,
+            |_| Ok(Some("unused-profile-key".into())),
+            &cfg_org,
+        )
+        .expect("resolve");
+        assert!(resolved.is_oauth);
+        assert_eq!(resolved.org_name.as_deref(), Some("profile-org"));
     }
 
     #[test]

--- a/src/switch.rs
+++ b/src/switch.rs
@@ -92,7 +92,7 @@ pub async fn run(base: BaseArgs, args: SwitchArgs) -> Result<()> {
         _ => {
             let mut b = base.clone();
             if !has_api_key_override && b.org_name.is_none() && b.profile.is_none() {
-                b.org_name = current_cfg.org.clone();
+                apply_current_switch_auth_context(&mut b, &current_cfg);
             }
             if !has_api_key_override && b.org_name.is_none() && b.profile.is_none() {
                 let profiles = auth::list_profiles()?;
@@ -227,6 +227,14 @@ pub(crate) fn select_scope() -> Result<(std::path::PathBuf, &'static str)> {
         Ok((global, "global"))
     } else {
         Ok((local, "local"))
+    }
+}
+
+fn apply_current_switch_auth_context(base: &mut BaseArgs, current_cfg: &config::Config) {
+    if let Some(profile) = config::trimmed_option(current_cfg.profile.as_deref()) {
+        base.profile = Some(profile.to_string());
+    } else {
+        base.org_name = current_cfg.org.clone();
     }
 }
 
@@ -534,6 +542,21 @@ mod tests {
 
         assert_eq!(login_base.profile, Some("staging".into()));
         assert_eq!(login_base.org_name, Some("custom-org".into()));
+    }
+
+    #[test]
+    fn current_switch_auth_context_prefers_profile_over_stale_org() {
+        let mut base = base_args(None, Some("project"));
+        let current_cfg = config::Config {
+            profile: Some("BT Staging".to_string()),
+            org: Some("braintrustdata.com".to_string()),
+            ..Default::default()
+        };
+
+        apply_current_switch_auth_context(&mut base, &current_cfg);
+
+        assert_eq!(base.profile.as_deref(), Some("BT Staging"));
+        assert_eq!(base.org_name, None);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Fixes `bt switch` and OAuth auth resolution when `config.json` contains a stale `org` that disagrees with the selected OAuth profile’s stored `org_name`.

## Problem

A config like this could cause `bt` to use the correct profile credentials but query the wrong org:

```json
{
  "profile": "BT Staging",
  "org": "braintrustdata.com",
  "project": "Loop"
}
```

For OAuth profiles, the token is user-scoped, so the stale config org could override the selected profile’s org and cause commands like `bt switch` to list projects from the wrong workspace.

## Repro

Given an OAuth auth profile like:

```json
{
  "profiles": {
    "BT Staging": {
      "auth_kind": "oauth",
      "api_url": "https://staging-api.braintrust.dev",
      "app_url": "https://www.braintrust.dev",
      "org_name": "BT Staging",
      "oauth_client_id": "bt_cli_default"
    }
  }
}
```

and a global config like:

```json
{
  "profile": "BT Staging",
  "org": "braintrustdata.com",
  "project": "Loop"
}
```

run:

```bash
bt status
bt switch
```

Before this fix:

- `bt status` showed `profile: BT Staging` but `org: braintrustdata.com`
- `bt switch` used the `BT Staging` profile credentials but listed projects from `braintrustdata.com`
- selecting a project wrote the old/stale org back into config

A second repro path was:

```bash
bt switch
# Select org: BT Staging
```

Before this fix, the project picker could still show projects from the previously configured `braintrustdata.com` org instead of the selected `BT Staging` org.

## Changes

- For OAuth profiles, auth resolution now prefers:
  1. explicit `--org` / env org
  2. selected profile’s stored `org_name`
  3. config `org`

- Preserves existing API key profile behavior, where config org can still override profile org.

- Updates `bt switch` project-only auth context to prefer the configured profile over a stale configured org.

- Adds regression tests for:
  - OAuth profile org overriding stale config org
  - API key config-org precedence remaining unchanged
  - `bt switch` preferring configured profile over stale org

## Validation

Ran:

```bash
cargo test resolve_auth_config_org_overrides_profile_org -- --nocapture
cargo test resolve_auth_oauth_profile_org_overrides_stale_config_org -- --nocapture
cargo test current_switch_auth_context_prefers_profile_over_stale_org -- --nocapture
cargo test switch::tests -- --nocapture
cargo check
```
