### PR TITLE
feat(setup): add eval improvement loop skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -408,9 +408,10 @@ Current behavior:
 - If `--workflow` is omitted in non-interactive mode, setup defaults to all workflows.
 - Use `--refresh-docs` in setup (or `bt docs fetch --refresh`) to clear old docs before re-fetching.
 - `cursor` is local-only in this flow. If selected with `--global`, `bt` prints a warning and continues installing the other selected agents.
-- Claude integration installs the Braintrust skill file under `.claude/skills/braintrust/SKILL.md`.
-- Gemini and Qwen integration symlink `.gemini/skills`/`.qwen/skills` to `.agents/skills/braintrust/SKILL.md`.
-- Copilot integration symlinks `.copilot/skills` to `.agents/skills/braintrust/SKILL.md`. MCP config is written via `copilot mcp add` to the project `.copilot` dir (local) or the default user config (global).
+- Skills setup installs the core Braintrust skill plus `eval-improvement-loop`, which repeatedly runs `bt eval` in offline, uploaded-experiment, or hill-climbing mode; commits every evaluated candidate on a dedicated branch; keeps eval data and scorers frozen; supports optional Braintrust session metadata; and uses a bundled helper to generate and validate its JSONL run log.
+- Claude integration exposes skills under `.claude/skills/`; canonical skill paths are `.agents/skills/braintrust/SKILL.md` and `.agents/skills/eval-improvement-loop/SKILL.md`.
+- Gemini and Qwen integration symlink `.gemini/skills`/`.qwen/skills` to `.agents/skills/`.
+- Copilot integration symlinks `.copilot/skills` to `.agents/skills/`. MCP config is written via `copilot mcp add` to the project `.copilot` dir (local) or the default user config (global).
 - Cursor integration installs `.cursor/rules/braintrust.mdc` with the same shared Braintrust guidance plus an auto-generated command-reference excerpt from this README.
 - Setup-time docs prefetch writes to `.bt/skills/docs` for `--local` and `~/.config/bt/skills/docs` (or `$XDG_CONFIG_HOME/bt/skills/docs`) for `--global`.
 - Docs fetch writes LLM-friendly local indexes: `.bt/skills/docs/README.md` and per-section `.bt/skills/docs/<section>/_index.md` (or the global equivalents under `~/.config/bt/skills/docs`).

