### PR TITLE
Embed the coding-agent tracing daemon

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -488,11 +488,11 @@ dependencies = [
  "chrono",
  "crossbeam",
  "futures",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "regex",
  "reqwest",
  "serde",
- "serde_json 1.0.149",
+ "serde_json 1.0.151",
  "serde_repr",
  "thiserror 1.0.69",
  "tokio",
@@ -594,7 +594,7 @@ dependencies = [
 [[package]]
 name = "bt-daemon"
 version = "0.1.0"
-source = "git+https://github.com/braintrustdata/braintrust-coding-agent-plugins?rev=96f452780b4c3b1aea2325853817721e777d3c48#96f452780b4c3b1aea2325853817721e777d3c48"
+source = "git+https://github.com/braintrustdata/braintrust-coding-agent-plugins?rev=30e4b53f373940ea26c7ca943bd56c51fa431e13#30e4b53f373940ea26c7ca943bd56c51fa431e13"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -603,9 +603,9 @@ dependencies = [
  "clap",
  "regex",
  "serde",
- "serde_json 1.0.149",
+ "serde_json 1.0.151",
  "sha2",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "tokio",
  "tracing",
  "uuid",
@@ -1871,12 +1871,6 @@ name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
-
-[[package]]
-name = "leb128fmt"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "libc"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -474,6 +474,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "braintrust-sdk-rust"
+version = "0.1.0-alpha.2"
+source = "git+https://github.com/braintrustdata/braintrust-sdk-rust?rev=d33e806bf6ab9548d37355f6a5098a971ef150aa#d33e806bf6ab9548d37355f6a5098a971ef150aa"
+dependencies = [
+ "anyhow",
+ "arc-swap",
+ "async-trait",
+ "backoff",
+ "base64 0.22.1",
+ "bon",
+ "bytes",
+ "chrono",
+ "crossbeam",
+ "futures",
+ "indexmap 2.13.0",
+ "regex",
+ "reqwest",
+ "serde",
+ "serde_json 1.0.149",
+ "serde_repr",
+ "thiserror 1.0.69",
+ "tokio",
+ "tracing",
+ "url",
+ "uuid",
+]
+
+[[package]]
 name = "brotli"
 version = "8.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -521,9 +549,11 @@ dependencies = [
  "actix-web",
  "anyhow",
  "assert_cmd",
+ "async-trait",
  "backoff",
  "base64 0.22.1",
- "braintrust-sdk-rust",
+ "braintrust-sdk-rust 0.1.0-alpha.2 (git+https://github.com/braintrustdata/braintrust-sdk-rust?rev=43ba73edbf5220b57090e049feb094b60a92fcd4)",
+ "bt-daemon",
  "chrono",
  "clap",
  "comfy-table",
@@ -554,10 +584,31 @@ dependencies = [
  "tempfile",
  "tokio",
  "toml",
+ "tracing-subscriber",
  "unicode-width 0.1.14",
  "urlencoding",
  "uuid",
  "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "bt-daemon"
+version = "0.1.0"
+source = "git+https://github.com/braintrustdata/braintrust-coding-agent-plugins?rev=96f452780b4c3b1aea2325853817721e777d3c48#96f452780b4c3b1aea2325853817721e777d3c48"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "braintrust-sdk-rust 0.1.0-alpha.2 (git+https://github.com/braintrustdata/braintrust-sdk-rust?rev=d33e806bf6ab9548d37355f6a5098a971ef150aa)",
+ "chrono",
+ "clap",
+ "regex",
+ "serde",
+ "serde_json 1.0.149",
+ "sha2",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+ "uuid",
 ]
 
 [[package]]
@@ -1816,6 +1867,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4345964bb142484797b161f473a503a434de77149dd8c7427788c6e13379388"
 
 [[package]]
+name = "lazy_static"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+
+[[package]]
+name = "leb128fmt"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
+
+[[package]]
 name = "libc"
 version = "0.2.189"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1932,6 +1995,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
+name = "matchers"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1525a2a28c7f4fa0fc98bb91ae755d1e2d1505079e05539e35bc876b5d65ae9"
+dependencies = [
+ "regex-automata",
+]
+
+[[package]]
 name = "memchr"
 version = "2.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1986,6 +2058,15 @@ name = "normalize-line-endings"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61807f77802ff30975e01f4f071c8ba10c022052f98b3294119f3e615d13e5be"
+
+[[package]]
+name = "nu-ansi-term"
+version = "0.50.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
+dependencies = [
+ "windows-sys 0.61.2",
+]
 
 [[package]]
 name = "num-conv"
@@ -2912,6 +2993,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha1_smol"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbfa15b3dddfee50a0fff136974b3e1bde555604ba463834a7eb7deb6417705d"
+
+[[package]]
 name = "sha2"
 version = "0.10.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2920,6 +3007,15 @@ dependencies = [
  "cfg-if",
  "cpufeatures 0.2.17",
  "digest 0.10.7",
+]
+
+[[package]]
+name = "sharded-slab"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
+dependencies = [
+ "lazy_static",
 ]
 
 [[package]]
@@ -3405,6 +3501,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
 dependencies = [
  "once_cell",
+ "valuable",
+]
+
+[[package]]
+name = "tracing-log"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
+dependencies = [
+ "log",
+ "once_cell",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.3.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb7f578e5945fb242538965c2d0b04418d38ec25c79d160cd279bf0731c8d319"
+dependencies = [
+ "matchers",
+ "nu-ansi-term",
+ "once_cell",
+ "regex-automata",
+ "sharded-slab",
+ "smallvec",
+ "thread_local",
+ "tracing",
+ "tracing-core",
+ "tracing-log",
 ]
 
 [[package]]
@@ -3540,8 +3666,15 @@ dependencies = [
  "getrandom 0.4.3",
  "js-sys",
  "serde_core",
+ "sha1_smol",
  "wasm-bindgen",
 ]
+
+[[package]]
+name = "valuable"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
 name = "version_check"
@@ -3710,7 +3843,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,8 @@ actix-web = "4.11.0"
 anyhow = "1.0.89"
 backoff = { version = "0.4.0", features = ["tokio"] }
 braintrust-sdk-rust = { git = "https://github.com/braintrustdata/braintrust-sdk-rust", rev = "43ba73edbf5220b57090e049feb094b60a92fcd4" }
+bt-daemon = { git = "https://github.com/braintrustdata/braintrust-coding-agent-plugins", rev = "96f452780b4c3b1aea2325853817721e777d3c48" }
+async-trait = "0.1"
 clap = { version = "4.5.20", features = ["derive", "env"] }
 crossterm = "0.28.1"
 futures-util = "0.3.31"
@@ -32,6 +34,7 @@ toml = "0.8"
 sha2 = "0.10.8"
 strip-ansi-escapes = "0.2.0"
 tokio = { version = "1.40.0", features = ["rt-multi-thread", "macros", "process", "net", "signal", "sync"] }
+tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 unicode-width = "0.1.13"
 dialoguer = { version = "0.11", features = ["fuzzy-select"] }
 fuzzy-matcher = "0.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ actix-web = "4.11.0"
 anyhow = "1.0.89"
 backoff = { version = "0.4.0", features = ["tokio"] }
 braintrust-sdk-rust = { git = "https://github.com/braintrustdata/braintrust-sdk-rust", rev = "43ba73edbf5220b57090e049feb094b60a92fcd4" }
-bt-daemon = { git = "https://github.com/braintrustdata/braintrust-coding-agent-plugins", rev = "96f452780b4c3b1aea2325853817721e777d3c48" }
+bt-daemon = { git = "https://github.com/braintrustdata/braintrust-coding-agent-plugins", rev = "30e4b53f373940ea26c7ca943bd56c51fa431e13" }
 async-trait = "0.1"
 clap = { version = "4.5.20", features = ["derive", "env"] }
 crossterm = "0.28.1"

--- a/src/agents.rs
+++ b/src/agents.rs
@@ -20,7 +20,8 @@ use bt_daemon::wire::{
 use bt_daemon::{
     braintrust_serve_options, paths, run_hook, run_import, run_serve, run_status, run_traced,
     shutdown_daemon, AuthLease, AuthProvider, AuthResolveReason, BraintrustSinkConfig, HookArgs,
-    HostInfo, ImportArgs, Registry, RunArgs, RunHookCommand, ServeArgs, ServeOptions, StatusArgs,
+    HostInfo, ImportArgs, OutputFormat, Registry, RunArgs, RunHookCommand, ServeArgs, ServeOptions,
+    StatusArgs, TraceCommandOutput,
 };
 
 use crate::args::BaseArgs;
@@ -75,6 +76,11 @@ enum SetupAgent {
     Codex,
     /// Install the published Claude Code tracing plugin.
     Claude,
+    /// Configure the published OpenCode tracing plugin.
+    #[command(name = "opencode", alias = "open-code")]
+    OpenCode,
+    /// Install the published Pi tracing extension.
+    Pi,
 }
 
 const CODEX_MARKETPLACE: &str = "braintrust-codex-plugins";
@@ -83,6 +89,8 @@ const CODEX_PLUGIN: &str = "trace-codex@braintrust-codex-plugins";
 const CLAUDE_MARKETPLACE: &str = "braintrust-claude-plugin";
 const CLAUDE_MARKETPLACE_SOURCE: &str = "braintrustdata/braintrust-claude-plugin";
 const CLAUDE_PLUGIN: &str = "trace-claude-code@braintrust-claude-plugin";
+const OPENCODE_PLUGIN: &str = "@braintrust/trace-opencode@^1";
+const PI_PLUGIN: &str = "npm:@braintrust/pi-extension@^1";
 
 /// How the shim (re)launches the daemon: `bt trace daemon` from this same
 /// binary.
@@ -342,29 +350,68 @@ fn setup_claude() -> anyhow::Result<()> {
     Ok(())
 }
 
+fn opencode_config_path() -> PathBuf {
+    let config_home = std::env::var_os("XDG_CONFIG_HOME")
+        .filter(|path| !path.is_empty())
+        .map(PathBuf::from)
+        .or_else(|| dirs::home_dir().map(|home| home.join(".config")))
+        .unwrap_or_else(|| PathBuf::from(".config"));
+    config_home.join("opencode").join("opencode.json")
+}
+
+fn setup_opencode() -> anyhow::Result<()> {
+    let path = opencode_config_path();
+    let mut config = load_settings(&path)?;
+    let plugins = config
+        .entry("plugin")
+        .or_insert_with(|| Value::Array(Vec::new()))
+        .as_array_mut()
+        .ok_or_else(|| {
+            anyhow::anyhow!(
+                "OpenCode `plugin` config must be an array: {}",
+                path.display()
+            )
+        })?;
+    plugins.retain(|plugin| {
+        plugin.as_str().is_none_or(|plugin| {
+            plugin != "@braintrust/trace-opencode"
+                && !plugin.starts_with("@braintrust/trace-opencode@")
+        })
+    });
+    plugins.push(Value::String(OPENCODE_PLUGIN.into()));
+
+    let mut encoded = serde_json::to_string_pretty(&Value::Object(config))?;
+    encoded.push('\n');
+    crate::utils::write_text_atomic(&path, &encoded)?;
+    Ok(())
+}
+
+fn setup_pi() -> anyhow::Result<()> {
+    run_command("pi", &["install", PI_PLUGIN])
+}
+
 fn load_settings(path: &Path) -> anyhow::Result<Map<String, Value>> {
     match std::fs::read(path) {
         Ok(raw) => {
             let value: Value = serde_json::from_slice(&raw)
-                .with_context(|| format!("invalid shared agent settings: {}", path.display()))?;
+                .with_context(|| format!("invalid JSON configuration: {}", path.display()))?;
             value.as_object().cloned().ok_or_else(|| {
-                anyhow::anyhow!(
-                    "shared agent settings must be a JSON object: {}",
-                    path.display()
-                )
+                anyhow::anyhow!("configuration must be a JSON object: {}", path.display())
             })
         }
         Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(Map::new()),
-        Err(error) => Err(error)
-            .with_context(|| format!("failed to read shared agent settings: {}", path.display())),
+        Err(error) => {
+            Err(error).with_context(|| format!("failed to read configuration: {}", path.display()))
+        }
     }
 }
 
-fn enable_tracing(route: SessionRoute) -> anyhow::Result<PathBuf> {
-    let path = paths::settings_path(None);
+fn enable_tracing(source: &str, route: SessionRoute) -> anyhow::Result<PathBuf> {
+    let path = paths::agent_settings_path(source, None);
     let mut settings = load_settings(&path)?;
-    settings.insert("traceToBraintrust".into(), Value::Bool(true));
+    settings.insert("trace_to_braintrust".into(), Value::Bool(true));
     settings.insert("route".into(), serde_json::to_value(route)?);
+    settings.remove("traceToBraintrust");
     settings.remove("project");
 
     let mut encoded = serde_json::to_string_pretty(&Value::Object(settings))?;
@@ -375,28 +422,37 @@ fn enable_tracing(route: SessionRoute) -> anyhow::Result<PathBuf> {
     {
         use std::os::unix::fs::PermissionsExt;
         std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o600))
-            .with_context(|| format!("failed to protect shared settings: {}", path.display()))?;
+            .with_context(|| format!("failed to protect agent settings: {}", path.display()))?;
     }
     Ok(path)
 }
 
-async fn run_setup(base: BaseArgs, args: SetupArgs) -> anyhow::Result<()> {
+async fn run_setup(base: BaseArgs, args: SetupArgs, format: OutputFormat) -> anyhow::Result<()> {
     let base = resolve_trace_project(base).await?;
 
-    match args.agent {
-        SetupAgent::Codex => setup_codex()?,
-        SetupAgent::Claude => setup_claude()?,
-    }
-    let settings_path = enable_tracing(session_route(&base))?;
+    let (source, label) = match args.agent {
+        SetupAgent::Codex => {
+            setup_codex()?;
+            ("codex", "Codex")
+        }
+        SetupAgent::Claude => {
+            setup_claude()?;
+            ("claude", "Claude Code")
+        }
+        SetupAgent::OpenCode => {
+            setup_opencode()?;
+            ("opencode", "OpenCode")
+        }
+        SetupAgent::Pi => {
+            setup_pi()?;
+            ("pi", "Pi")
+        }
+    };
+    let settings_path = enable_tracing(source, session_route(&base))?;
     println!(
-        "The Braintrust tracing plugin is installed for {} and configured in {}.",
-        match args.agent {
-            SetupAgent::Codex => "Codex",
-            SetupAgent::Claude => "Claude Code",
-        },
-        settings_path.display()
+        "{}",
+        TraceCommandOutput::setup(source, label, settings_path).render(format)?
     );
-    println!("Restart the coding agent to load the tracing plugin.");
     Ok(())
 }
 
@@ -420,8 +476,9 @@ async fn session_config(base: &BaseArgs) -> anyhow::Result<SessionConfig> {
 }
 
 pub async fn run(base: BaseArgs, args: TraceArgs) -> anyhow::Result<()> {
+    let format = OutputFormat::from(base.login.json);
     match args.command {
-        TraceCommand::Setup(setup_args) => run_setup(base, setup_args).await,
+        TraceCommand::Setup(setup_args) => run_setup(base, setup_args, format).await,
         TraceCommand::Daemon(serve_args) => {
             init_daemon_logging(base.verbose);
             run_serve(serve_args, serve_options(base)).await
@@ -434,16 +491,11 @@ pub async fn run(base: BaseArgs, args: TraceArgs) -> anyhow::Result<()> {
             }
             Ok(())
         }
-        TraceCommand::Status(status_args) => match run_status(status_args).await? {
-            Some(status) => {
-                println!("{}", serde_json::to_string_pretty(&status)?);
-                Ok(())
-            }
-            None => {
-                println!("bt-daemon is not running");
-                Ok(())
-            }
-        },
+        TraceCommand::Status(status_args) => {
+            let output = TraceCommandOutput::status(run_status(status_args).await?);
+            println!("{}", output.render(format)?);
+            Ok(())
+        }
         TraceCommand::Stop(stop_args) => {
             let socket = paths::socket_path(stop_args.socket.as_deref());
             let status_args = StatusArgs {
@@ -451,11 +503,11 @@ pub async fn run(base: BaseArgs, args: TraceArgs) -> anyhow::Result<()> {
                 session_id: None,
             };
             if run_status(status_args).await?.is_none() {
-                println!("No tracing daemon is running.");
+                println!("{}", TraceCommandOutput::stop(false, false).render(format)?);
                 return Ok(());
             }
             shutdown_daemon(&socket).await?;
-            println!("Tracing daemon stopped.");
+            println!("{}", TraceCommandOutput::stop(true, true).render(format)?);
             Ok(())
         }
         TraceCommand::Import(import_args) => {

--- a/src/agents.rs
+++ b/src/agents.rs
@@ -1,0 +1,487 @@
+//! `bt trace` — manages coding-agent tracing integrations.
+//!
+//! Hooks forward only profile, organization, and destination selection. The
+//! long-lived daemon host resolves those selections through `bt`'s auth store,
+//! including OAuth refresh and keychain access.
+
+use std::ffi::OsString;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+use std::sync::Arc;
+
+use anyhow::{bail, Context};
+use async_trait::async_trait;
+use clap::{Args, Subcommand};
+use serde_json::{Map, Value};
+
+use bt_daemon::wire::{
+    AuthSelection, BackendAuth, FlushMode, SessionConfig, SessionRoute, TraceDestination,
+};
+use bt_daemon::{
+    braintrust_serve_options, paths, run_hook, run_import, run_serve, run_status, run_traced,
+    shutdown_daemon, AuthLease, AuthProvider, AuthResolveReason, BraintrustSinkConfig, HookArgs,
+    HostInfo, ImportArgs, Registry, RunArgs, RunHookCommand, ServeArgs, ServeOptions, StatusArgs,
+};
+
+use crate::args::BaseArgs;
+
+#[derive(Debug, Clone, Args)]
+pub struct TraceArgs {
+    #[command(subcommand)]
+    command: TraceCommand,
+}
+
+#[derive(Debug, Clone, Subcommand)]
+// Clap argument structs are parsed once; keeping their natural shapes is
+// clearer than boxing individual command variants for stack-size savings.
+#[allow(clippy::large_enum_variant)]
+enum TraceCommand {
+    /// Install the published Braintrust tracing plugin for a coding agent.
+    Setup(SetupArgs),
+    /// Run the tracing daemon (foreground).
+    #[command(hide = true)]
+    Daemon(ServeArgs),
+    /// Forward one coding-agent hook event (read from stdin) to the daemon.
+    #[command(hide = true)]
+    Hook(HookArgs),
+    /// Print daemon/session status.
+    #[command(hide = true)]
+    Status(StatusArgs),
+    /// Gracefully stop the tracing daemon.
+    #[command(hide = true)]
+    Stop(StopArgs),
+    /// Import a past Codex or Claude Code session by its resume id.
+    Import(ImportArgs),
+    /// Launch a coding agent with tracing enabled for this invocation.
+    Run(RunArgs),
+}
+
+#[derive(Debug, Clone, Args)]
+struct StopArgs {
+    /// Socket path override (default: see the daemon protocol documentation).
+    #[arg(long)]
+    socket: Option<PathBuf>,
+}
+
+#[derive(Debug, Clone, Args)]
+struct SetupArgs {
+    #[command(subcommand)]
+    agent: SetupAgent,
+}
+
+#[derive(Debug, Clone, Copy, Subcommand)]
+enum SetupAgent {
+    /// Install the published Codex tracing plugin.
+    Codex,
+    /// Install the published Claude Code tracing plugin.
+    Claude,
+}
+
+const CODEX_MARKETPLACE: &str = "braintrust-codex-plugins";
+const CODEX_MARKETPLACE_SOURCE: &str = "braintrustdata/braintrust-codex-plugin";
+const CODEX_PLUGIN: &str = "trace-codex@braintrust-codex-plugins";
+const CLAUDE_MARKETPLACE: &str = "braintrust-claude-plugin";
+const CLAUDE_MARKETPLACE_SOURCE: &str = "braintrustdata/braintrust-claude-plugin";
+const CLAUDE_PLUGIN: &str = "trace-claude-code@braintrust-claude-plugin";
+
+/// How the shim (re)launches the daemon: `bt trace daemon` from this same
+/// binary.
+fn host_info() -> HostInfo {
+    let exe = std::env::current_exe()
+        .map(OsString::from)
+        .unwrap_or_else(|_| OsString::from("bt"));
+    HostInfo {
+        serve_argv: vec![exe, OsString::from("trace"), OsString::from("daemon")],
+        version: crate::CLI_VERSION.to_string(),
+    }
+}
+
+/// Production serve options: real agent translators, the Braintrust sink, and
+/// `bt`'s profile-aware auth resolver.
+fn serve_options(base: BaseArgs) -> ServeOptions {
+    let cfg = BraintrustSinkConfig {
+        api_url: None,
+        app_url: None,
+        version: crate::CLI_VERSION.to_string(),
+    };
+    let mut options = braintrust_serve_options(
+        crate::CLI_VERSION,
+        cfg,
+        Arc::new(Registry::default_agents()),
+    );
+    options.auth_provider = Some(Arc::new(BtAuthProvider { base }));
+    options
+}
+
+#[derive(Clone)]
+struct BtAuthProvider {
+    base: BaseArgs,
+}
+
+#[async_trait]
+impl AuthProvider for BtAuthProvider {
+    async fn resolve(
+        &self,
+        selection: &AuthSelection,
+        _reason: AuthResolveReason,
+    ) -> anyhow::Result<AuthLease> {
+        let mut base = self.base.clone();
+        base.no_input = true;
+        if let Some(profile) = &selection.profile {
+            base.profile = Some(profile.clone());
+            base.profile_explicit = true;
+            base.prefer_profile = true;
+        }
+        if let Some(org_name) = &selection.org_name {
+            base.org_name = Some(org_name.clone());
+        }
+        let resolved = crate::auth::resolve_auth(&base)
+            .await
+            .map_err(|error| anyhow::anyhow!("resolve auth: {error}"))?;
+        let token = resolved
+            .api_key
+            .ok_or_else(|| anyhow::anyhow!("selected Braintrust profile has no credential"))?;
+        let profile = resolved
+            .profile
+            .or_else(|| selection.profile.clone())
+            .unwrap_or_else(|| "environment".into());
+        let expires_at_ms = resolved.is_oauth.then(|| {
+            chrono::Utc::now()
+                .timestamp_millis()
+                .saturating_add(5 * 60 * 1000)
+        });
+        Ok(AuthLease {
+            profile,
+            auth: BackendAuth {
+                token,
+                api_url: resolved.api_url,
+                app_url: resolved.app_url,
+                org_name: resolved.org_name,
+                org_id: None,
+            },
+            expires_at_ms,
+        })
+    }
+}
+
+fn session_route(base: &BaseArgs) -> SessionRoute {
+    SessionRoute {
+        auth: AuthSelection {
+            profile: base.profile.clone(),
+            org_name: base.org_name.clone(),
+        },
+        destination: base
+            .project
+            .clone()
+            .map(|project_name| TraceDestination::ProjectLogs {
+                project_id: None,
+                project_name: Some(project_name),
+            }),
+        flush_mode: FlushMode::FireAndForget,
+        additional_metadata: None,
+    }
+}
+
+async fn resolve_trace_project(mut base: BaseArgs) -> anyhow::Result<BaseArgs> {
+    if base
+        .project
+        .as_deref()
+        .is_some_and(|project| !project.trim().is_empty())
+    {
+        return Ok(base);
+    }
+
+    if let Some(project) =
+        crate::config::configured_project_for_context(&base, base.org_name.as_deref())
+    {
+        base.project = Some(project);
+        return Ok(base);
+    }
+
+    if !crate::ui::is_interactive() {
+        bail!(
+            "project choice required in non-interactive mode; pass --project <NAME> or set BRAINTRUST_DEFAULT_PROJECT"
+        );
+    }
+
+    let auth = crate::auth::resolve_auth(&base)
+        .await
+        .map_err(|error| anyhow::anyhow!("resolve auth: {error}"))?;
+    if let Some(profile) = auth.profile.clone() {
+        base.profile = Some(profile);
+        base.profile_explicit = true;
+        base.prefer_profile = true;
+    }
+    if base.org_name.is_none() {
+        base.org_name = auth.org_name.clone();
+    }
+    if let Some(project) =
+        crate::config::configured_project_for_context(&base, auth.org_name.as_deref())
+    {
+        base.project = Some(project);
+        return Ok(base);
+    }
+
+    let login = crate::auth::login_read_only(&base).await?;
+    let client = crate::http::ApiClient::new(&login)?;
+    let project = crate::ui::select_project(
+        &client,
+        None,
+        Some("Select a project for coding-agent traces"),
+        crate::ui::ProjectSelectMode::ExistingOnly,
+    )
+    .await?;
+    base.project = Some(project.name);
+    Ok(base)
+}
+
+fn init_daemon_logging(verbose: bool) {
+    let fallback = if verbose { "debug" } else { "info" };
+    let filter = tracing_subscriber::EnvFilter::new(fallback);
+    if let Err(error) = tracing_subscriber::fmt()
+        .with_env_filter(filter)
+        .with_writer(std::io::stderr)
+        .try_init()
+    {
+        eprintln!("bt trace daemon logging unavailable: {error}");
+    }
+}
+
+fn command_json(program: &str, args: &[&str]) -> anyhow::Result<Value> {
+    let output = Command::new(program).args(args).output().with_context(|| {
+        format!("failed to run `{program}`; install {program} and ensure it is on PATH")
+    })?;
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        bail!("`{program} {}` failed: {}", args.join(" "), stderr.trim());
+    }
+    serde_json::from_slice(&output.stdout)
+        .with_context(|| format!("`{program} {}` returned invalid JSON", args.join(" ")))
+}
+
+fn run_command(program: &str, args: &[&str]) -> anyhow::Result<()> {
+    let status = Command::new(program).args(args).status().with_context(|| {
+        format!("failed to run `{program}`; install {program} and ensure it is on PATH")
+    })?;
+    if !status.success() {
+        bail!("`{program} {}` failed with {status}", args.join(" "));
+    }
+    Ok(())
+}
+
+fn codex_marketplace_installed(value: &Value) -> bool {
+    value
+        .get("marketplaces")
+        .and_then(Value::as_array)
+        .is_some_and(|items| {
+            items
+                .iter()
+                .any(|item| item.get("name").and_then(Value::as_str) == Some(CODEX_MARKETPLACE))
+        })
+}
+
+fn codex_plugin_installed(value: &Value) -> bool {
+    value
+        .get("installed")
+        .and_then(Value::as_array)
+        .is_some_and(|items| {
+            items
+                .iter()
+                .any(|item| item.get("pluginId").and_then(Value::as_str) == Some(CODEX_PLUGIN))
+        })
+}
+
+fn claude_marketplace_installed(value: &Value) -> bool {
+    value.as_array().is_some_and(|items| {
+        items
+            .iter()
+            .any(|item| item.get("name").and_then(Value::as_str) == Some(CLAUDE_MARKETPLACE))
+    })
+}
+
+fn claude_plugin(value: &Value) -> Option<&Value> {
+    value
+        .as_array()?
+        .iter()
+        .find(|item| item.get("id").and_then(Value::as_str) == Some(CLAUDE_PLUGIN))
+}
+
+fn setup_codex() -> anyhow::Result<()> {
+    let marketplaces = command_json("codex", &["plugin", "marketplace", "list", "--json"])?;
+    if !codex_marketplace_installed(&marketplaces) {
+        run_command(
+            "codex",
+            &["plugin", "marketplace", "add", CODEX_MARKETPLACE_SOURCE],
+        )?;
+    }
+
+    let plugins = command_json("codex", &["plugin", "list", "--json"])?;
+    if !codex_plugin_installed(&plugins) {
+        run_command("codex", &["plugin", "add", CODEX_PLUGIN])?;
+    }
+    Ok(())
+}
+
+fn setup_claude() -> anyhow::Result<()> {
+    let marketplaces = command_json("claude", &["plugin", "marketplace", "list", "--json"])?;
+    if !claude_marketplace_installed(&marketplaces) {
+        run_command(
+            "claude",
+            &["plugin", "marketplace", "add", CLAUDE_MARKETPLACE_SOURCE],
+        )?;
+    }
+
+    let plugins = command_json("claude", &["plugin", "list", "--json"])?;
+    match claude_plugin(&plugins) {
+        None => run_command("claude", &["plugin", "install", CLAUDE_PLUGIN])?,
+        Some(plugin) if plugin.get("enabled").and_then(Value::as_bool) == Some(false) => {
+            run_command("claude", &["plugin", "enable", CLAUDE_PLUGIN])?;
+        }
+        Some(_) => {}
+    }
+    Ok(())
+}
+
+fn load_settings(path: &Path) -> anyhow::Result<Map<String, Value>> {
+    match std::fs::read(path) {
+        Ok(raw) => {
+            let value: Value = serde_json::from_slice(&raw)
+                .with_context(|| format!("invalid shared agent settings: {}", path.display()))?;
+            value.as_object().cloned().ok_or_else(|| {
+                anyhow::anyhow!(
+                    "shared agent settings must be a JSON object: {}",
+                    path.display()
+                )
+            })
+        }
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(Map::new()),
+        Err(error) => Err(error)
+            .with_context(|| format!("failed to read shared agent settings: {}", path.display())),
+    }
+}
+
+fn enable_tracing(route: SessionRoute) -> anyhow::Result<PathBuf> {
+    let path = paths::settings_path(None);
+    let mut settings = load_settings(&path)?;
+    settings.insert("traceToBraintrust".into(), Value::Bool(true));
+    settings.insert("route".into(), serde_json::to_value(route)?);
+    settings.remove("project");
+
+    let mut encoded = serde_json::to_string_pretty(&Value::Object(settings))?;
+    encoded.push('\n');
+    crate::utils::write_text_atomic(&path, &encoded)?;
+
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o600))
+            .with_context(|| format!("failed to protect shared settings: {}", path.display()))?;
+    }
+    Ok(path)
+}
+
+async fn run_setup(base: BaseArgs, args: SetupArgs) -> anyhow::Result<()> {
+    let base = resolve_trace_project(base).await?;
+
+    match args.agent {
+        SetupAgent::Codex => setup_codex()?,
+        SetupAgent::Claude => setup_claude()?,
+    }
+    let settings_path = enable_tracing(session_route(&base))?;
+    println!(
+        "The Braintrust tracing plugin is installed for {} and configured in {}.",
+        match args.agent {
+            SetupAgent::Codex => "Codex",
+            SetupAgent::Claude => "Claude Code",
+        },
+        settings_path.display()
+    );
+    println!("Restart the coding agent to load the tracing plugin.");
+    Ok(())
+}
+
+/// Resolve `bt`'s auth for one-shot imports.
+async fn session_config(base: &BaseArgs) -> anyhow::Result<SessionConfig> {
+    let auth = crate::auth::resolve_auth(base)
+        .await
+        .map_err(|e| anyhow::anyhow!("resolve auth: {e}"))?;
+    Ok(SessionConfig {
+        auth: BackendAuth {
+            token: auth.api_key.unwrap_or_default(),
+            api_url: auth.api_url,
+            app_url: auth.app_url,
+            org_name: auth.org_name,
+            org_id: None,
+        },
+        destination: session_route(base).destination,
+        flush_mode: FlushMode::FireAndForget,
+        additional_metadata: None,
+    })
+}
+
+pub async fn run(base: BaseArgs, args: TraceArgs) -> anyhow::Result<()> {
+    match args.command {
+        TraceCommand::Setup(setup_args) => run_setup(base, setup_args).await,
+        TraceCommand::Daemon(serve_args) => {
+            init_daemon_logging(base.verbose);
+            run_serve(serve_args, serve_options(base)).await
+        }
+        TraceCommand::Hook(hook_args) => {
+            // A hook must NEVER fail the agent's turn. It forwards only
+            // non-secret routing selection; the daemon resolves credentials.
+            if let Err(e) = run_hook(hook_args, session_route(&base), host_info()).await {
+                eprintln!("bt trace hook (non-fatal): {e}");
+            }
+            Ok(())
+        }
+        TraceCommand::Status(status_args) => match run_status(status_args).await? {
+            Some(status) => {
+                println!("{}", serde_json::to_string_pretty(&status)?);
+                Ok(())
+            }
+            None => {
+                println!("bt-daemon is not running");
+                Ok(())
+            }
+        },
+        TraceCommand::Stop(stop_args) => {
+            let socket = paths::socket_path(stop_args.socket.as_deref());
+            let status_args = StatusArgs {
+                socket: Some(socket.clone()),
+                session_id: None,
+            };
+            if run_status(status_args).await?.is_none() {
+                println!("No tracing daemon is running.");
+                return Ok(());
+            }
+            shutdown_daemon(&socket).await?;
+            println!("Tracing daemon stopped.");
+            Ok(())
+        }
+        TraceCommand::Import(import_args) => {
+            let base = if import_args.destination.is_none() && import_args.parent.is_none() {
+                resolve_trace_project(base).await?
+            } else {
+                base
+            };
+            let config = session_config(&base).await?;
+            run_import(import_args, serve_options(base), Some(config)).await
+        }
+        TraceCommand::Run(run_args) => {
+            let base = resolve_trace_project(base).await?;
+            let exe = std::env::current_exe()
+                .map(OsString::from)
+                .unwrap_or_else(|_| OsString::from("bt"));
+            let hook_command = RunHookCommand {
+                program: exe,
+                args: vec![OsString::from("trace"), OsString::from("hook")],
+            };
+            let status = run_traced(run_args, hook_command, session_route(&base)).await?;
+            if status.success() {
+                Ok(())
+            } else {
+                bail!("coding agent exited with {status}")
+            }
+        }
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,6 +2,7 @@ use anyhow::{Context, Result};
 use clap::{parser::ValueSource, ArgMatches, CommandFactory, FromArgMatches, Parser, Subcommand};
 use std::ffi::{OsStr, OsString};
 
+mod agents;
 mod args;
 mod auth;
 #[allow(dead_code)]
@@ -80,6 +81,7 @@ Data & evaluation
 
 Additional
   docs         Manage workflow docs for coding agents
+  trace        Manage coding-agent tracing
   setup        Configure Braintrust setup flows
   status       Show current identity, org, and project context
   update       Update bt in-place
@@ -168,6 +170,8 @@ enum Commands {
     Switch(CLIArgs<switch::SwitchArgs>),
     /// Show current identity, org, and project context
     Status(CLIArgs<status::StatusArgs>),
+    /// Manage coding-agent tracing
+    Trace(CLIArgs<agents::TraceArgs>),
     // /// View and modify config
     // Config(CLIArgs<config::ConfigArgs>),
 }
@@ -198,6 +202,7 @@ impl Commands {
             Commands::Util(cmd) => &cmd.base,
             Commands::Switch(cmd) => &cmd.base,
             Commands::Status(cmd) => &cmd.base,
+            Commands::Trace(cmd) => &cmd.base,
         }
     }
 
@@ -226,6 +231,7 @@ impl Commands {
             Commands::Util(cmd) => &mut cmd.base,
             Commands::Switch(cmd) => &mut cmd.base,
             Commands::Status(cmd) => &mut cmd.base,
+            Commands::Trace(cmd) => &mut cmd.base,
         }
     }
 
@@ -343,6 +349,7 @@ fn try_main() -> Result<()> {
             Commands::SelfCommand(cmd) => self_update::run(cmd.base, cmd.args).await?,
             Commands::Switch(cmd) => switch::run(cmd.base, cmd.args).await?,
             Commands::Status(cmd) => status::run(cmd.base, cmd.args).await?,
+            Commands::Trace(cmd) => agents::run(cmd.base, cmd.args).await?,
         }
         Ok(())
     });

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -55,7 +55,7 @@ esac
 fn write_run_agent(path: &Path) {
     fs::write(
         path,
-        "#!/bin/sh\nprintf '%s\\n' \"$*\" > \"$AGENT_RUN_LOG\"\nprintf '%s\\n' \"$BT_TRACE_INVOCATION_SETTINGS\" > \"$AGENT_RUN_SETTINGS\"\n",
+        "#!/bin/sh\nprintf '%s\\n' \"$*\" > \"$AGENT_RUN_LOG\"\nprintf '%s\\n' \"$BT_TRACE_INVOCATION_SETTINGS\" > \"$AGENT_RUN_SETTINGS\"\nif [ -n \"$AGENT_RUN_CONFIG\" ]; then printf '%s\\n' \"$OPENCODE_CONFIG_CONTENT\" > \"$AGENT_RUN_CONFIG\"; fi\n",
     )
     .expect("write fake run agent");
     use std::os::unix::fs::PermissionsExt;
@@ -237,7 +237,9 @@ fn trace_help_exposes_user_commands_and_hides_internal_commands() {
         .assert()
         .success()
         .stdout(predicate::str::contains("codex"))
-        .stdout(predicate::str::contains("claude"));
+        .stdout(predicate::str::contains("claude"))
+        .stdout(predicate::str::contains("opencode"))
+        .stdout(predicate::str::contains("pi"));
 
     bt_command()
         .args(["trace", "run", "--help"])
@@ -245,7 +247,9 @@ fn trace_help_exposes_user_commands_and_hides_internal_commands() {
         .success()
         .stdout(predicate::str::contains("<SOURCE>"))
         .stdout(predicate::str::contains("codex"))
-        .stdout(predicate::str::contains("claude"));
+        .stdout(predicate::str::contains("claude"))
+        .stdout(predicate::str::contains("opencode"))
+        .stdout(predicate::str::contains("pi"));
 }
 
 #[test]
@@ -323,6 +327,106 @@ fn trace_run_uses_the_invocation_project_without_changing_setup() {
 
 #[cfg(unix)]
 #[test]
+fn trace_run_opencode_injects_the_npm_plugin_without_changing_global_config() {
+    let home = tempfile::tempdir().expect("home tempdir");
+    let bin_dir = tempfile::tempdir().expect("bin tempdir");
+    let state_dir = tempfile::tempdir().expect("state tempdir");
+    let run_log = state_dir.path().join("run.log");
+    let run_settings = state_dir.path().join("run-settings.json");
+    let run_config = state_dir.path().join("run-config.json");
+    let global_config = home.path().join(".config/opencode/braintrust.json");
+    fs::create_dir_all(global_config.parent().expect("config parent"))
+        .expect("create config parent");
+    fs::write(&global_config, r#"{"trace_to_braintrust":true}"#).expect("seed global config");
+    write_run_agent(&bin_dir.path().join("opencode"));
+
+    bt_command()
+        .env("HOME", home.path())
+        .env("OPENCODE_BIN", bin_dir.path().join("opencode"))
+        .env("AGENT_RUN_LOG", &run_log)
+        .env("AGENT_RUN_SETTINGS", &run_settings)
+        .env("AGENT_RUN_CONFIG", &run_config)
+        .args([
+            "trace",
+            "run",
+            "opencode",
+            "--project",
+            "isolated-opencode",
+            "--",
+            "--version",
+        ])
+        .assert()
+        .success();
+
+    let inline: serde_json::Value =
+        serde_json::from_slice(&fs::read(run_config).expect("read OpenCode inline config"))
+            .expect("parse OpenCode inline config");
+    assert_eq!(
+        inline["plugin"],
+        serde_json::json!(["@braintrust/trace-opencode@^1"])
+    );
+    let settings: serde_json::Value =
+        serde_json::from_slice(&fs::read(run_settings).expect("read invocation settings"))
+            .expect("parse invocation settings");
+    assert_eq!(
+        settings["route"]["destination"]["project_name"],
+        "isolated-opencode"
+    );
+    assert_eq!(
+        fs::read_to_string(global_config).expect("read global config"),
+        r#"{"trace_to_braintrust":true}"#
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn trace_run_pi_injects_the_npm_extension_for_only_that_process() {
+    let home = tempfile::tempdir().expect("home tempdir");
+    let bin_dir = tempfile::tempdir().expect("bin tempdir");
+    let state_dir = tempfile::tempdir().expect("state tempdir");
+    let run_log = state_dir.path().join("run.log");
+    let run_settings = state_dir.path().join("run-settings.json");
+    let global_config = home.path().join(".pi/agent/braintrust.json");
+    fs::create_dir_all(global_config.parent().expect("config parent"))
+        .expect("create config parent");
+    fs::write(&global_config, r#"{"trace_to_braintrust":true}"#).expect("seed global config");
+    write_run_agent(&bin_dir.path().join("pi"));
+
+    bt_command()
+        .env("HOME", home.path())
+        .env("PI_BIN", bin_dir.path().join("pi"))
+        .env("AGENT_RUN_LOG", &run_log)
+        .env("AGENT_RUN_SETTINGS", &run_settings)
+        .args([
+            "trace",
+            "run",
+            "pi",
+            "--project",
+            "isolated-pi",
+            "--",
+            "--version",
+        ])
+        .assert()
+        .success();
+
+    assert!(fs::read_to_string(run_log)
+        .expect("read Pi arguments")
+        .contains("-e npm:@braintrust/pi-extension@^1 --version"));
+    let settings: serde_json::Value =
+        serde_json::from_slice(&fs::read(run_settings).expect("read invocation settings"))
+            .expect("parse invocation settings");
+    assert_eq!(
+        settings["route"]["destination"]["project_name"],
+        "isolated-pi"
+    );
+    assert_eq!(
+        fs::read_to_string(global_config).expect("read global config"),
+        r#"{"trace_to_braintrust":true}"#
+    );
+}
+
+#[cfg(unix)]
+#[test]
 fn trace_stop_gracefully_stops_an_isolated_daemon() {
     use std::process::Stdio;
     use std::thread;
@@ -392,6 +496,46 @@ fn trace_stop_gracefully_stops_an_isolated_daemon() {
     panic!("tracing daemon did not stop");
 }
 
+#[test]
+fn trace_status_and_stop_honor_global_json_when_daemon_is_absent() {
+    let state = tempfile::tempdir().expect("state tempdir");
+    #[cfg(unix)]
+    let socket = state.path().join("missing.sock");
+    #[cfg(windows)]
+    let socket = std::path::PathBuf::from(format!(
+        r"\\.\pipe\missing-bt-trace-{}",
+        uuid::Uuid::new_v4()
+    ));
+
+    for (command, expected) in [
+        (
+            "status",
+            serde_json::json!({"command":"status","running":false,"sessions":[]}),
+        ),
+        (
+            "stop",
+            serde_json::json!({"command":"stop","running":false,"stopped":false}),
+        ),
+    ] {
+        let stdout = bt_command()
+            .args([
+                "trace",
+                command,
+                "--json",
+                "--socket",
+                socket.to_str().expect("UTF-8 socket path"),
+            ])
+            .assert()
+            .success()
+            .get_output()
+            .stdout
+            .clone();
+        let output: serde_json::Value =
+            serde_json::from_slice(&stdout).expect("trace command emits JSON");
+        assert_eq!(output, expected);
+    }
+}
+
 #[cfg(unix)]
 #[test]
 fn trace_setup_codex_installs_plugin_and_preserves_existing_settings() {
@@ -445,7 +589,8 @@ fn trace_setup_codex_installs_plugin_and_preserves_existing_settings() {
 
     let settings: serde_json::Value =
         serde_json::from_slice(&fs::read(config).expect("read config")).expect("parse config");
-    assert_eq!(settings["traceToBraintrust"], true);
+    assert_eq!(settings["trace_to_braintrust"], true);
+    assert!(settings.get("traceToBraintrust").is_none());
     assert_eq!(
         settings["route"]["destination"]["project_name"],
         "agent-traces"
@@ -487,7 +632,7 @@ fn trace_setup_claude_installs_plugin_and_writes_selected_project() {
 
     let settings: serde_json::Value =
         serde_json::from_slice(&fs::read(config).expect("read config")).expect("parse config");
-    assert_eq!(settings["traceToBraintrust"], true);
+    assert_eq!(settings["trace_to_braintrust"], true);
     assert_eq!(
         settings["route"]["destination"]["project_name"],
         "coding-agents"
@@ -519,6 +664,181 @@ fn trace_setup_claude_enables_an_existing_disabled_plugin() {
     assert!(calls.contains("plugin enable trace-claude-code@braintrust-claude-plugin"));
     assert!(!calls.contains("plugin marketplace add"));
     assert!(!calls.contains("plugin install"));
+}
+
+#[test]
+fn trace_setup_opencode_configures_the_npm_plugin_and_selected_route() {
+    let home = tempfile::tempdir().expect("home tempdir");
+    let config_home = tempfile::tempdir().expect("config tempdir");
+    let opencode_dir = config_home.path().join("opencode");
+    fs::create_dir_all(&opencode_dir).expect("create OpenCode config dir");
+    fs::write(
+        opencode_dir.join("opencode.json"),
+        r#"{"plugin":["other-plugin","@braintrust/trace-opencode@0.9.0"],"model":"test/model"}"#,
+    )
+    .expect("seed OpenCode config");
+
+    bt_command()
+        .env("HOME", home.path())
+        .env("XDG_CONFIG_HOME", config_home.path())
+        .args([
+            "trace",
+            "setup",
+            "open-code",
+            "--profile",
+            "work",
+            "--org",
+            "acme",
+            "--project",
+            "agent-traces",
+        ])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("installed for OpenCode"));
+
+    let opencode: serde_json::Value = serde_json::from_slice(
+        &fs::read(opencode_dir.join("opencode.json")).expect("read OpenCode config"),
+    )
+    .expect("parse OpenCode config");
+    assert_eq!(opencode["model"], "test/model");
+    assert_eq!(
+        opencode["plugin"],
+        serde_json::json!(["other-plugin", "@braintrust/trace-opencode@^1"])
+    );
+
+    let settings: serde_json::Value = serde_json::from_slice(
+        &fs::read(opencode_dir.join("braintrust.json")).expect("read OpenCode settings"),
+    )
+    .expect("parse OpenCode settings");
+    assert_eq!(settings["trace_to_braintrust"], true);
+    assert_eq!(settings["route"]["auth"]["profile"], "work");
+    assert_eq!(settings["route"]["auth"]["org_name"], "acme");
+    assert_eq!(
+        settings["route"]["destination"]["project_name"],
+        "agent-traces"
+    );
+}
+
+#[test]
+fn trace_setup_honors_global_json() {
+    let home = tempfile::tempdir().expect("home tempdir");
+    let config_home = tempfile::tempdir().expect("config tempdir");
+    let stdout = bt_command()
+        .env("HOME", home.path())
+        .env("XDG_CONFIG_HOME", config_home.path())
+        .args([
+            "trace",
+            "setup",
+            "opencode",
+            "--project",
+            "agent-traces",
+            "--json",
+        ])
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+    let output: serde_json::Value =
+        serde_json::from_slice(&stdout).expect("trace setup emits JSON");
+    assert_eq!(output["command"], "setup");
+    assert_eq!(output["source"], "opencode");
+    assert_eq!(output["display_name"], "OpenCode");
+    assert_eq!(output["restart_required"], true);
+    assert_eq!(
+        output["settings_path"],
+        config_home
+            .path()
+            .join("opencode/braintrust.json")
+            .to_string_lossy()
+            .as_ref()
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn trace_setup_pi_installs_the_npm_extension_and_selected_route() {
+    let home = tempfile::tempdir().expect("home tempdir");
+    let bin_dir = tempfile::tempdir().expect("bin tempdir");
+    let state_dir = tempfile::tempdir().expect("state tempdir");
+    let log = state_dir.path().join("pi.log");
+    write_agent_cli(&bin_dir.path().join("pi"), "{}", "{}");
+
+    bt_command()
+        .env("HOME", home.path())
+        .env("PATH", bin_dir.path())
+        .env("AGENT_SETUP_LOG", &log)
+        .args(["trace", "setup", "pi", "--project", "pi-traces"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("installed for Pi"));
+
+    assert_eq!(
+        fs::read_to_string(log).expect("read Pi calls").trim(),
+        "install npm:@braintrust/pi-extension@^1"
+    );
+    let settings: serde_json::Value = serde_json::from_slice(
+        &fs::read(home.path().join(".pi/agent/braintrust.json")).expect("read Pi settings"),
+    )
+    .expect("parse Pi settings");
+    assert_eq!(settings["trace_to_braintrust"], true);
+    assert_eq!(
+        settings["route"]["destination"]["project_name"],
+        "pi-traces"
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn trace_setup_keeps_each_agents_persistent_selection_independent() {
+    let home = tempfile::tempdir().expect("home tempdir");
+    let config_home = tempfile::tempdir().expect("config tempdir");
+    let bin_dir = tempfile::tempdir().expect("bin tempdir");
+    let log = tempfile::NamedTempFile::new().expect("setup log");
+    write_agent_cli(
+        &bin_dir.path().join("codex"),
+        r#"{"marketplaces":[]}"#,
+        r#"{"installed":[]}"#,
+    );
+
+    bt_command()
+        .env("HOME", home.path())
+        .env("XDG_CONFIG_HOME", config_home.path())
+        .env("PATH", bin_dir.path())
+        .env("AGENT_SETUP_LOG", log.path())
+        .args(["trace", "setup", "codex", "--project", "codex-project"])
+        .assert()
+        .success();
+    bt_command()
+        .env("HOME", home.path())
+        .env("XDG_CONFIG_HOME", config_home.path())
+        .args([
+            "trace",
+            "setup",
+            "opencode",
+            "--project",
+            "opencode-project",
+        ])
+        .assert()
+        .success();
+
+    let codex: serde_json::Value = serde_json::from_slice(
+        &fs::read(home.path().join(".codex/braintrust.json")).expect("read Codex settings"),
+    )
+    .expect("parse Codex settings");
+    let opencode: serde_json::Value = serde_json::from_slice(
+        &fs::read(config_home.path().join("opencode/braintrust.json"))
+            .expect("read OpenCode settings"),
+    )
+    .expect("parse OpenCode settings");
+    assert_eq!(
+        codex["route"]["destination"]["project_name"],
+        "codex-project"
+    );
+    assert_eq!(
+        opencode["route"]["destination"]["project_name"],
+        "opencode-project"
+    );
 }
 
 #[test]

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -29,6 +29,41 @@ fn write_executable(path: &Path) {
     }
 }
 
+#[cfg(unix)]
+fn write_agent_cli(path: &Path, marketplace_json: &str, plugin_json: &str) {
+    let script = format!(
+        r#"#!/bin/sh
+printf '%s\n' "$*" >> "$AGENT_SETUP_LOG"
+case "$*" in
+  "plugin marketplace list --json")
+    printf '%s\n' '{marketplace_json}'
+    ;;
+  "plugin list --json")
+    printf '%s\n' '{plugin_json}'
+    ;;
+esac
+"#
+    );
+    fs::write(path, script).expect("write fake agent CLI");
+    use std::os::unix::fs::PermissionsExt;
+    let mut perms = fs::metadata(path).expect("metadata").permissions();
+    perms.set_mode(0o755);
+    fs::set_permissions(path, perms).expect("chmod");
+}
+
+#[cfg(unix)]
+fn write_run_agent(path: &Path) {
+    fs::write(
+        path,
+        "#!/bin/sh\nprintf '%s\\n' \"$*\" > \"$AGENT_RUN_LOG\"\nprintf '%s\\n' \"$BT_TRACE_INVOCATION_SETTINGS\" > \"$AGENT_RUN_SETTINGS\"\n",
+    )
+    .expect("write fake run agent");
+    use std::os::unix::fs::PermissionsExt;
+    let mut perms = fs::metadata(path).expect("metadata").permissions();
+    perms.set_mode(0o755);
+    fs::set_permissions(path, perms).expect("chmod");
+}
+
 fn make_git_repo() -> tempfile::TempDir {
     let dir = tempfile::tempdir().expect("tempdir");
     fs::write(dir.path().join(".git"), "gitdir: /tmp/fake").expect("write .git");
@@ -134,6 +169,356 @@ fn status_all_json_includes_profile_urls() {
         .stdout(predicate::str::contains(
             "\"api_url\":\"https://oauth-api.test.example\"",
         ));
+}
+
+#[test]
+fn trace_help_exposes_user_commands_and_hides_internal_commands() {
+    bt_command().args(["daemon", "--help"]).assert().failure();
+    bt_command().args(["agents", "--help"]).assert().failure();
+    bt_command()
+        .args(["trace", "--help"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("setup"))
+        .stdout(predicate::str::contains("\n  import"))
+        .stdout(predicate::str::contains("\n  run"))
+        .stdout(predicate::str::contains("\n  daemon").not())
+        .stdout(predicate::str::contains("serve").not())
+        .stdout(predicate::str::contains("\n  hook").not())
+        .stdout(predicate::str::contains("\n  status").not())
+        .stdout(predicate::str::contains("\n  stop").not())
+        .stdout(predicate::str::contains("\n  replay").not());
+
+    bt_command()
+        .args(["trace", "daemon", "--help"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Run the tracing daemon"))
+        .stdout(predicate::str::contains("--socket"))
+        .stdout(predicate::str::contains("--idle-timeout-secs"));
+
+    bt_command()
+        .args(["trace", "hook", "--help"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("--source"))
+        .stdout(predicate::str::contains("--flush-on-turn-end"))
+        .stdout(predicate::str::contains("--profile"))
+        .stdout(predicate::str::contains("--project"));
+
+    bt_command()
+        .args(["trace", "status", "--help"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("--socket"));
+
+    bt_command()
+        .args(["trace", "stop", "--help"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("--socket"));
+
+    bt_command()
+        .args(["trace", "import", "--help"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("<SOURCE>"))
+        .stdout(predicate::str::contains("<SESSION_ID>"))
+        .stdout(predicate::str::contains("codex"))
+        .stdout(predicate::str::contains("claude"));
+
+    bt_command()
+        .args(["trace", "replay", "--help"])
+        .assert()
+        .failure();
+
+    bt_command()
+        .args(["trace", "setup", "--help"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("codex"))
+        .stdout(predicate::str::contains("claude"));
+
+    bt_command()
+        .args(["trace", "run", "--help"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("<SOURCE>"))
+        .stdout(predicate::str::contains("codex"))
+        .stdout(predicate::str::contains("claude"));
+}
+
+#[test]
+fn trace_commands_require_a_project_non_interactively() {
+    for args in [
+        vec!["trace", "setup", "codex", "--no-input"],
+        vec!["trace", "run", "codex", "--no-input"],
+        vec![
+            "trace",
+            "import",
+            "codex",
+            "00000000-0000-0000-0000-000000000000",
+            "--no-input",
+        ],
+    ] {
+        let home = tempfile::tempdir().expect("home tempdir");
+        let config_home = tempfile::tempdir().expect("config tempdir");
+        let mut cmd = bt_command();
+        clear_braintrust_auth_env(&mut cmd);
+        cmd.env("HOME", home.path())
+            .env("XDG_CONFIG_HOME", config_home.path())
+            .args(args)
+            .assert()
+            .failure()
+            .stderr(predicate::str::contains(
+                "project choice required in non-interactive mode",
+            ))
+            .stderr(predicate::str::contains("--project <NAME>"));
+    }
+}
+
+#[cfg(unix)]
+#[test]
+fn trace_run_uses_the_invocation_project_without_changing_setup() {
+    let home = tempfile::tempdir().expect("home tempdir");
+    let bin_dir = tempfile::tempdir().expect("bin tempdir");
+    let state_dir = tempfile::tempdir().expect("state tempdir");
+    let run_log = state_dir.path().join("run.log");
+    let run_settings = state_dir.path().join("run-settings.json");
+    let setup_settings = state_dir.path().join("setup-settings.json");
+    write_run_agent(&bin_dir.path().join("codex"));
+
+    bt_command()
+        .env("HOME", home.path())
+        .env("PATH", bin_dir.path())
+        .env("AGENT_RUN_LOG", &run_log)
+        .env("AGENT_RUN_SETTINGS", &run_settings)
+        .env("BT_DAEMON_CONFIG", &setup_settings)
+        .args([
+            "trace",
+            "run",
+            "codex",
+            "--project",
+            "invocation-project",
+            "--",
+            "--version",
+        ])
+        .assert()
+        .success();
+
+    let args = fs::read_to_string(run_log).expect("read run args");
+    assert!(args.contains("--version"));
+    let settings: serde_json::Value =
+        serde_json::from_slice(&fs::read(run_settings).expect("read invocation settings"))
+            .expect("parse invocation settings");
+    assert_eq!(
+        settings["route"]["destination"]["project_name"],
+        "invocation-project"
+    );
+    assert!(
+        !setup_settings.exists(),
+        "managed run must not change persistent setup settings"
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn trace_stop_gracefully_stops_an_isolated_daemon() {
+    use std::process::Stdio;
+    use std::thread;
+    use std::time::Duration;
+
+    let state = tempfile::tempdir().expect("state tempdir");
+    let socket = state.path().join("daemon.sock");
+    let bin = env!("CARGO_BIN_EXE_bt");
+    let mut daemon = std::process::Command::new(bin)
+        .args([
+            "trace",
+            "daemon",
+            "--socket",
+            socket.to_str().expect("UTF-8 socket path"),
+            "--data-dir",
+            state.path().to_str().expect("UTF-8 state path"),
+            "--idle-timeout-secs",
+            "0",
+        ])
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .spawn()
+        .expect("spawn tracing daemon");
+
+    for _ in 0..100 {
+        if socket.exists() {
+            break;
+        }
+        thread::sleep(Duration::from_millis(25));
+    }
+    if !socket.exists() {
+        let _ = daemon.kill();
+        panic!("tracing daemon did not create its socket");
+    }
+
+    bt_command()
+        .args([
+            "trace",
+            "stop",
+            "--socket",
+            socket.to_str().expect("UTF-8 socket path"),
+        ])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Tracing daemon stopped."));
+
+    for _ in 0..100 {
+        if let Some(status) = daemon.try_wait().expect("poll tracing daemon") {
+            assert!(status.success(), "tracing daemon exited unsuccessfully");
+
+            bt_command()
+                .args([
+                    "trace",
+                    "stop",
+                    "--socket",
+                    socket.to_str().expect("UTF-8 socket path"),
+                ])
+                .assert()
+                .success()
+                .stdout(predicate::str::contains("No tracing daemon is running."));
+            return;
+        }
+        thread::sleep(Duration::from_millis(25));
+    }
+
+    let _ = daemon.kill();
+    panic!("tracing daemon did not stop");
+}
+
+#[cfg(unix)]
+#[test]
+fn trace_setup_codex_installs_plugin_and_preserves_existing_settings() {
+    let home = tempfile::tempdir().expect("home tempdir");
+    let bin_dir = tempfile::tempdir().expect("bin tempdir");
+    let state_dir = tempfile::tempdir().expect("state tempdir");
+    let log = state_dir.path().join("codex.log");
+    let config = state_dir.path().join("config.json");
+    write_agent_cli(
+        &bin_dir.path().join("codex"),
+        r#"{"marketplaces":[]}"#,
+        r#"{"installed":[]}"#,
+    );
+    fs::write(
+        &config,
+        r#"{
+          "flushOnTurnEnd": true,
+          "additionalMetadata": {"team": "sdk"},
+          "apiKey": "legacy-secret",
+          "apiUrl": "https://legacy.example",
+          "auth": {"type": "legacy"}
+        }"#,
+    )
+    .expect("seed config");
+
+    bt_command()
+        .env("HOME", home.path())
+        .env("PATH", bin_dir.path())
+        .env("AGENT_SETUP_LOG", &log)
+        .env("BT_DAEMON_CONFIG", &config)
+        .args([
+            "trace",
+            "setup",
+            "codex",
+            "--profile",
+            "test-profile",
+            "--org",
+            "test-org",
+            "--project",
+            "agent-traces",
+        ])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains(
+            "The Braintrust tracing plugin is installed for Codex",
+        ));
+
+    let calls = fs::read_to_string(log).expect("read fake CLI calls");
+    assert!(calls.contains("plugin marketplace add braintrustdata/braintrust-codex-plugin"));
+    assert!(calls.contains("plugin add trace-codex@braintrust-codex-plugins"));
+
+    let settings: serde_json::Value =
+        serde_json::from_slice(&fs::read(config).expect("read config")).expect("parse config");
+    assert_eq!(settings["traceToBraintrust"], true);
+    assert_eq!(
+        settings["route"]["destination"]["project_name"],
+        "agent-traces"
+    );
+    assert_eq!(settings["route"]["auth"]["profile"], "test-profile");
+    assert_eq!(settings["route"]["auth"]["org_name"], "test-org");
+    assert_eq!(settings["flushOnTurnEnd"], true);
+    assert_eq!(settings["additionalMetadata"]["team"], "sdk");
+    assert_eq!(settings["apiKey"], "legacy-secret");
+    assert_eq!(settings["apiUrl"], "https://legacy.example");
+    assert_eq!(settings["auth"]["type"], "legacy");
+}
+
+#[cfg(unix)]
+#[test]
+fn trace_setup_claude_installs_plugin_and_writes_selected_project() {
+    let home = tempfile::tempdir().expect("home tempdir");
+    let bin_dir = tempfile::tempdir().expect("bin tempdir");
+    let state_dir = tempfile::tempdir().expect("state tempdir");
+    let log = state_dir.path().join("claude.log");
+    let config = state_dir.path().join("config.json");
+    write_agent_cli(&bin_dir.path().join("claude"), "[]", "[]");
+
+    bt_command()
+        .env("HOME", home.path())
+        .env("PATH", bin_dir.path())
+        .env("AGENT_SETUP_LOG", &log)
+        .env("BT_DAEMON_CONFIG", &config)
+        .args(["trace", "setup", "claude", "--project", "coding-agents"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains(
+            "The Braintrust tracing plugin is installed for Claude Code",
+        ));
+
+    let calls = fs::read_to_string(log).expect("read fake CLI calls");
+    assert!(calls.contains("plugin marketplace add braintrustdata/braintrust-claude-plugin"));
+    assert!(calls.contains("plugin install trace-claude-code@braintrust-claude-plugin"));
+
+    let settings: serde_json::Value =
+        serde_json::from_slice(&fs::read(config).expect("read config")).expect("parse config");
+    assert_eq!(settings["traceToBraintrust"], true);
+    assert_eq!(
+        settings["route"]["destination"]["project_name"],
+        "coding-agents"
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn trace_setup_claude_enables_an_existing_disabled_plugin() {
+    let home = tempfile::tempdir().expect("home tempdir");
+    let bin_dir = tempfile::tempdir().expect("bin tempdir");
+    let state_dir = tempfile::tempdir().expect("state tempdir");
+    let log = state_dir.path().join("claude.log");
+    write_agent_cli(
+        &bin_dir.path().join("claude"),
+        r#"[{"name":"braintrust-claude-plugin"}]"#,
+        r#"[{"id":"trace-claude-code@braintrust-claude-plugin","enabled":false}]"#,
+    );
+
+    bt_command()
+        .env("HOME", home.path())
+        .env("PATH", bin_dir.path())
+        .env("AGENT_SETUP_LOG", &log)
+        .args(["trace", "setup", "claude", "--project", "coding-agents"])
+        .assert()
+        .success();
+
+    let calls = fs::read_to_string(log).expect("read fake CLI calls");
+    assert!(calls.contains("plugin enable trace-claude-code@braintrust-claude-plugin"));
+    assert!(!calls.contains("plugin marketplace add"));
+    assert!(!calls.contains("plugin install"));
 }
 
 #[test]


### PR DESCRIPTION
## Dependencies

Depends on merged [braintrustdata/braintrust-coding-agent-plugins#1](https://github.com/braintrustdata/braintrust-coding-agent-plugins/pull/1), pinned at its squash-merge commit `bebff4e0349fd9d2ee4a8ce1eeeafafee91ac74b`.

That daemon PR in turn depends on [braintrustdata/braintrust-sdk-rust#86](https://github.com/braintrustdata/braintrust-sdk-rust/pull/86), pinned at commit `d33e806bf6ab9548d37355f6a5098a971ef150aa`.

The plugin source cutover is intentionally deferred to stacked [braintrustdata/braintrust-coding-agent-plugins#3](https://github.com/braintrustdata/braintrust-coding-agent-plugins/pull/3), which must land only after this daemon is available in a released `bt` CLI.

## Summary

This embeds the shared coding-agent tracing daemon in `bt` under the `bt trace` command family. `bt trace setup` and `bt trace import` are the user-facing commands. The `daemon`, `hook`, `status`, and `stop` subcommands remain directly callable by plugins and operators who know their names, but are hidden from public help and usage output as implementation details.

`bt trace import codex <session-id>` and `bt trace import claude <session-id>` locate and snapshot native session transcripts in the agents' standard data directories, resolve the current `bt` profile and project, and send the reconstructed historical trace through the production Braintrust sink. The source is explicit because session IDs alone do not identify their producer. Codex snapshots are streamed once, native turn IDs and compaction history replacements are retained, and large imports drain in small bounded operation batches to avoid losing later turns to bounded delivery queues without serializing a network flush for every boundary. Claude imports preserve native turn ownership when physical record order is not timestamp-monotonic and propagate Claude API-error markers into turn and LLM errors. Daemon restart recovery remains an internal WAL operation; it may idempotently resubmit rows under stable backend row IDs, but cannot create duplicate logical spans.

The foreground daemon initializes structured logging at INFO by default, or DEBUG with `--verbose`, and emits safe request lifecycle fields such as JSON-RPC method, request ID, event type, source, and session ID. Payloads and credentials are not logged.

`bt trace setup codex` and `bt trace setup claude` use the coding agents' own plugin managers to add the official Braintrust marketplaces and install the currently published tracing plugins. Setup also creates the shared tracing settings when needed, enables tracing, and accepts `--project` for routing. It performs a non-destructive merge: every other setting, including legacy authentication and backend fields needed by currently published plugins, is preserved unchanged.

The `bt` host resolves its normal profile, OAuth, keychain, or API-key credentials for each hook invocation and transcript import, passing the resulting token, backend URLs, organization, and project to the credential-passive daemon library. Hook errors remain fail-open so tracing cannot break a Codex or Claude Code turn.

The daemon is consumed from the exact Git commit of its migration PR rather than through a local path dependency. The integration is rebased on current `bt` main and preserves the newer top-level `update` command and command routing introduced there.

CLI regression tests verify that `setup` and `import` are advertised by `bt trace --help`, while the four hidden operational commands remain directly callable. They also cover the required import source and session ID, rejection of the removed replay spelling, hook options, graceful and idempotent stop, Codex and Claude plugin-manager invocations, default and explicit project selection, and preservation of existing settings. The superseded `bt daemon` and `bt agents` paths remain rejected.

## Validation

- `cargo fmt --check`
- `cargo test --test cli`
  - all 30 CLI tests passed.
- Daemon dependency suite: 60 tests passed under all features, including multi-turn native Codex and Claude transcript imports, non-monotonic Claude record ordering and API errors, compaction-state replacement, turn-checkpoint delivery, and restart ID stability.
- Real installed Codex and Claude Code sessions completed against deterministic mock inference and satisfied their mock ingest trace scenarios.
- Manual isolated lifecycle smoke delivered deterministic Codex rows to a local mock Braintrust backend with project routing and `braintrust.plugin.codex` span-origin metadata.
- A real three-turn Claude transcript with non-monotonic record timestamps was imported into Braintrust; all three LLM spans were parented to their corresponding turns, native API failures were marked as errors, and re-import retained the same seven span IDs.

## Project selection and managed runs

- expose `bt trace run codex|claude` with invocation-local hooks and routing
- reuse an explicit or configured project for setup, run, and project-default imports
- prompt with the existing project selector when an interactive user has not selected a project
- require `--project` with actionable guidance in non-interactive mode
- persist setup profile, organization, and project selection as the typed daemon route while leaving managed-run selection process-local

Covers [SDK-128](https://linear.app/braintrustdata/issue/SDK-128/bt-trace-run) and [SDK-129](https://linear.app/braintrustdata/issue/SDK-129/add-project-selection-to-bt-trace-import-when-ambiguous).