### PR TITLE
Improve auth resolution

### DIFF
--- a/src/auth.rs
+++ b/src/auth.rs
@@ -862,19 +862,13 @@ fn config_auth_context_from_config(
     base: &BaseArgs,
     cfg: &crate::config::Config,
 ) -> (Option<String>, Option<String>) {
-    let selected_profile = crate::config::trimmed_option(base.profile.as_deref());
-    let configured_profile = crate::config::trimmed_option(cfg.profile.as_deref());
-    let profile = if selected_profile.is_none() {
-        configured_profile.map(str::to_string)
+    let profile = if crate::config::trimmed_option(base.profile.as_deref()).is_none() {
+        crate::config::trimmed_option(cfg.profile.as_deref()).map(str::to_string)
     } else {
         None
     };
 
-    let config_matches_selected_profile =
-        selected_profile.is_none_or(|profile| Some(profile) == configured_profile);
-    let org = if crate::config::trimmed_option(base.org_name.as_deref()).is_none()
-        && config_matches_selected_profile
-    {
+    let org = if crate::config::trimmed_option(base.org_name.as_deref()).is_none() {
         crate::config::trimmed_option(cfg.org.as_deref()).map(str::to_string)
     } else {
         None
@@ -4224,21 +4218,9 @@ mod tests {
     }
 
     #[test]
-    fn config_auth_context_ignores_org_for_different_selected_profile() {
+    fn config_auth_context_preserves_explicit_profile_and_config_org() {
         let mut base = make_base();
         base.profile = Some("explicit-profile".to_string());
-        let cfg = auth_config(Some("config-profile"), Some("local-org"));
-
-        let (profile, org) = config_auth_context_from_config(&base, &cfg);
-
-        assert_eq!(profile, None);
-        assert_eq!(org, None);
-    }
-
-    #[test]
-    fn config_auth_context_keeps_org_for_matching_selected_profile() {
-        let mut base = make_base();
-        base.profile = Some("config-profile".to_string());
         let cfg = auth_config(Some("config-profile"), Some("local-org"));
 
         let (profile, org) = config_auth_context_from_config(&base, &cfg);
@@ -4662,34 +4644,6 @@ mod tests {
     }
 
     #[test]
-    fn resolve_auth_selected_profile_ignores_other_profiles_config_org() {
-        let mut base = make_base();
-        base.profile = Some("test-profile".to_string());
-
-        let mut store = AuthStore::default();
-        store.profiles.insert(
-            "test-profile".into(),
-            AuthProfile {
-                org_name: Some("profile-org".into()),
-                ..Default::default()
-            },
-        );
-        let cfg = auth_config(Some("other-profile"), Some("local-org"));
-        let (_, cfg_org) = config_auth_context_from_config(&base, &cfg);
-
-        let resolved = resolve_auth_from_store_with_secret_lookup(
-            &base,
-            &store,
-            |_| Ok(Some("profile-key".into())),
-            &cfg_org,
-        )
-        .expect("resolve");
-
-        assert_eq!(resolved.api_key.as_deref(), Some("profile-key"));
-        assert_eq!(resolved.org_name.as_deref(), Some("profile-org"));
-    }
-
-    #[test]
     fn resolve_auth_api_key_override_keeps_config_org() {
         let mut base = make_base();
         base.api_key = Some("explicit-key".into());
@@ -4706,10 +4660,9 @@ mod tests {
     }
 
     #[test]
-    fn resolve_auth_explicit_org_overrides_explicit_profile_org() {
+    fn resolve_auth_explicit_profile_overrides_org_resolution() {
         let mut base = make_base();
         base.profile = Some("other".into());
-        base.profile_explicit = true;
         base.org_name = Some("acme-corp".into());
 
         let mut store = AuthStore::default();

--- a/src/auth.rs
+++ b/src/auth.rs
@@ -108,6 +108,17 @@ fn recoverable_auth_error(kind: RecoverableAuthErrorKind, message: String) -> an
     anyhow::Error::new(RecoverableAuthError { kind, message })
 }
 
+fn shell_quote_arg(value: &str) -> String {
+    if value
+        .chars()
+        .all(|ch| ch.is_ascii_alphanumeric() || matches!(ch, '-' | '_' | '.' | '/' | ':' | '='))
+    {
+        value.to_string()
+    } else {
+        format!("'{}'", value.replace('\'', "'\\''"))
+    }
+}
+
 pub fn is_missing_credential_error(err: &anyhow::Error) -> bool {
     err.chain().any(|source| {
         source
@@ -851,13 +862,19 @@ fn config_auth_context_from_config(
     base: &BaseArgs,
     cfg: &crate::config::Config,
 ) -> (Option<String>, Option<String>) {
-    let profile = if crate::config::trimmed_option(base.profile.as_deref()).is_none() {
-        crate::config::trimmed_option(cfg.profile.as_deref()).map(str::to_string)
+    let selected_profile = crate::config::trimmed_option(base.profile.as_deref());
+    let configured_profile = crate::config::trimmed_option(cfg.profile.as_deref());
+    let profile = if selected_profile.is_none() {
+        configured_profile.map(str::to_string)
     } else {
         None
     };
 
-    let org = if crate::config::trimmed_option(base.org_name.as_deref()).is_none() {
+    let config_matches_selected_profile =
+        selected_profile.is_none_or(|profile| Some(profile) == configured_profile);
+    let org = if crate::config::trimmed_option(base.org_name.as_deref()).is_none()
+        && config_matches_selected_profile
+    {
         crate::config::trimmed_option(cfg.org.as_deref()).map(str::to_string)
     } else {
         None
@@ -914,7 +931,8 @@ pub async fn resolve_auth(base: &BaseArgs) -> Result<ResolvedAuth> {
         recoverable_auth_error(
             RecoverableAuthErrorKind::OauthClientId,
             format!(
-                "oauth profile '{profile_name}' is missing client_id; re-run `bt auth login --oauth --profile {profile_name}`"
+                "oauth profile '{profile_name}' is missing client_id; re-run `bt auth login --oauth --profile {}`",
+                shell_quote_arg(&profile_name)
             ),
         )
     })?;
@@ -935,7 +953,8 @@ pub async fn resolve_auth(base: &BaseArgs) -> Result<ResolvedAuth> {
         recoverable_auth_error(
             RecoverableAuthErrorKind::OauthRefreshToken,
             format!(
-                "oauth refresh token missing for profile '{profile_name}'; re-run `bt auth login --oauth --profile {profile_name}`"
+                "oauth refresh token missing for profile '{profile_name}'; re-run `bt auth login --oauth --profile {}`",
+                shell_quote_arg(&profile_name)
             ),
         )
     })?;
@@ -1159,7 +1178,8 @@ where
     if let Some(profile_name) = selected_profile_name {
         let profile = store.profiles.get(profile_name).ok_or_else(|| {
             anyhow::anyhow!(
-                "profile '{profile_name}' not found; run `bt auth profiles` or `bt auth login --profile {profile_name}`"
+                "profile '{profile_name}' not found; run `bt auth profiles` or `bt auth login --profile {}`",
+                shell_quote_arg(profile_name)
             )
         })?;
         let is_oauth = profile.auth_kind == AuthKind::Oauth;
@@ -1170,7 +1190,8 @@ where
                 recoverable_auth_error(
                     RecoverableAuthErrorKind::StoredCredential,
                     format!(
-                        "no keychain credential found for profile '{profile_name}'; re-run `bt auth login --profile {profile_name}`"
+                        "no keychain credential found for profile '{profile_name}'; re-run `bt auth login --profile {}`",
+                        shell_quote_arg(profile_name)
                     ),
                 )
             })?)
@@ -1531,13 +1552,15 @@ async fn run_login_refresh(base: &BaseArgs) -> Result<()> {
         .unwrap_or_else(|| DEFAULT_API_URL.to_string());
     let client_id = profile.oauth_client_id.clone().ok_or_else(|| {
         anyhow::anyhow!(
-            "oauth profile '{profile_name}' is missing client_id; re-run `bt auth login --oauth --profile {profile_name}`"
+            "oauth profile '{profile_name}' is missing client_id; re-run `bt auth login --oauth --profile {}`",
+            shell_quote_arg(&profile_name)
         )
     })?;
     let previous_expires_at = profile.oauth_access_expires_at;
     let refresh_token = load_profile_oauth_refresh_token(profile_name.as_str())?.ok_or_else(|| {
         anyhow::anyhow!(
-            "oauth refresh token missing for profile '{profile_name}'; re-run `bt auth login --oauth --profile {profile_name}`"
+            "oauth refresh token missing for profile '{profile_name}'; re-run `bt auth login --oauth --profile {}`",
+            shell_quote_arg(&profile_name)
         )
     })?;
 
@@ -2929,7 +2952,8 @@ fn map_refresh_oauth_error(
                 message.push_str(&format!(" ({description})"));
             }
             message.push_str(&format!(
-                "; re-run `bt auth login --oauth --profile {profile_name}`"
+                "; re-run `bt auth login --oauth --profile {}`",
+                shell_quote_arg(profile_name)
             ));
             return recoverable_auth_error(RecoverableAuthErrorKind::OauthRefreshToken, message);
         }
@@ -4019,13 +4043,21 @@ mod tests {
     fn invalid_grant_refresh_error_is_treated_as_recoverable() {
         let err = map_refresh_oauth_error(
             "https://api.example.com",
-            "work",
+            "test profile",
             reqwest::StatusCode::BAD_REQUEST,
             r#"{"error":"invalid_grant","error_description":"refresh token expired"}"#,
         );
 
         assert!(is_missing_credential_error(&err));
         assert!(err.to_string().contains("refresh token expired"));
+        assert!(err
+            .to_string()
+            .contains("re-run `bt auth login --oauth --profile 'test profile'`"));
+    }
+
+    #[test]
+    fn shell_quote_arg_escapes_single_quotes() {
+        assert_eq!(shell_quote_arg("test profile's"), "'test profile'\\''s'");
     }
 
     #[test]
@@ -4192,9 +4224,21 @@ mod tests {
     }
 
     #[test]
-    fn config_auth_context_preserves_explicit_profile_and_config_org() {
+    fn config_auth_context_ignores_org_for_different_selected_profile() {
         let mut base = make_base();
         base.profile = Some("explicit-profile".to_string());
+        let cfg = auth_config(Some("config-profile"), Some("local-org"));
+
+        let (profile, org) = config_auth_context_from_config(&base, &cfg);
+
+        assert_eq!(profile, None);
+        assert_eq!(org, None);
+    }
+
+    #[test]
+    fn config_auth_context_keeps_org_for_matching_selected_profile() {
+        let mut base = make_base();
+        base.profile = Some("config-profile".to_string());
         let cfg = auth_config(Some("config-profile"), Some("local-org"));
 
         let (profile, org) = config_auth_context_from_config(&base, &cfg);
@@ -4618,6 +4662,34 @@ mod tests {
     }
 
     #[test]
+    fn resolve_auth_selected_profile_ignores_other_profiles_config_org() {
+        let mut base = make_base();
+        base.profile = Some("test-profile".to_string());
+
+        let mut store = AuthStore::default();
+        store.profiles.insert(
+            "test-profile".into(),
+            AuthProfile {
+                org_name: Some("profile-org".into()),
+                ..Default::default()
+            },
+        );
+        let cfg = auth_config(Some("other-profile"), Some("local-org"));
+        let (_, cfg_org) = config_auth_context_from_config(&base, &cfg);
+
+        let resolved = resolve_auth_from_store_with_secret_lookup(
+            &base,
+            &store,
+            |_| Ok(Some("profile-key".into())),
+            &cfg_org,
+        )
+        .expect("resolve");
+
+        assert_eq!(resolved.api_key.as_deref(), Some("profile-key"));
+        assert_eq!(resolved.org_name.as_deref(), Some("profile-org"));
+    }
+
+    #[test]
     fn resolve_auth_api_key_override_keeps_config_org() {
         let mut base = make_base();
         base.api_key = Some("explicit-key".into());
@@ -4634,9 +4706,10 @@ mod tests {
     }
 
     #[test]
-    fn resolve_auth_explicit_profile_overrides_org_resolution() {
+    fn resolve_auth_explicit_org_overrides_explicit_profile_org() {
         let mut base = make_base();
         base.profile = Some("other".into());
+        base.profile_explicit = true;
         base.org_name = Some("acme-corp".into());
 
         let mut store = AuthStore::default();


### PR DESCRIPTION
* Quote strings with spaces in them in shell args.
* If you do `bt auth login` it writes both a profile and org to `~/.bt/config.json`. However, if you then login with a different profile/org, it reads the org value from this `config.json` and never uses the new profile's org.