--- a/skills/eval-improvement-loop/SKILL.md
+++ b/skills/eval-improvement-loop/SKILL.md
@@ -1,0 +1,258 @@
+---
+name: eval-improvement-loop
+description: Autonomously run Braintrust evals locally and iterate on prompts, models, or application code to improve eval scores. Use when asked to improve eval results, optimize against an eval, repeatedly run evals, or start an eval improvement loop.
+---
+
+# Eval Improvement Loop
+
+Run a bounded, evidence-driven loop: establish a baseline, change one hypothesis, run the eval locally, keep validated gains, revert regressions, and repeat.
+
+## Non-negotiable rules
+
+- Run eval code locally with `bt eval --jsonl`. Add `--local` only for offline/no-upload mode; Braintrust hill climbing requires uploaded experiments and must not use `--local`. Neither mode prevents model-provider calls or their cost.
+- Treat eval files, scorers, test cases, datasets, fixtures, and expected outputs as the benchmark. **Do not edit them to raise the score.** Only edit the system under test unless the user explicitly asks to improve eval design.
+- Never expose hidden/held-out expected outputs to the system under test.
+- A sampled run is a smoke/development result, never a final result. Validate every kept improvement on the full dataset.
+- Change one coherent idea per iteration so results are attributable.
+- Work only on a dedicated `eval-loop/...` branch. Every baseline and candidate state that reaches an eval must be committed first so results map to an exact git revision.
+- Preserve user work. Never use broad `git reset --hard`, `git checkout -- .`, or `git clean -fd` commands.
+- Stop at the agreed iteration/cost/time limit, on user interruption, or when several structurally different ideas fail to improve the full eval. Do not run an unbounded cost-bearing loop.
+
+## Setup
+
+### 1. Inspect and classify
+
+Find evals and inspect the relevant code:
+
+```bash
+bt eval --local --list <eval-paths>
+git status --short
+```
+
+Determine:
+
+- eval files/evaluator filters to run;
+- the system-under-test files that may be edited;
+- frozen benchmark files that must not be edited;
+- primary score or metric and whether higher/lower is better;
+- secondary scores and correctness checks;
+- iteration, time, or cost budget.
+
+Infer these when unambiguous. Ask only for decisions that materially change the experiment. Default to 20 iterations when the user requests autonomous iteration but gives no limit. If model calls have unknown or potentially high cost, confirm the budget before starting.
+
+There are two distinct goals:
+
+1. **Score optimization** (default): freeze the eval and improve the system under test.
+2. **Eval design**: improve datasets/scorers/eval coverage. Define an independent meta-evaluation first; never claim that changing a scorer improved the system's score.
+
+For score optimization, choose one execution mode and record it in `session.md`:
+
+- **Offline**: `bt eval --local --jsonl`. Tasks and scorers run, but no immutable Braintrust experiment is uploaded.
+- **Experiment**: `bt eval --jsonl`. The code runs locally and uploads an immutable experiment snapshot for comparison and sharing.
+- **Hill climb**: the eval uses `BaseExperiment()` / `BaseExperiment(...)` and comparative scorers such as `Battle` or `Summary`. Run without `--local`; the previous experiment outputs must be available in Braintrust.
+
+Do not silently switch modes during a session.
+
+### 2. Configure Braintrust run identity (uploaded modes)
+
+Git metadata is the authoritative link between an uploaded Braintrust experiment and the evaluated candidate, but **do not assume it is being collected**. Before the first uploaded experiment or hill-climb run, tell the user:
+
+> Braintrust uses commit and branch metadata for experiment comparison and hill-climbing base selection when it is available. Collection depends on the SDK version and the organization's **Settings → Logging** policy; some current SDK versions (for example, Python v0.23+) may collect nothing when no organization policy is configured.
+
+Ask the user to verify the policy or approve a one-time evaluator configuration. Follow the current [git metadata collection guidance](https://www.braintrust.dev/docs/kb/running-evaluations-per-git-commit-sha) and request only `commit`, `branch`, and `dirty` through the SDK's `git_metadata_settings` / equivalent. Call-site settings can narrow the organization policy but cannot expand beyond it. Do not claim an experiment is SHA-linked until collection is confirmed. Every uploaded eval must run from the committed candidate with `dirty: false`.
+
+Optionally add stable Braintrust experiment metadata during this one-time setup:
+
+```typescript
+metadata: {
+  eval_loop: true,
+  eval_loop_session: "eval-loop/<session-slug>",
+  eval_loop_mode: "experiment", // or "hill_climb"
+}
+```
+
+```python
+metadata={
+    "eval_loop": True,
+    "eval_loop_session": "eval-loop/<session-slug>",
+    "eval_loop_mode": "experiment",  # or "hill_climb"
+}
+```
+
+This is a provenance-only exception to the frozen-eval rule: get approval, make the metadata/git-collection change before the baseline, commit it, and then freeze the eval harness. Preserve useful existing metadata such as model and prompt version. Do not add a changing run number or candidate SHA by editing the eval file every iteration; git metadata already identifies the candidate, and `.bt/eval-loop/log.jsonl` maps that SHA to the deterministic run number and hypothesis. If the evaluator already exposes provenance as parameters, passing optional run metadata via `bt eval --param` is acceptable as long as the parameter values are recorded by the experiment and remain outside the task/scorer inputs.
+
+Offline `--local` runs upload nothing, so Braintrust metadata does not apply; rely on the local JSONL log.
+
+### 3. Protect the working tree
+
+Require a Git repository and a clean tree. If there are user changes, ask the user to commit/stash them or approve a separate worktree. Do not overwrite them.
+
+Always create a dedicated branch before the baseline. Never run the loop directly on the default branch:
+
+```bash
+git switch -c eval-loop/<short-goal>-<YYYYMMDD>
+git status --short
+git rev-parse HEAD
+```
+
+If setup requires legitimate changes to the system under test, commit them before the baseline. The baseline must always resolve to a commit. On resume, continue only if already on the session branch and the worktree is clean.
+
+Store loop state under `.bt/eval-loop/` so it survives candidate reverts:
+
+```text
+.bt/eval-loop/session.md
+.bt/eval-loop/log.jsonl
+.bt/eval-loop/runs/<run-id>.jsonl
+.bt/eval-loop/runs/<run-id>.stderr
+```
+
+Write `session.md` with the objective, execution mode, exact commands, primary score, direction, editable files, frozen files, checks, budget, branch, baseline commit, whether git metadata collection was confirmed, and any optional Braintrust metadata keys. A fresh agent should be able to resume from it. Keep `.bt/eval-loop/` out of commits; if `.bt/` is not already ignored, add this exact session directory to `.git/info/exclude` rather than changing the project's `.gitignore`.
+
+### 4. Choose run commands
+
+Use machine-readable output and save every run. In offline mode:
+
+```bash
+bt eval --local --jsonl <eval-paths> >.bt/eval-loop/runs/<run-id>.jsonl \
+  2>.bt/eval-loop/runs/<run-id>.stderr
+```
+
+In uploaded experiment or hill-climb mode, omit `--local`:
+
+```bash
+bt eval --jsonl <eval-paths> >.bt/eval-loop/runs/<run-id>.jsonl \
+  2>.bt/eval-loop/runs/<run-id>.stderr
+```
+
+For development runs on a large dataset, use a deterministic sample, again including `--local` only in offline mode:
+
+```bash
+bt eval [--local] --jsonl --sample <N> --sample-seed <SEED> <eval-paths> \
+  >.bt/eval-loop/runs/<run-id>.jsonl \
+  2>.bt/eval-loop/runs/<run-id>.stderr
+```
+
+Use `--filter`, `--param`, `--matrix-param`, `--runner`, or `--language` when the session requires them. Keep parameters identical between a candidate and the baseline it is compared with. Do not use `--watch`: each candidate needs a discrete output file and commit association. Respect eval-level trial counts; for stochastic tasks, multiple trials or repeated runs provide a stronger signal than a single noisy score.
+
+`--jsonl` emits one summary object per evaluator, though eval console output may also be present. Do not parse or write loop JSONL by hand. Use the bundled helper, resolved relative to this skill:
+
+```bash
+EVAL_LOOP_LOG="<SKILL_DIR>/scripts/eval_loop_log.py"
+python3 "$EVAL_LOOP_LOG" extract \
+  --input .bt/eval-loop/runs/<run-id>.jsonl
+```
+
+The helper ignores non-JSON console lines, validates summary shapes, and normalizes all scores and metrics. If the primary name occurs in multiple evaluator summaries, pass `--evaluator` when appending; the helper rejects ambiguous selection instead of averaging unrelated results.
+
+## Establish baselines
+
+1. Run the full eval once. This is the final baseline.
+2. If using sampled development runs, run the exact sample command on the unchanged baseline too.
+3. For noisy evals, repeat the baseline and use the median. Record the observed noise; do not treat movement within that range as a gain.
+4. Run correctness checks once before iterating.
+5. Generate and append the baseline record with the helper:
+
+```bash
+python3 "$EVAL_LOOP_LOG" append \
+  --log .bt/eval-loop/log.jsonl \
+  --eval-output .bt/eval-loop/runs/1-full.jsonl \
+  --run 1 --kind baseline --scope full --status keep --mode offline \
+  --primary-name quality --primary-kind score --direction higher \
+  --hypothesis "unchanged baseline" \
+  --base-commit "$(git rev-parse --short HEAD)"
+```
+
+Replace `--mode offline` with `experiment` or `hill_climb` when applicable. For a sampled record, use `--scope sample --sample-count <N> --sample-seed <SEED>`. For a crash with no summary, omit `--eval-output` and `--primary-value`; null primary values are accepted only for `crash` and `checks_failed` records.
+
+## Iteration loop
+
+Repeat until the budget or stopping rule is reached:
+
+1. Read `session.md`, recent `log.jsonl` entries, and `git log`.
+2. Form one specific hypothesis based on failures or score patterns.
+3. Record the current clean `HEAD` as `BASE_COMMIT`.
+4. Edit only allowed system-under-test files.
+5. Verify frozen benchmark files are unchanged and run fast syntax/type/unit checks.
+6. Commit the candidate **before** evaluating it:
+
+   ```bash
+   git add -- <exact editable paths>
+   git commit -m "eval-loop: <hypothesis>"
+   CANDIDATE_COMMIT="$(git rev-parse HEAD)"
+   ```
+
+7. Run the deterministic sampled eval, or the full eval if it is already small.
+8. Parse and compare the primary plus all secondary scores against the matching baseline/current best.
+9. If a sample improves beyond noise, log it as `advance` and run correctness checks plus the **full eval on the same candidate commit**.
+10. Keep only if the full primary score improves beyond noise and guardrails pass. The candidate commit remains on the branch.
+11. On `discard`, `crash`, or `checks_failed`, restore the previous tree with a targeted revert commit:
+
+    ```bash
+    git revert --no-edit "$CANDIDATE_COMMIT"
+    REVERT_COMMIT="$(git rev-parse HEAD)"
+    ```
+
+12. Generate the run record only after the keep/revert decision. Every candidate record includes `--commit "$CANDIDATE_COMMIT"`; failed/discarded records also include `--revert-commit "$REVERT_COMMIT"`.
+13. Confirm the worktree is clean, then update `session.md` with durable wins, dead ends, and the next best ideas.
+
+Generate every candidate record with `append`, for example:
+
+```bash
+python3 "$EVAL_LOOP_LOG" append \
+  --log .bt/eval-loop/log.jsonl \
+  --eval-output .bt/eval-loop/runs/4-full.jsonl \
+  --run 4 --kind candidate --scope full --status discard --mode offline \
+  --primary-name quality --primary-kind score --direction higher \
+  --hypothesis "shorten the system prompt" \
+  --changed-file src/prompt.ts --base-commit abcdef0 \
+  --commit fedcba9 --revert-commit 1234567 \
+  --reason "full score regressed despite a sampled gain" \
+  --next "try structured instructions without removing examples"
+```
+
+`append` validates the complete existing log before writing, emits compact one-object-per-line JSON, sorts/deduplicates changed files, preserves uploaded experiment identity from the eval summary, and refuses invalid status/value/commit combinations. Run an explicit final check before reporting:
+
+```bash
+python3 "$EVAL_LOOP_LOG" validate --log .bt/eval-loop/log.jsonl
+```
+
+Do not amend or rewrite a candidate commit after evaluating it: that would change the SHA associated with the result. Keep metrics in `.bt/eval-loop/log.jsonl`; the pre-eval commit message should describe only the hypothesis.
+
+## Braintrust hill climbing
+
+Follow the current [Run evaluations](https://www.braintrust.dev/docs/evaluate/run-evaluations) guidance when the eval uses `BaseExperiment`:
+
+- Braintrust uses git metadata when available (timestamps otherwise) to select the best base experiment, so the dedicated branch and pre-eval candidate commits are mandatory.
+- `BaseExperiment()` automatically builds expected values from the prior experiment, merging reviewed `expected` values with its outputs; reviewed expected values take precedence. `BaseExperiment(name="...")` pins a specific base. Never manually copy or expose those values to the task.
+- Use a **comparative scorer** such as `Battle` or `Summary` to decide whether the candidate beats its direct base. A comparative score above 50% means it wins on average.
+- Also track at least one **non-comparative scorer** such as `ClosedQA`. It provides an absolute quality signal that remains comparable across non-sequential experiments.
+- Do not interpret a comparative score as globally comparable across unrelated bases. Log the comparison experiment name and immutable experiment identity extracted by the helper.
+- Keep a candidate only when it beats the direct base, non-comparative guardrails do not regress materially, and full-run/check requirements pass. The kept experiment becomes the next hill-climbing reference.
+- Hill climbing cannot run in offline `--local` mode because the base experiment outputs must be retrieved and the new immutable experiment must be stored.
+
+## Comparison policy
+
+- **Higher-is-better:** candidate must be greater than the best full result plus the noise/minimum-improvement threshold.
+- **Lower-is-better:** candidate must be less than the best full result minus that threshold.
+- Re-run marginal gains before keeping them.
+- Do not average unrelated scores unless the user explicitly defines that aggregate.
+- A catastrophic secondary regression, correctness failure, or policy/safety regression blocks a keep even when the primary improves.
+- Periodically run a different deterministic confirmation sample to detect overfitting, but compare it with a baseline from the same seed.
+
+## Safe revert procedure
+
+Evaluated candidates are always commits. Revert a failed candidate with `git revert --no-edit <candidate-commit>` so the exact evaluated revision remains in history and no broad working-tree reset can destroy user work. If an idea fails before it is committed/evaluated, restore only its exact tracked paths and remove only untracked files created by that attempt.
+
+Never revert or commit `.bt/eval-loop/`; it is the persistent experiment record. Before the next iteration, verify the branch tree matches the last kept commit and `git status --short` is clean.
+
+## Resume and finish
+
+When `.bt/eval-loop/session.md` exists, read it, the tail of `log.jsonl`, current status, and recent commits before continuing. Re-run the current best if the environment or dependencies changed.
+
+At the end report:
+
+- baseline and best **full** primary score with absolute/relative change;
+- secondary score changes and checks;
+- kept commits and files changed;
+- discarded hypotheses and useful findings;
+- whether the limit, plateau rule, or user interruption stopped the loop.

--- a/skills/eval-improvement-loop/scripts/eval_loop_log.py
+++ b/skills/eval-improvement-loop/scripts/eval_loop_log.py
@@ -1,0 +1,448 @@
+#!/usr/bin/env python3
+"""Generate, extract, and validate eval-improvement-loop JSONL records."""
+
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import json
+import math
+import os
+import sys
+from pathlib import Path
+from typing import Any
+
+SCHEMA_VERSION = 1
+KINDS = {"baseline", "candidate", "confirmation"}
+SCOPES = {"full", "sample"}
+STATUSES = {"advance", "keep", "discard", "crash", "checks_failed"}
+DIRECTIONS = {"higher", "lower"}
+PRIMARY_KINDS = {"score", "metric"}
+MODES = {"offline", "experiment", "hill_climb"}
+EXPERIMENT_KEYS = {
+    "project_name",
+    "project_id",
+    "experiment_name",
+    "experiment_id",
+    "experiment_url",
+    "comparison_experiment_name",
+}
+RECORD_KEYS = {
+    "schema_version",
+    "run",
+    "timestamp",
+    "kind",
+    "scope",
+    "status",
+    "mode",
+    "evaluator",
+    "experiment",
+    "primary",
+    "scores",
+    "metrics",
+    "sample",
+    "base_commit",
+    "commit",
+    "revert_commit",
+    "hypothesis",
+    "changed_files",
+    "reason",
+    "next",
+    "eval_output",
+}
+
+
+class ValidationError(ValueError):
+    pass
+
+
+def fail(message: str) -> None:
+    raise ValidationError(message)
+
+
+def is_number(value: Any) -> bool:
+    return isinstance(value, (int, float)) and not isinstance(value, bool) and math.isfinite(value)
+
+
+def require_string(value: Any, field: str, *, allow_empty: bool = False) -> str:
+    if not isinstance(value, str) or (not allow_empty and not value.strip()):
+        fail(f"{field} must be a non-empty string")
+    return value
+
+
+def validate_number_map(value: Any, field: str) -> None:
+    if not isinstance(value, dict):
+        fail(f"{field} must be an object")
+    for name, number in value.items():
+        require_string(name, f"{field} key")
+        if not is_number(number):
+            fail(f"{field}.{name} must be a finite number")
+
+
+def validate_record(record: Any, *, line: int | None = None) -> None:
+    prefix = f"line {line}: " if line is not None else ""
+    try:
+        if not isinstance(record, dict):
+            fail("record must be a JSON object")
+        unknown = sorted(set(record) - RECORD_KEYS)
+        if unknown:
+            fail(f"unknown field(s): {', '.join(unknown)}")
+        missing = sorted(
+            {
+                "schema_version",
+                "run",
+                "timestamp",
+                "kind",
+                "scope",
+                "status",
+                "mode",
+                "primary",
+                "scores",
+                "metrics",
+                "hypothesis",
+                "changed_files",
+            }
+            - set(record)
+        )
+        if missing:
+            fail(f"missing field(s): {', '.join(missing)}")
+        if record["schema_version"] != SCHEMA_VERSION:
+            fail(f"schema_version must be {SCHEMA_VERSION}")
+        if not isinstance(record["run"], int) or isinstance(record["run"], bool) or record["run"] < 1:
+            fail("run must be a positive integer")
+        timestamp = require_string(record["timestamp"], "timestamp")
+        try:
+            parsed_timestamp = dt.datetime.fromisoformat(timestamp.replace("Z", "+00:00"))
+        except ValueError:
+            fail("timestamp must be ISO 8601")
+        if parsed_timestamp.tzinfo is None:
+            fail("timestamp must include a timezone")
+        if record["kind"] not in KINDS:
+            fail(f"kind must be one of: {', '.join(sorted(KINDS))}")
+        if record["scope"] not in SCOPES:
+            fail(f"scope must be one of: {', '.join(sorted(SCOPES))}")
+        if record["status"] not in STATUSES:
+            fail(f"status must be one of: {', '.join(sorted(STATUSES))}")
+        if record["mode"] not in MODES:
+            fail(f"mode must be one of: {', '.join(sorted(MODES))}")
+        if "evaluator" in record and record["evaluator"] is not None:
+            require_string(record["evaluator"], "evaluator")
+        if "experiment" in record:
+            experiment = record["experiment"]
+            if not isinstance(experiment, dict) or set(experiment) != EXPERIMENT_KEYS:
+                fail("experiment must contain exactly the documented experiment identity fields")
+            for field, value in experiment.items():
+                if value is not None:
+                    require_string(value, f"experiment.{field}")
+            if record["mode"] == "offline" and any(
+                experiment[field] is not None
+                for field in ("experiment_id", "experiment_url")
+            ):
+                fail("offline records cannot reference an uploaded experiment")
+
+        primary = record["primary"]
+        if not isinstance(primary, dict) or set(primary) != {"name", "kind", "value", "direction"}:
+            fail("primary must contain exactly name, kind, value, and direction")
+        primary_name = require_string(primary["name"], "primary.name")
+        if primary["kind"] not in PRIMARY_KINDS:
+            fail(f"primary.kind must be one of: {', '.join(sorted(PRIMARY_KINDS))}")
+        if primary["direction"] not in DIRECTIONS:
+            fail(f"primary.direction must be one of: {', '.join(sorted(DIRECTIONS))}")
+        if primary["value"] is not None and not is_number(primary["value"]):
+            fail("primary.value must be a finite number or null")
+        if primary["value"] is None and record["status"] not in {"crash", "checks_failed"}:
+            fail("primary.value may be null only for crash or checks_failed")
+
+        validate_number_map(record["scores"], "scores")
+        validate_number_map(record["metrics"], "metrics")
+        primary_values = record["scores"] if primary["kind"] == "score" else record["metrics"]
+        if primary["value"] is not None:
+            if primary_name not in primary_values:
+                fail(f"primary metric {primary_name!r} is missing from {primary['kind']} values")
+            if primary_values[primary_name] != primary["value"]:
+                fail("primary.value does not match the extracted value")
+
+        if record["scope"] == "sample":
+            sample = record.get("sample")
+            if not isinstance(sample, dict) or set(sample) != {"count", "seed"}:
+                fail("sample scope requires sample with exactly count and seed")
+            if not isinstance(sample["count"], int) or isinstance(sample["count"], bool) or sample["count"] < 1:
+                fail("sample.count must be a positive integer")
+            if not isinstance(sample["seed"], int) or isinstance(sample["seed"], bool) or sample["seed"] < 0:
+                fail("sample.seed must be a non-negative integer")
+        elif "sample" in record:
+            fail("sample is only valid when scope is sample")
+
+        for field in (
+            "base_commit",
+            "commit",
+            "revert_commit",
+            "reason",
+            "next",
+            "eval_output",
+        ):
+            if field in record and record[field] is not None:
+                require_string(record[field], field)
+        require_string(record["hypothesis"], "hypothesis")
+        if not isinstance(record["changed_files"], list):
+            fail("changed_files must be an array")
+        for index, path in enumerate(record["changed_files"]):
+            require_string(path, f"changed_files[{index}]")
+        if len(record["changed_files"]) != len(set(record["changed_files"])):
+            fail("changed_files must not contain duplicates")
+        if record["kind"] == "candidate" and not record.get("commit"):
+            fail("every candidate requires the evaluated commit")
+        if record["status"] == "advance" and record["scope"] != "sample":
+            fail("advance is only valid for a sampled candidate moving to full validation")
+        if record["kind"] == "candidate" and record["status"] == "keep" and record["scope"] != "full":
+            fail("a kept candidate must be validated on the full dataset")
+        if record["status"] in {"keep", "advance"} and record.get("revert_commit"):
+            fail("kept or advancing records cannot have revert_commit")
+        if (
+            record["kind"] == "candidate"
+            and record["status"] in {"discard", "crash", "checks_failed"}
+            and not record.get("revert_commit")
+        ):
+            fail("a discarded or failed candidate requires revert_commit")
+    except ValidationError as error:
+        raise ValidationError(prefix + str(error)) from error
+
+
+def load_log(path: Path) -> list[dict[str, Any]]:
+    if not path.exists():
+        return []
+    records: list[dict[str, Any]] = []
+    previous_run = 0
+    for line_number, raw in enumerate(path.read_text(encoding="utf-8").splitlines(), start=1):
+        if not raw.strip():
+            fail(f"line {line_number}: blank lines are not allowed")
+        try:
+            record = json.loads(raw)
+        except json.JSONDecodeError as error:
+            fail(f"line {line_number}: invalid JSON: {error.msg}")
+        validate_record(record, line=line_number)
+        run = record["run"]
+        expected_run = previous_run + 1
+        if run != expected_run:
+            fail(f"line {line_number}: run must be {expected_run}, got {run}")
+        previous_run = run
+        records.append(record)
+    return records
+
+
+def extract_values(container: Any, value_field: str, field: str) -> dict[str, float]:
+    if container is None:
+        return {}
+    if not isinstance(container, dict):
+        fail(f"eval summary {field} must be an object")
+    values: dict[str, float] = {}
+    for key, item in container.items():
+        if not isinstance(item, dict) or not is_number(item.get(value_field)):
+            fail(f"eval summary {field}.{key}.{value_field} must be a finite number")
+        values[key] = item[value_field]
+    return values
+
+
+def extract_summaries(path: Path) -> list[dict[str, Any]]:
+    if not path.exists():
+        fail(f"eval output does not exist: {path}")
+    summaries: list[dict[str, Any]] = []
+    for line_number, raw in enumerate(path.read_text(encoding="utf-8", errors="replace").splitlines(), start=1):
+        try:
+            value = json.loads(raw)
+        except json.JSONDecodeError:
+            continue
+        if not isinstance(value, dict) or not isinstance(value.get("scores"), dict):
+            continue
+        evaluator = value.get("experimentName") or value.get("experiment_name")
+        if evaluator is not None and not isinstance(evaluator, str):
+            fail(f"eval output line {line_number}: experimentName must be a string")
+        summaries.append(
+            {
+                "evaluator": evaluator,
+                "experiment": {
+                    "project_name": value.get("projectName", value.get("project_name")),
+                    "project_id": value.get("projectId", value.get("project_id")),
+                    "experiment_name": value.get("experimentName", value.get("experiment_name")),
+                    "experiment_id": value.get("experimentId", value.get("experiment_id")),
+                    "experiment_url": value.get("experimentUrl", value.get("experiment_url")),
+                    "comparison_experiment_name": value.get(
+                        "comparisonExperimentName",
+                        value.get("comparison_experiment_name"),
+                    ),
+                },
+                "scores": extract_values(value.get("scores"), "score", "scores"),
+                "metrics": extract_values(value.get("metrics"), "metric", "metrics"),
+                "is_final": value.get("isFinal", value.get("is_final")),
+                "run_mode": value.get("runMode", value.get("run_mode")),
+            }
+        )
+    if not summaries:
+        fail(f"no eval summary objects with scores found in {path}")
+    return summaries
+
+
+def select_summary(summaries: list[dict[str, Any]], evaluator: str | None, primary_name: str, primary_kind: str) -> dict[str, Any]:
+    candidates = summaries
+    if evaluator is not None:
+        candidates = [summary for summary in summaries if summary["evaluator"] == evaluator]
+        if not candidates:
+            available = sorted(str(summary["evaluator"]) for summary in summaries)
+            fail(f"evaluator {evaluator!r} not found; available: {', '.join(available)}")
+    field = "scores" if primary_kind == "score" else "metrics"
+    candidates = [summary for summary in candidates if primary_name in summary[field]]
+    if not candidates:
+        fail(f"primary {primary_kind} {primary_name!r} was not found")
+    if len(candidates) > 1:
+        names = [str(summary["evaluator"]) for summary in candidates]
+        fail(f"primary {primary_kind} {primary_name!r} is ambiguous across evaluators: {', '.join(names)}; pass --evaluator")
+    return candidates[0]
+
+
+def utc_timestamp() -> str:
+    return dt.datetime.now(dt.timezone.utc).isoformat(timespec="seconds").replace("+00:00", "Z")
+
+
+def command_extract(args: argparse.Namespace) -> None:
+    summaries = extract_summaries(args.input)
+    print(json.dumps(summaries, sort_keys=True, separators=(",", ":")))
+
+
+def command_validate(args: argparse.Namespace) -> None:
+    records = load_log(args.log)
+    print(f"valid: {len(records)} record(s)")
+
+
+def command_append(args: argparse.Namespace) -> None:
+    records = load_log(args.log)
+    expected_run = records[-1]["run"] + 1 if records else 1
+    if args.run != expected_run:
+        fail(f"run must be {expected_run}, got {args.run}")
+
+    scores: dict[str, float] = {}
+    metrics: dict[str, float] = {}
+    evaluator = args.evaluator
+    experiment: dict[str, str | None] | None = None
+    primary_value = args.primary_value
+    if args.eval_output is not None:
+        summary = select_summary(
+            extract_summaries(args.eval_output),
+            args.evaluator,
+            args.primary_name,
+            args.primary_kind,
+        )
+        evaluator = summary["evaluator"]
+        experiment = summary["experiment"]
+        scores = summary["scores"]
+        metrics = summary["metrics"]
+        if args.scope == "full" and summary["is_final"] is False:
+            fail("full record cannot use a non-final eval summary")
+        if args.scope == "sample" and summary["is_final"] is True:
+            fail("sample record cannot use a final eval summary")
+        values = scores if args.primary_kind == "score" else metrics
+        extracted = values[args.primary_name]
+        if primary_value is not None and primary_value != extracted:
+            fail("--primary-value does not match the eval output")
+        primary_value = extracted
+    elif primary_value is not None:
+        target = scores if args.primary_kind == "score" else metrics
+        target[args.primary_name] = primary_value
+
+    record: dict[str, Any] = {
+        "schema_version": SCHEMA_VERSION,
+        "run": args.run,
+        "timestamp": args.timestamp or utc_timestamp(),
+        "kind": args.kind,
+        "scope": args.scope,
+        "status": args.status,
+        "mode": args.mode,
+        "primary": {
+            "name": args.primary_name,
+            "kind": args.primary_kind,
+            "value": primary_value,
+            "direction": args.direction,
+        },
+        "scores": scores,
+        "metrics": metrics,
+        "hypothesis": args.hypothesis,
+        "changed_files": sorted(set(args.changed_file)),
+    }
+    optional = {
+        "evaluator": evaluator,
+        "experiment": experiment,
+        "base_commit": args.base_commit,
+        "commit": args.commit,
+        "revert_commit": args.revert_commit,
+        "reason": args.reason,
+        "next": args.next,
+        "eval_output": str(args.eval_output) if args.eval_output is not None else None,
+    }
+    record.update({key: value for key, value in optional.items() if value is not None})
+    if args.scope == "sample":
+        if args.sample_count is None or args.sample_seed is None:
+            fail("sample scope requires --sample-count and --sample-seed")
+        record["sample"] = {"count": args.sample_count, "seed": args.sample_seed}
+    elif args.sample_count is not None or args.sample_seed is not None:
+        fail("sample options require --scope sample")
+
+    validate_record(record)
+    args.log.parent.mkdir(parents=True, exist_ok=True)
+    line = json.dumps(record, sort_keys=True, separators=(",", ":"), ensure_ascii=False)
+    with args.log.open("a", encoding="utf-8") as handle:
+        handle.write(line + "\n")
+        handle.flush()
+        os.fsync(handle.fileno())
+    print(line)
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    extract = subparsers.add_parser("extract", help="extract normalized summaries from bt eval --jsonl output")
+    extract.add_argument("--input", required=True, type=Path)
+    extract.set_defaults(func=command_extract)
+
+    validate = subparsers.add_parser("validate", help="validate an eval-loop log")
+    validate.add_argument("--log", required=True, type=Path)
+    validate.set_defaults(func=command_validate)
+
+    append = subparsers.add_parser("append", help="generate, validate, and append one compact JSONL record")
+    append.add_argument("--log", required=True, type=Path)
+    append.add_argument("--eval-output", type=Path)
+    append.add_argument("--run", required=True, type=int)
+    append.add_argument("--kind", required=True, choices=sorted(KINDS))
+    append.add_argument("--scope", required=True, choices=sorted(SCOPES))
+    append.add_argument("--status", required=True, choices=sorted(STATUSES))
+    append.add_argument("--mode", required=True, choices=sorted(MODES))
+    append.add_argument("--primary-name", required=True)
+    append.add_argument("--primary-kind", choices=sorted(PRIMARY_KINDS), default="score")
+    append.add_argument("--primary-value", type=float)
+    append.add_argument("--direction", required=True, choices=sorted(DIRECTIONS))
+    append.add_argument("--evaluator")
+    append.add_argument("--hypothesis", required=True)
+    append.add_argument("--changed-file", action="append", default=[])
+    append.add_argument("--base-commit")
+    append.add_argument("--commit")
+    append.add_argument("--revert-commit")
+    append.add_argument("--reason")
+    append.add_argument("--next")
+    append.add_argument("--sample-count", type=int)
+    append.add_argument("--sample-seed", type=int)
+    append.add_argument("--timestamp", help="ISO 8601 timestamp; defaults to current UTC time")
+    append.set_defaults(func=command_append)
+    return parser
+
+
+def main() -> int:
+    try:
+        args = build_parser().parse_args()
+        args.func(args)
+        return 0
+    except ValidationError as error:
+        print(f"error: {error}", file=sys.stderr)
+        return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/setup/mod.rs
+++ b/src/setup/mod.rs
@@ -35,6 +35,9 @@ const SHARED_SKILL_BODY: &str = include_str!("../../skills/shared/braintrust-cli
 const SHARED_WORKFLOW_GUIDE: &str = include_str!("../../skills/shared/workflows.md");
 const SHARED_SKILL_TEMPLATE: &str = include_str!("../../skills/shared/skill_template.md");
 const SKILL_FRONTMATTER: &str = include_str!("../../skills/shared/skill_frontmatter.md");
+const EVAL_IMPROVEMENT_SKILL: &str = include_str!("../../skills/eval-improvement-loop/SKILL.md");
+const EVAL_IMPROVEMENT_LOG_SCRIPT: &str =
+    include_str!("../../skills/eval-improvement-loop/scripts/eval_loop_log.py");
 const BT_README: &str = include_str!("../../README.md");
 const SETUP_WIZARD_CREATE_PATH: &str = "/api/cli/wizard-session/create";
 const SETUP_WIZARD_POLL_PATH: &str = "/api/cli/wizard-session/poll";
@@ -559,10 +562,15 @@ struct SkillsSetupOutcome {
     successful_count: usize,
 }
 
+struct BundledSkill {
+    name: &'static str,
+    files: Vec<(&'static str, String)>,
+}
+
 #[derive(Debug, Clone)]
 struct SkillsAliasResult {
     changed: bool,
-    path: PathBuf,
+    paths: Vec<PathBuf>,
 }
 
 pub async fn run_setup_top(base: BaseArgs, mut args: SetupArgs) -> Result<()> {
@@ -4479,15 +4487,23 @@ fn install_agent_skill(
     alias_dir: Option<&str>,
 ) -> Result<AgentInstallResult> {
     let root = scope_root(scope, local_root, home)?;
-    let skill_content = render_braintrust_skill();
-    let (canonical_changed, skill_path) = install_canonical_skill(root, &skill_content)?;
+    let skills = bundled_skills();
+    let (canonical_changed, canonical_paths) = install_canonical_skills(root, &skills)?;
     let mut changed = canonical_changed;
-    let mut paths = vec![skill_path.display().to_string()];
+    let mut paths = canonical_paths
+        .into_iter()
+        .map(|path| path.display().to_string())
+        .collect::<Vec<_>>();
 
     if let Some(alias_dir) = alias_dir {
-        let alias = ensure_agent_skills_alias(root, alias_dir, &skill_content)?;
+        let alias = ensure_agent_skills_alias(root, alias_dir, &skills)?;
         changed |= alias.changed;
-        paths.push(alias.path.display().to_string());
+        paths.extend(
+            alias
+                .paths
+                .into_iter()
+                .map(|path| path.display().to_string()),
+        );
     }
 
     Ok(AgentInstallResult {
@@ -4498,7 +4514,7 @@ fn install_agent_skill(
             InstallStatus::Skipped
         },
         message: if changed {
-            "installed skill".to_string()
+            "installed skills".to_string()
         } else {
             "already configured".to_string()
         },
@@ -4506,16 +4522,49 @@ fn install_agent_skill(
     })
 }
 
-fn install_canonical_skill(root: &Path, skill_content: &str) -> Result<(bool, PathBuf)> {
-    let skill_path = root.join(".agents/skills/braintrust/SKILL.md");
-    let changed = write_text_file_if_changed(&skill_path, skill_content)?;
-    Ok((changed, skill_path))
+fn bundled_skills() -> Vec<BundledSkill> {
+    vec![
+        BundledSkill {
+            name: "braintrust",
+            files: vec![("SKILL.md", render_braintrust_skill())],
+        },
+        BundledSkill {
+            name: "eval-improvement-loop",
+            files: vec![
+                ("SKILL.md", EVAL_IMPROVEMENT_SKILL.trim().to_string()),
+                (
+                    "scripts/eval_loop_log.py",
+                    EVAL_IMPROVEMENT_LOG_SCRIPT.trim().to_string(),
+                ),
+            ],
+        },
+    ]
+}
+
+fn install_canonical_skills(root: &Path, skills: &[BundledSkill]) -> Result<(bool, Vec<PathBuf>)> {
+    install_skills_in_dir(&root.join(".agents/skills"), skills)
+}
+
+fn install_skills_in_dir(
+    skills_dir: &Path,
+    skills: &[BundledSkill],
+) -> Result<(bool, Vec<PathBuf>)> {
+    let mut changed = false;
+    let mut paths = Vec::new();
+    for skill in skills {
+        for (relative_path, content) in &skill.files {
+            let path = skills_dir.join(skill.name).join(relative_path);
+            changed |= write_text_file_if_changed(&path, content)?;
+            paths.push(path);
+        }
+    }
+    Ok((changed, paths))
 }
 
 fn ensure_agent_skills_alias(
     root: &Path,
     agent_dir: &str,
-    skill_content: &str,
+    skills: &[BundledSkill],
 ) -> Result<SkillsAliasResult> {
     let canonical_skills_dir = root.join(".agents/skills");
     fs::create_dir_all(&canonical_skills_dir).with_context(|| {
@@ -4536,33 +4585,25 @@ fn ensure_agent_skills_alias(
             if symlink_points_to(&alias_path, &canonical_skills_dir) {
                 return Ok(SkillsAliasResult {
                     changed: false,
-                    path: alias_path,
+                    paths: vec![alias_path],
                 });
             }
             fs::remove_file(&alias_path)
                 .with_context(|| format!("failed to replace symlink {}", alias_path.display()))?;
         } else {
-            let mirror_skill_path = alias_path.join("braintrust/SKILL.md");
-            let changed = write_text_file_if_changed(&mirror_skill_path, skill_content)?;
-            return Ok(SkillsAliasResult {
-                changed,
-                path: mirror_skill_path,
-            });
+            let (changed, paths) = install_skills_in_dir(&alias_path, skills)?;
+            return Ok(SkillsAliasResult { changed, paths });
         }
     }
 
     match create_dir_symlink(&canonical_skills_dir, &alias_path) {
         Ok(()) => Ok(SkillsAliasResult {
             changed: true,
-            path: alias_path,
+            paths: vec![alias_path],
         }),
         Err(_) => {
-            let mirror_skill_path = alias_path.join("braintrust/SKILL.md");
-            let changed = write_text_file_if_changed(&mirror_skill_path, skill_content)?;
-            Ok(SkillsAliasResult {
-                changed,
-                path: mirror_skill_path,
-            })
+            let (changed, paths) = install_skills_in_dir(&alias_path, skills)?;
+            Ok(SkillsAliasResult { changed, paths })
         }
     }
 }
@@ -7694,6 +7735,12 @@ mod tests {
             .install_skill(InstallScope::Local, Some(&root), &home)
             .expect("first install");
         assert!(matches!(first.status, InstallStatus::Installed));
+        assert!(root
+            .join(".agents/skills/eval-improvement-loop/SKILL.md")
+            .exists());
+        assert!(root
+            .join(".agents/skills/eval-improvement-loop/scripts/eval_loop_log.py")
+            .exists());
 
         let second = Agent::Codex
             .install_skill(InstallScope::Local, Some(&root), &home)
@@ -7782,6 +7829,15 @@ mod tests {
     fn rendered_skill_frontmatter_name_matches_braintrust_directory() {
         let content = render_braintrust_skill();
         assert!(content.starts_with("---\nname: braintrust\n"));
+    }
+
+    #[test]
+    fn bundled_eval_skill_frontmatter_matches_directory() {
+        assert!(EVAL_IMPROVEMENT_SKILL.starts_with("---\nname: eval-improvement-loop\n"));
+        assert!(EVAL_IMPROVEMENT_SKILL.contains("Settings → Logging"));
+        assert!(EVAL_IMPROVEMENT_SKILL.contains("git_metadata_settings"));
+        assert!(EVAL_IMPROVEMENT_SKILL.contains("eval_loop_session"));
+        assert!(EVAL_IMPROVEMENT_LOG_SCRIPT.starts_with("#!/usr/bin/env python3\n"));
     }
 
     #[test]

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -257,6 +257,14 @@ fn setup_uses_codex_detected_on_path_without_explicit_agent() {
         .path()
         .join(".agents/skills/braintrust/SKILL.md")
         .exists());
+    assert!(home
+        .path()
+        .join(".agents/skills/eval-improvement-loop/SKILL.md")
+        .exists());
+    assert!(home
+        .path()
+        .join(".agents/skills/eval-improvement-loop/scripts/eval_loop_log.py")
+        .exists());
 }
 
 #[test]

--- a/tests/eval_loop_skill.rs
+++ b/tests/eval_loop_skill.rs
@@ -1,0 +1,194 @@
+use std::fs;
+use std::path::Path;
+use std::process::{Command, Output};
+
+fn python3_available() -> bool {
+    Command::new("python3")
+        .arg("--version")
+        .output()
+        .map(|output| output.status.success())
+        .unwrap_or(false)
+}
+
+fn run_script(script: &Path, args: &[&str]) -> Output {
+    Command::new("python3")
+        .arg(script)
+        .args(args)
+        .output()
+        .expect("run eval loop log script")
+}
+
+#[test]
+fn eval_loop_log_script_generates_and_validates_compact_jsonl() {
+    if !python3_available() {
+        eprintln!("Skipping eval loop skill test (python3 not installed).");
+        return;
+    }
+
+    let root = tempfile::tempdir().expect("create tempdir");
+    let eval_output = root.path().join("eval.jsonl");
+    let log = root.path().join("log.jsonl");
+    let script = Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("skills/eval-improvement-loop/scripts/eval_loop_log.py");
+
+    fs::write(
+        &eval_output,
+        concat!(
+            "console output that is not JSON\n",
+            r#"{"projectName":"test-project","projectId":"project-test-id","experimentName":"test-evaluator","experimentId":"experiment-test-id","experimentUrl":"https://www.example.test/test-experiment","scores":{"quality":{"name":"quality","score":0.75},"style":{"name":"style","score":0.8}},"metrics":{"duration":{"name":"duration","metric":1.2}},"isFinal":true,"runMode":"full"}"#,
+            "\n"
+        ),
+    )
+    .expect("write eval output");
+
+    let append = run_script(
+        &script,
+        &[
+            "append",
+            "--log",
+            log.to_str().expect("log path"),
+            "--eval-output",
+            eval_output.to_str().expect("eval output path"),
+            "--run",
+            "1",
+            "--kind",
+            "baseline",
+            "--scope",
+            "full",
+            "--status",
+            "keep",
+            "--mode",
+            "experiment",
+            "--primary-name",
+            "quality",
+            "--direction",
+            "higher",
+            "--hypothesis",
+            "unchanged baseline",
+            "--timestamp",
+            "2026-07-21T00:00:00Z",
+        ],
+    );
+    assert!(
+        append.status.success(),
+        "append failed: {}",
+        String::from_utf8_lossy(&append.stderr)
+    );
+
+    let validate = run_script(
+        &script,
+        &["validate", "--log", log.to_str().expect("log path")],
+    );
+    assert!(validate.status.success());
+    assert_eq!(
+        String::from_utf8_lossy(&validate.stdout).trim(),
+        "valid: 1 record(s)"
+    );
+
+    let content = fs::read_to_string(&log).expect("read log");
+    assert_eq!(content.lines().count(), 1);
+    let record: serde_json::Value = serde_json::from_str(content.trim()).expect("parse record");
+    assert_eq!(record["schema_version"], 1);
+    assert_eq!(record["evaluator"], "test-evaluator");
+    assert_eq!(record["primary"]["value"], 0.75);
+    assert_eq!(record["scores"]["style"], 0.8);
+    assert_eq!(record["metrics"]["duration"], 1.2);
+    assert_eq!(record["experiment"]["experiment_id"], "experiment-test-id");
+
+    let discard = run_script(
+        &script,
+        &[
+            "append",
+            "--log",
+            log.to_str().expect("log path"),
+            "--eval-output",
+            eval_output.to_str().expect("eval output path"),
+            "--run",
+            "2",
+            "--kind",
+            "candidate",
+            "--scope",
+            "full",
+            "--status",
+            "discard",
+            "--mode",
+            "experiment",
+            "--primary-name",
+            "quality",
+            "--direction",
+            "higher",
+            "--hypothesis",
+            "test candidate",
+            "--base-commit",
+            "base-test-commit",
+            "--commit",
+            "candidate-test-commit",
+            "--revert-commit",
+            "revert-test-commit",
+            "--changed-file",
+            "src/z_test.rs",
+            "--changed-file",
+            "src/a_test.rs",
+            "--changed-file",
+            "src/z_test.rs",
+            "--reason",
+            "quality did not improve",
+            "--timestamp",
+            "2026-07-21T00:01:00Z",
+        ],
+    );
+    assert!(
+        discard.status.success(),
+        "discard append failed: {}",
+        String::from_utf8_lossy(&discard.stderr)
+    );
+    let records = fs::read_to_string(&log).expect("read two records");
+    let discarded: serde_json::Value =
+        serde_json::from_str(records.lines().nth(1).expect("second record"))
+            .expect("parse discard record");
+    assert_eq!(discarded["commit"], "candidate-test-commit");
+    assert_eq!(discarded["revert_commit"], "revert-test-commit");
+    assert_eq!(
+        discarded["changed_files"],
+        serde_json::json!(["src/a_test.rs", "src/z_test.rs"])
+    );
+
+    let invalid_keep = run_script(
+        &script,
+        &[
+            "append",
+            "--log",
+            log.to_str().expect("log path"),
+            "--eval-output",
+            eval_output.to_str().expect("eval output path"),
+            "--run",
+            "3",
+            "--kind",
+            "candidate",
+            "--scope",
+            "full",
+            "--status",
+            "keep",
+            "--mode",
+            "experiment",
+            "--primary-name",
+            "quality",
+            "--direction",
+            "higher",
+            "--hypothesis",
+            "candidate without a commit",
+            "--timestamp",
+            "2026-07-21T00:01:00Z",
+        ],
+    );
+    assert!(!invalid_keep.status.success());
+    assert!(String::from_utf8_lossy(&invalid_keep.stderr)
+        .contains("every candidate requires the evaluated commit"));
+    assert_eq!(
+        fs::read_to_string(&log)
+            .expect("read unchanged log")
+            .lines()
+            .count(),
+        2
+    );
+}


### PR DESCRIPTION
Install a reusable skill for iterating on eval candidates from dedicated branches in offline, uploaded-experiment, or hill-climbing mode.

Bundle a deterministic JSONL helper that extracts eval summaries and validates run, score, experiment, and commit/revert metadata.