### PR TITLE
fix(args): command specific flags could be shown as global

### DIFF
--- a/src/args.rs
+++ b/src/args.rs
@@ -110,11 +110,11 @@ pub struct BaseArgs {
 
 #[derive(Debug, Clone, Args)]
 pub struct CLIArgs<T: Args> {
-    #[command(flatten, next_help_heading = "Global options")]
-    pub base: BaseArgs,
-
     #[command(flatten)]
     pub args: T,
+
+    #[command(flatten, next_help_heading = "Global options")]
+    pub base: BaseArgs,
 }
 
 impl BaseArgs {


### PR DESCRIPTION
Look at the position of the `-g/--global` and `-l/--local` flags.
Before:
```
❯ bt switch -h
Switch org and project context

Usage: bt switch [OPTIONS] [TARGET]

Arguments:
  [TARGET]  Target: project name or org/project

Options:
      --json                 Output as JSON
  -v, --verbose              Increase output verbosity [env: BRAINTRUST_VERBOSE=]
  -q, --quiet                Reduce interactive UI output [env: BRAINTRUST_QUIET=]
      --no-color             Disable ANSI color output [env: BRAINTRUST_NO_COLOR=]
      --no-input             Disable all interactive prompts [env: BRAINTRUST_NO_INPUT=]
      --profile <PROFILE>    Use a saved login profile (or via BRAINTRUST_PROFILE) [env: BRAINTRUST_PROFILE=]
  -o, --org <ORG_NAME>       Override active org (or via BRAINTRUST_ORG_NAME) [env: BRAINTRUST_ORG_NAME=]
  -p, --project <PROJECT>    Override active project [env: BRAINTRUST_DEFAULT_PROJECT]
      --prefer-profile       Prefer profile credentials even if BRAINTRUST_API_KEY/--api-key is set
      --api-url <API_URL>    Override API URL (or via BRAINTRUST_API_URL) [env: BRAINTRUST_API_URL]
      --app-url <APP_URL>    Override app URL (or via BRAINTRUST_APP_URL) [env: BRAINTRUST_APP_URL]
      --ca-cert <CA_CERT>    Path to a PEM-encoded CA bundle used for HTTPS requests [env: BRAINTRUST_CA_CERT]
      --env-file <ENV_FILE>  Path to a .env file to load before running commands [env: BRAINTRUST_ENV_FILE]
  -g, --global               Force set global config value
  -l, --local                Force set local config value
  -h, --help                 Print help

Examples:
  bt switch
  bt switch my-project
  bt switch personal-org/my-project
```

After:
```
❯ bt switch -h
Switch org and project context

Usage: bt switch [OPTIONS] [TARGET]

Arguments:
  [TARGET]  Target: project name or org/project

Options:
  -g, --global  Force set global config value
  -l, --local   Force set local config value
  -h, --help    Print help

Global options:
      --json                 Output as JSON
  -v, --verbose              Increase output verbosity [env: BRAINTRUST_VERBOSE=]
  -q, --quiet                Reduce interactive UI output [env: BRAINTRUST_QUIET=]
      --no-color             Disable ANSI color output [env: BRAINTRUST_NO_COLOR=]
      --no-input             Disable all interactive prompts [env: BRAINTRUST_NO_INPUT=]
      --profile <PROFILE>    Use a saved login profile (or via BRAINTRUST_PROFILE) [env: BRAINTRUST_PROFILE=]
  -o, --org <ORG_NAME>       Override active org (or via BRAINTRUST_ORG_NAME) [env: BRAINTRUST_ORG_NAME=]
  -p, --project <PROJECT>    Override active project [env: BRAINTRUST_DEFAULT_PROJECT]
      --prefer-profile       Prefer profile credentials even if BRAINTRUST_API_KEY/--api-key is set
      --api-url <API_URL>    Override API URL (or via BRAINTRUST_API_URL) [env: BRAINTRUST_API_URL]
      --app-url <APP_URL>    Override app URL (or via BRAINTRUST_APP_URL) [env: BRAINTRUST_APP_URL]
      --ca-cert <CA_CERT>    Path to a PEM-encoded CA bundle used for HTTPS requests [env: BRAINTRUST_CA_CERT]
      --env-file <ENV_FILE>  Path to a .env file to load before running commands [env: BRAINTRUST_ENV_FILE]

Examples:
  bt switch
  bt switch my-project
  bt switch personal-org/my-project
```