### PR TITLE
Support OpenCode and Pi trace setup

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -576,7 +576,7 @@ dependencies = [
 [[package]]
 name = "bt-daemon"
 version = "0.1.0"
-source = "git+https://github.com/braintrustdata/braintrust-coding-agent-plugins?rev=96f452780b4c3b1aea2325853817721e777d3c48#96f452780b4c3b1aea2325853817721e777d3c48"
+source = "git+https://github.com/braintrustdata/braintrust-coding-agent-plugins?rev=8e13b6c551424ab6f935e0e61de43a2afe8864be#8e13b6c551424ab6f935e0e61de43a2afe8864be"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ actix-web = "4.11.0"
 anyhow = "1.0.89"
 backoff = { version = "0.4.0", features = ["tokio"] }
 braintrust-sdk-rust = { git = "https://github.com/braintrustdata/braintrust-sdk-rust", rev = "43ba73edbf5220b57090e049feb094b60a92fcd4" }
-bt-daemon = { git = "https://github.com/braintrustdata/braintrust-coding-agent-plugins", rev = "96f452780b4c3b1aea2325853817721e777d3c48" }
+bt-daemon = { git = "https://github.com/braintrustdata/braintrust-coding-agent-plugins", rev = "8e13b6c551424ab6f935e0e61de43a2afe8864be" }
 async-trait = "0.1"
 clap = { version = "4.5.20", features = ["derive", "env"] }
 crossterm = "0.28.1"

--- a/src/agents.rs
+++ b/src/agents.rs
@@ -75,6 +75,11 @@ enum SetupAgent {
     Codex,
     /// Install the published Claude Code tracing plugin.
     Claude,
+    /// Configure the published OpenCode tracing plugin.
+    #[command(name = "opencode", alias = "open-code")]
+    OpenCode,
+    /// Install the published Pi tracing extension.
+    Pi,
 }
 
 const CODEX_MARKETPLACE: &str = "braintrust-codex-plugins";
@@ -83,6 +88,8 @@ const CODEX_PLUGIN: &str = "trace-codex@braintrust-codex-plugins";
 const CLAUDE_MARKETPLACE: &str = "braintrust-claude-plugin";
 const CLAUDE_MARKETPLACE_SOURCE: &str = "braintrustdata/braintrust-claude-plugin";
 const CLAUDE_PLUGIN: &str = "trace-claude-code@braintrust-claude-plugin";
+const OPENCODE_PLUGIN: &str = "@braintrust/trace-opencode@^1";
+const PI_PLUGIN: &str = "npm:@braintrust/pi-extension@^1";
 
 /// How the shim (re)launches the daemon: `bt trace daemon` from this same
 /// binary.
@@ -342,29 +349,68 @@ fn setup_claude() -> anyhow::Result<()> {
     Ok(())
 }
 
+fn opencode_config_path() -> PathBuf {
+    let config_home = std::env::var_os("XDG_CONFIG_HOME")
+        .filter(|path| !path.is_empty())
+        .map(PathBuf::from)
+        .or_else(|| dirs::home_dir().map(|home| home.join(".config")))
+        .unwrap_or_else(|| PathBuf::from(".config"));
+    config_home.join("opencode").join("opencode.json")
+}
+
+fn setup_opencode() -> anyhow::Result<()> {
+    let path = opencode_config_path();
+    let mut config = load_settings(&path)?;
+    let plugins = config
+        .entry("plugin")
+        .or_insert_with(|| Value::Array(Vec::new()))
+        .as_array_mut()
+        .ok_or_else(|| {
+            anyhow::anyhow!(
+                "OpenCode `plugin` config must be an array: {}",
+                path.display()
+            )
+        })?;
+    plugins.retain(|plugin| {
+        plugin.as_str().is_none_or(|plugin| {
+            plugin != "@braintrust/trace-opencode"
+                && !plugin.starts_with("@braintrust/trace-opencode@")
+        })
+    });
+    plugins.push(Value::String(OPENCODE_PLUGIN.into()));
+
+    let mut encoded = serde_json::to_string_pretty(&Value::Object(config))?;
+    encoded.push('\n');
+    crate::utils::write_text_atomic(&path, &encoded)?;
+    Ok(())
+}
+
+fn setup_pi() -> anyhow::Result<()> {
+    run_command("pi", &["install", PI_PLUGIN])
+}
+
 fn load_settings(path: &Path) -> anyhow::Result<Map<String, Value>> {
     match std::fs::read(path) {
         Ok(raw) => {
             let value: Value = serde_json::from_slice(&raw)
-                .with_context(|| format!("invalid shared agent settings: {}", path.display()))?;
+                .with_context(|| format!("invalid JSON configuration: {}", path.display()))?;
             value.as_object().cloned().ok_or_else(|| {
-                anyhow::anyhow!(
-                    "shared agent settings must be a JSON object: {}",
-                    path.display()
-                )
+                anyhow::anyhow!("configuration must be a JSON object: {}", path.display())
             })
         }
         Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(Map::new()),
-        Err(error) => Err(error)
-            .with_context(|| format!("failed to read shared agent settings: {}", path.display())),
+        Err(error) => {
+            Err(error).with_context(|| format!("failed to read configuration: {}", path.display()))
+        }
     }
 }
 
-fn enable_tracing(route: SessionRoute) -> anyhow::Result<PathBuf> {
-    let path = paths::settings_path(None);
+fn enable_tracing(source: &str, route: SessionRoute) -> anyhow::Result<PathBuf> {
+    let path = paths::agent_settings_path(source, None);
     let mut settings = load_settings(&path)?;
-    settings.insert("traceToBraintrust".into(), Value::Bool(true));
+    settings.insert("trace_to_braintrust".into(), Value::Bool(true));
     settings.insert("route".into(), serde_json::to_value(route)?);
+    settings.remove("traceToBraintrust");
     settings.remove("project");
 
     let mut encoded = serde_json::to_string_pretty(&Value::Object(settings))?;
@@ -375,7 +421,7 @@ fn enable_tracing(route: SessionRoute) -> anyhow::Result<PathBuf> {
     {
         use std::os::unix::fs::PermissionsExt;
         std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o600))
-            .with_context(|| format!("failed to protect shared settings: {}", path.display()))?;
+            .with_context(|| format!("failed to protect agent settings: {}", path.display()))?;
     }
     Ok(path)
 }
@@ -383,17 +429,28 @@ fn enable_tracing(route: SessionRoute) -> anyhow::Result<PathBuf> {
 async fn run_setup(base: BaseArgs, args: SetupArgs) -> anyhow::Result<()> {
     let base = resolve_trace_project(base).await?;
 
-    match args.agent {
-        SetupAgent::Codex => setup_codex()?,
-        SetupAgent::Claude => setup_claude()?,
-    }
-    let settings_path = enable_tracing(session_route(&base))?;
+    let (source, label) = match args.agent {
+        SetupAgent::Codex => {
+            setup_codex()?;
+            ("codex", "Codex")
+        }
+        SetupAgent::Claude => {
+            setup_claude()?;
+            ("claude", "Claude Code")
+        }
+        SetupAgent::OpenCode => {
+            setup_opencode()?;
+            ("opencode", "OpenCode")
+        }
+        SetupAgent::Pi => {
+            setup_pi()?;
+            ("pi", "Pi")
+        }
+    };
+    let settings_path = enable_tracing(source, session_route(&base))?;
     println!(
         "The Braintrust tracing plugin is installed for {} and configured in {}.",
-        match args.agent {
-            SetupAgent::Codex => "Codex",
-            SetupAgent::Claude => "Claude Code",
-        },
+        label,
         settings_path.display()
     );
     println!("Restart the coding agent to load the tracing plugin.");

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -55,7 +55,7 @@ esac
 fn write_run_agent(path: &Path) {
     fs::write(
         path,
-        "#!/bin/sh\nprintf '%s\\n' \"$*\" > \"$AGENT_RUN_LOG\"\nprintf '%s\\n' \"$BT_TRACE_INVOCATION_SETTINGS\" > \"$AGENT_RUN_SETTINGS\"\n",
+        "#!/bin/sh\nprintf '%s\\n' \"$*\" > \"$AGENT_RUN_LOG\"\nprintf '%s\\n' \"$BT_TRACE_INVOCATION_SETTINGS\" > \"$AGENT_RUN_SETTINGS\"\nif [ -n \"$AGENT_RUN_CONFIG\" ]; then printf '%s\\n' \"$OPENCODE_CONFIG_CONTENT\" > \"$AGENT_RUN_CONFIG\"; fi\n",
     )
     .expect("write fake run agent");
     use std::os::unix::fs::PermissionsExt;
@@ -237,7 +237,9 @@ fn trace_help_exposes_user_commands_and_hides_internal_commands() {
         .assert()
         .success()
         .stdout(predicate::str::contains("codex"))
-        .stdout(predicate::str::contains("claude"));
+        .stdout(predicate::str::contains("claude"))
+        .stdout(predicate::str::contains("opencode"))
+        .stdout(predicate::str::contains("pi"));
 
     bt_command()
         .args(["trace", "run", "--help"])
@@ -245,7 +247,9 @@ fn trace_help_exposes_user_commands_and_hides_internal_commands() {
         .success()
         .stdout(predicate::str::contains("<SOURCE>"))
         .stdout(predicate::str::contains("codex"))
-        .stdout(predicate::str::contains("claude"));
+        .stdout(predicate::str::contains("claude"))
+        .stdout(predicate::str::contains("opencode"))
+        .stdout(predicate::str::contains("pi"));
 }
 
 #[test]
@@ -318,6 +322,106 @@ fn trace_run_uses_the_invocation_project_without_changing_setup() {
     assert!(
         !setup_settings.exists(),
         "managed run must not change persistent setup settings"
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn trace_run_opencode_injects_the_npm_plugin_without_changing_global_config() {
+    let home = tempfile::tempdir().expect("home tempdir");
+    let bin_dir = tempfile::tempdir().expect("bin tempdir");
+    let state_dir = tempfile::tempdir().expect("state tempdir");
+    let run_log = state_dir.path().join("run.log");
+    let run_settings = state_dir.path().join("run-settings.json");
+    let run_config = state_dir.path().join("run-config.json");
+    let global_config = home.path().join(".config/opencode/braintrust.json");
+    fs::create_dir_all(global_config.parent().expect("config parent"))
+        .expect("create config parent");
+    fs::write(&global_config, r#"{"trace_to_braintrust":true}"#).expect("seed global config");
+    write_run_agent(&bin_dir.path().join("opencode"));
+
+    bt_command()
+        .env("HOME", home.path())
+        .env("OPENCODE_BIN", bin_dir.path().join("opencode"))
+        .env("AGENT_RUN_LOG", &run_log)
+        .env("AGENT_RUN_SETTINGS", &run_settings)
+        .env("AGENT_RUN_CONFIG", &run_config)
+        .args([
+            "trace",
+            "run",
+            "opencode",
+            "--project",
+            "isolated-opencode",
+            "--",
+            "--version",
+        ])
+        .assert()
+        .success();
+
+    let inline: serde_json::Value =
+        serde_json::from_slice(&fs::read(run_config).expect("read OpenCode inline config"))
+            .expect("parse OpenCode inline config");
+    assert_eq!(
+        inline["plugin"],
+        serde_json::json!(["@braintrust/trace-opencode@^1"])
+    );
+    let settings: serde_json::Value =
+        serde_json::from_slice(&fs::read(run_settings).expect("read invocation settings"))
+            .expect("parse invocation settings");
+    assert_eq!(
+        settings["route"]["destination"]["project_name"],
+        "isolated-opencode"
+    );
+    assert_eq!(
+        fs::read_to_string(global_config).expect("read global config"),
+        r#"{"trace_to_braintrust":true}"#
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn trace_run_pi_injects_the_npm_extension_for_only_that_process() {
+    let home = tempfile::tempdir().expect("home tempdir");
+    let bin_dir = tempfile::tempdir().expect("bin tempdir");
+    let state_dir = tempfile::tempdir().expect("state tempdir");
+    let run_log = state_dir.path().join("run.log");
+    let run_settings = state_dir.path().join("run-settings.json");
+    let global_config = home.path().join(".pi/agent/braintrust.json");
+    fs::create_dir_all(global_config.parent().expect("config parent"))
+        .expect("create config parent");
+    fs::write(&global_config, r#"{"trace_to_braintrust":true}"#).expect("seed global config");
+    write_run_agent(&bin_dir.path().join("pi"));
+
+    bt_command()
+        .env("HOME", home.path())
+        .env("PI_BIN", bin_dir.path().join("pi"))
+        .env("AGENT_RUN_LOG", &run_log)
+        .env("AGENT_RUN_SETTINGS", &run_settings)
+        .args([
+            "trace",
+            "run",
+            "pi",
+            "--project",
+            "isolated-pi",
+            "--",
+            "--version",
+        ])
+        .assert()
+        .success();
+
+    assert!(fs::read_to_string(run_log)
+        .expect("read Pi arguments")
+        .contains("-e npm:@braintrust/pi-extension@^1 --version"));
+    let settings: serde_json::Value =
+        serde_json::from_slice(&fs::read(run_settings).expect("read invocation settings"))
+            .expect("parse invocation settings");
+    assert_eq!(
+        settings["route"]["destination"]["project_name"],
+        "isolated-pi"
+    );
+    assert_eq!(
+        fs::read_to_string(global_config).expect("read global config"),
+        r#"{"trace_to_braintrust":true}"#
     );
 }
 
@@ -445,7 +549,8 @@ fn trace_setup_codex_installs_plugin_and_preserves_existing_settings() {
 
     let settings: serde_json::Value =
         serde_json::from_slice(&fs::read(config).expect("read config")).expect("parse config");
-    assert_eq!(settings["traceToBraintrust"], true);
+    assert_eq!(settings["trace_to_braintrust"], true);
+    assert!(settings.get("traceToBraintrust").is_none());
     assert_eq!(
         settings["route"]["destination"]["project_name"],
         "agent-traces"
@@ -487,7 +592,7 @@ fn trace_setup_claude_installs_plugin_and_writes_selected_project() {
 
     let settings: serde_json::Value =
         serde_json::from_slice(&fs::read(config).expect("read config")).expect("parse config");
-    assert_eq!(settings["traceToBraintrust"], true);
+    assert_eq!(settings["trace_to_braintrust"], true);
     assert_eq!(
         settings["route"]["destination"]["project_name"],
         "coding-agents"
@@ -519,6 +624,145 @@ fn trace_setup_claude_enables_an_existing_disabled_plugin() {
     assert!(calls.contains("plugin enable trace-claude-code@braintrust-claude-plugin"));
     assert!(!calls.contains("plugin marketplace add"));
     assert!(!calls.contains("plugin install"));
+}
+
+#[test]
+fn trace_setup_opencode_configures_the_npm_plugin_and_selected_route() {
+    let home = tempfile::tempdir().expect("home tempdir");
+    let config_home = tempfile::tempdir().expect("config tempdir");
+    let opencode_dir = config_home.path().join("opencode");
+    fs::create_dir_all(&opencode_dir).expect("create OpenCode config dir");
+    fs::write(
+        opencode_dir.join("opencode.json"),
+        r#"{"plugin":["other-plugin","@braintrust/trace-opencode@0.9.0"],"model":"test/model"}"#,
+    )
+    .expect("seed OpenCode config");
+
+    bt_command()
+        .env("HOME", home.path())
+        .env("XDG_CONFIG_HOME", config_home.path())
+        .args([
+            "trace",
+            "setup",
+            "open-code",
+            "--profile",
+            "work",
+            "--org",
+            "acme",
+            "--project",
+            "agent-traces",
+        ])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("installed for OpenCode"));
+
+    let opencode: serde_json::Value = serde_json::from_slice(
+        &fs::read(opencode_dir.join("opencode.json")).expect("read OpenCode config"),
+    )
+    .expect("parse OpenCode config");
+    assert_eq!(opencode["model"], "test/model");
+    assert_eq!(
+        opencode["plugin"],
+        serde_json::json!(["other-plugin", "@braintrust/trace-opencode@^1"])
+    );
+
+    let settings: serde_json::Value = serde_json::from_slice(
+        &fs::read(opencode_dir.join("braintrust.json")).expect("read OpenCode settings"),
+    )
+    .expect("parse OpenCode settings");
+    assert_eq!(settings["trace_to_braintrust"], true);
+    assert_eq!(settings["route"]["auth"]["profile"], "work");
+    assert_eq!(settings["route"]["auth"]["org_name"], "acme");
+    assert_eq!(
+        settings["route"]["destination"]["project_name"],
+        "agent-traces"
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn trace_setup_pi_installs_the_npm_extension_and_selected_route() {
+    let home = tempfile::tempdir().expect("home tempdir");
+    let bin_dir = tempfile::tempdir().expect("bin tempdir");
+    let state_dir = tempfile::tempdir().expect("state tempdir");
+    let log = state_dir.path().join("pi.log");
+    write_agent_cli(&bin_dir.path().join("pi"), "{}", "{}");
+
+    bt_command()
+        .env("HOME", home.path())
+        .env("PATH", bin_dir.path())
+        .env("AGENT_SETUP_LOG", &log)
+        .args(["trace", "setup", "pi", "--project", "pi-traces"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("installed for Pi"));
+
+    assert_eq!(
+        fs::read_to_string(log).expect("read Pi calls").trim(),
+        "install npm:@braintrust/pi-extension@^1"
+    );
+    let settings: serde_json::Value = serde_json::from_slice(
+        &fs::read(home.path().join(".pi/agent/braintrust.json")).expect("read Pi settings"),
+    )
+    .expect("parse Pi settings");
+    assert_eq!(settings["trace_to_braintrust"], true);
+    assert_eq!(
+        settings["route"]["destination"]["project_name"],
+        "pi-traces"
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn trace_setup_keeps_each_agents_persistent_selection_independent() {
+    let home = tempfile::tempdir().expect("home tempdir");
+    let config_home = tempfile::tempdir().expect("config tempdir");
+    let bin_dir = tempfile::tempdir().expect("bin tempdir");
+    let log = tempfile::NamedTempFile::new().expect("setup log");
+    write_agent_cli(
+        &bin_dir.path().join("codex"),
+        r#"{"marketplaces":[]}"#,
+        r#"{"installed":[]}"#,
+    );
+
+    bt_command()
+        .env("HOME", home.path())
+        .env("XDG_CONFIG_HOME", config_home.path())
+        .env("PATH", bin_dir.path())
+        .env("AGENT_SETUP_LOG", log.path())
+        .args(["trace", "setup", "codex", "--project", "codex-project"])
+        .assert()
+        .success();
+    bt_command()
+        .env("HOME", home.path())
+        .env("XDG_CONFIG_HOME", config_home.path())
+        .args([
+            "trace",
+            "setup",
+            "opencode",
+            "--project",
+            "opencode-project",
+        ])
+        .assert()
+        .success();
+
+    let codex: serde_json::Value = serde_json::from_slice(
+        &fs::read(home.path().join(".codex/braintrust.json")).expect("read Codex settings"),
+    )
+    .expect("parse Codex settings");
+    let opencode: serde_json::Value = serde_json::from_slice(
+        &fs::read(config_home.path().join("opencode/braintrust.json"))
+            .expect("read OpenCode settings"),
+    )
+    .expect("parse OpenCode settings");
+    assert_eq!(
+        codex["route"]["destination"]["project_name"],
+        "codex-project"
+    );
+    assert_eq!(
+        opencode["route"]["destination"]["project_name"],
+        "opencode-project"
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- add `bt trace setup opencode` and `bt trace setup pi`
- configure OpenCode's published npm plugin and install Pi's published npm extension
- write profile, organization, and project selection to each agent's own `braintrust.json`
- keep managed OpenCode and Pi runs isolated from their persistent configuration
- pin the coordinated plugin-monorepo implementation at `952e2f26c8613d3fac82ca4999aae448a0b82139`

## Validation

- full `cargo test --locked` (715 unit tests plus all integration suites)
- focused setup and managed-run CLI tests
- `cargo fmt --all -- --check`
- `cargo check --locked`
- `git diff --check`

Strict clippy currently reaches only unrelated pre-existing `collapsible_match` failures under Rust 1.95 in datasets, SQL, and traces code; this PR does not modify those files.

Depends on the stacked plugin-monorepo PR.