### PR TITLE
cedric/remove self update

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -21,7 +21,6 @@ mod prompts;
 mod python_runner;
 mod runner_sse;
 mod scorers;
-mod self_update;
 mod setup;
 mod source_language;
 mod sql;
@@ -32,6 +31,7 @@ mod tools;
 mod topics;
 mod traces;
 mod ui;
+mod update;
 mod util_cmd;
 mod utils;
 
@@ -148,10 +148,7 @@ enum Commands {
     /// Manage prompts
     Prompts(CLIArgs<prompts::PromptsArgs>),
     /// Update bt in-place
-    Update(CLIArgs<self_update::UpdateArgs>),
-    #[command(name = "self", hide = true)]
-    /// Self-management commands
-    SelfCommand(CLIArgs<self_update::SelfArgs>),
+    Update(CLIArgs<update::UpdateArgs>),
     /// Manage tools
     Tools(CLIArgs<tools::ToolsArgs>),
     /// Manage scorers
@@ -189,7 +186,6 @@ impl Commands {
             Commands::Datasets(cmd) => &cmd.base,
             Commands::Prompts(cmd) => &cmd.base,
             Commands::Update(cmd) => &cmd.base,
-            Commands::SelfCommand(cmd) => &cmd.base,
             Commands::Tools(cmd) => &cmd.base,
             Commands::Scorers(cmd) => &cmd.base,
             Commands::Functions(cmd) => &cmd.base,
@@ -217,7 +213,6 @@ impl Commands {
             Commands::Topics(cmd) => &mut cmd.base,
             Commands::Prompts(cmd) => &mut cmd.base,
             Commands::Update(cmd) => &mut cmd.base,
-            Commands::SelfCommand(cmd) => &mut cmd.base,
             Commands::Tools(cmd) => &mut cmd.base,
             Commands::Scorers(cmd) => &mut cmd.base,
             Commands::Functions(cmd) => &mut cmd.base,
@@ -325,22 +320,13 @@ fn try_main() -> Result<()> {
             Commands::Datasets(cmd) => datasets::run(cmd.base, cmd.args).await?,
             Commands::Topics(cmd) => topics::run(cmd.base, cmd.args).await?,
             Commands::Prompts(cmd) => prompts::run(cmd.base, cmd.args).await?,
-            Commands::Update(cmd) => {
-                self_update::run(
-                    cmd.base,
-                    self_update::SelfArgs {
-                        command: self_update::SelfSubcommand::Update(cmd.args),
-                    },
-                )
-                .await?
-            }
+            Commands::Update(cmd) => update::run(cmd.base, cmd.args).await?,
             Commands::Tools(cmd) => tools::run(cmd.base, cmd.args).await?,
             Commands::Scorers(cmd) => scorers::run(cmd.base, cmd.args).await?,
             Commands::Functions(cmd) => functions::run(cmd.base, cmd.args).await?,
             Commands::Experiments(cmd) => experiments::run(cmd.base, cmd.args).await?,
             Commands::Sync(cmd) => sync::run(cmd.base, cmd.args).await?,
             Commands::Util(cmd) => util_cmd::run(cmd.base, cmd.args).await?,
-            Commands::SelfCommand(cmd) => self_update::run(cmd.base, cmd.args).await?,
             Commands::Switch(cmd) => switch::run(cmd.base, cmd.args).await?,
             Commands::Status(cmd) => status::run(cmd.base, cmd.args).await?,
         }

--- a/src/update.rs
+++ b/src/update.rs
@@ -3,7 +3,7 @@ use std::path::{Path, PathBuf};
 use std::process::Command;
 
 use anyhow::{Context, Result};
-use clap::{Args, Subcommand, ValueEnum};
+use clap::{Args, ValueEnum};
 use reqwest::Client;
 use serde::Deserialize;
 
@@ -17,18 +17,6 @@ Examples:
   bt update --check
   bt update --channel canary
 ")]
-pub struct SelfArgs {
-    #[command(subcommand)]
-    pub command: SelfSubcommand,
-}
-
-#[derive(Debug, Clone, Subcommand)]
-pub enum SelfSubcommand {
-    /// Update bt in-place (installer-managed installs only)
-    Update(UpdateArgs),
-}
-
-#[derive(Debug, Clone, Args)]
 pub struct UpdateArgs {
     /// Check for updates without installing
     #[arg(long)]
@@ -85,10 +73,8 @@ struct GitHubRelease {
     target_commitish: Option<String>,
 }
 
-pub async fn run(base: BaseArgs, args: SelfArgs) -> Result<()> {
-    match args.command {
-        SelfSubcommand::Update(args) => run_update(&base, args).await,
-    }
+pub async fn run(base: BaseArgs, args: UpdateArgs) -> Result<()> {
+    run_update(&base, args).await
 }
 
 async fn run_update(base: &BaseArgs, args: UpdateArgs) -> Result<()> {

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -80,19 +80,9 @@ fn setup_verbose_is_accepted_after_subcommand() {
 }
 
 #[test]
-fn update_help_exposes_self_update_flags() {
+fn update_help_exposes_update_flags() {
     bt_command()
         .args(["update", "--help"])
-        .assert()
-        .success()
-        .stdout(predicate::str::contains("--check"))
-        .stdout(predicate::str::contains("--channel"));
-}
-
-#[test]
-fn self_update_remains_as_hidden_compatibility_path() {
-    bt_command()
-        .args(["self", "update", "--help"])
         .assert()
         .success()
         .stdout(predicate::str::contains("--check"))


### PR DESCRIPTION
- **chore(update)!: remove `bt self update`**
  `bt self update` had already been deprecated by `bt update`
  it was hidden since `bt update`'s introduction
  `bt update` does exactly the same things, it's only a name change

[To the LLM reviewing this PR for docs update: this is a breaking change and has to be triaged]