### PR TITLE
chore(init): init checks it can write .bt before making API calls

### DIFF
--- a/src/auth.rs
+++ b/src/auth.rs
@@ -204,11 +204,22 @@ fn select_profile_for_app_interactive(
 }
 
 pub async fn list_available_orgs(base: &BaseArgs) -> Result<Vec<AvailableOrg>> {
-    let resolved = resolve_auth(base).await?;
-    let app_url = resolved
+    Ok(resolve_org_options(base).await?.orgs)
+}
+
+pub(crate) struct OrgOptions {
+    auth: ResolvedAuth,
+    api_key: String,
+    pub orgs: Vec<AvailableOrg>,
+}
+
+pub(crate) async fn resolve_org_options(base: &BaseArgs) -> Result<OrgOptions> {
+    let auth = resolve_auth(base).await?;
+    let app_url = auth
         .app_url
+        .clone()
         .unwrap_or_else(|| DEFAULT_APP_URL.to_string());
-    let api_key = match resolved.api_key {
+    let api_key = match auth.api_key.clone() {
         Some(api_key) => api_key,
         None => login(base)
             .await?
@@ -225,14 +236,54 @@ pub async fn list_available_orgs(base: &BaseArgs) -> Result<Vec<AvailableOrg>> {
             .then_with(|| a.name.cmp(&b.name))
     });
 
-    Ok(orgs
-        .into_iter()
-        .map(|org| AvailableOrg {
-            id: org.id,
-            name: org.name,
-            api_url: org.api_url,
-        })
-        .collect())
+    Ok(OrgOptions {
+        auth,
+        api_key,
+        orgs: orgs
+            .into_iter()
+            .map(|org| AvailableOrg {
+                id: org.id,
+                name: org.name,
+                api_url: org.api_url,
+            })
+            .collect(),
+    })
+}
+
+impl OrgOptions {
+    /// `/api/apikey/login` returned the whole login state alongside the org
+    /// list, so this needs no request.
+    pub(crate) async fn login_context(&self, base: &BaseArgs, org: &AvailableOrg) -> LoginContext {
+        maybe_warn_api_key_override(base);
+        let app_url = self
+            .auth
+            .app_url
+            .clone()
+            .unwrap_or_else(|| DEFAULT_APP_URL.to_string());
+        let api_url = org
+            .api_url
+            .clone()
+            .or_else(|| self.auth.api_url.clone())
+            .unwrap_or_else(|| DEFAULT_API_URL.to_string());
+
+        let login = LoginState::new();
+        login.set(
+            self.api_key.clone(),
+            org.id.clone(),
+            org.name.clone(),
+            api_url.clone(),
+            app_url.clone(),
+        );
+
+        let ctx = LoginContext {
+            login,
+            api_url,
+            app_url,
+            profile: self.auth.profile.clone(),
+        };
+        maybe_warn_ai_provider_key_staleness(base, &ctx).await;
+        ctx
+    }
 }
 
 pub(crate) async fn list_available_orgs_for_api_key(
@@ -4953,6 +5004,61 @@ mod tests {
         assert_eq!(params.code.as_deref(), Some("next-code"));
         assert_eq!(params.state.as_deref(), Some("next-state"));
         assert!(response.starts_with("HTTP/1.1 200 OK"));
+    }
+
+    fn org_options(api_url: Option<&str>) -> OrgOptions {
+        OrgOptions {
+            auth: ResolvedAuth {
+                api_key: Some("sk-test".to_string()),
+                api_url: api_url.map(String::from),
+                app_url: None,
+                org_name: None,
+                is_oauth: false,
+                profile: Some("test-profile".to_string()),
+            },
+            api_key: "sk-test".to_string(),
+            orgs: Vec::new(),
+        }
+    }
+
+    fn available_org(api_url: Option<&str>) -> AvailableOrg {
+        AvailableOrg {
+            id: "org_123".to_string(),
+            name: "test-org".to_string(),
+            api_url: api_url.map(String::from),
+        }
+    }
+
+    /// Must fill the same fields the SDK's `perform_login` does.
+    #[tokio::test]
+    async fn login_context_matches_a_real_login() {
+        // `json` suppresses the interactive warnings the call would otherwise emit.
+        let base: BaseArgs = crate::args::LoginBaseArgs {
+            json: true,
+            ..Default::default()
+        }
+        .into();
+        let profile_url = Some("https://api.profile.example");
+
+        let ctx = org_options(profile_url)
+            .login_context(&base, &available_org(Some("https://api.org.example")))
+            .await;
+        assert_eq!(ctx.api_url, "https://api.org.example");
+        assert_eq!(ctx.app_url, DEFAULT_APP_URL);
+        assert_eq!(ctx.profile.as_deref(), Some("test-profile"));
+        assert_eq!(ctx.login.api_key().as_deref(), Some("sk-test"));
+        assert_eq!(ctx.login.org_id().as_deref(), Some("org_123"));
+        assert_eq!(ctx.login.org_name().as_deref(), Some("test-org"));
+
+        let from_profile = org_options(profile_url)
+            .login_context(&base, &available_org(None))
+            .await;
+        assert_eq!(from_profile.api_url, "https://api.profile.example");
+
+        let from_default = org_options(None)
+            .login_context(&base, &available_org(None))
+            .await;
+        assert_eq!(from_default.api_url, DEFAULT_API_URL);
     }
 
     #[tokio::test]

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -269,20 +269,56 @@ pub fn local_save_path() -> Result<PathBuf> {
     Ok(std::env::current_dir()?.join(".bt").join("config.json"))
 }
 
-/// Verify that a config can be written before doing slower work such as API calls.
-pub fn preflight_config_write(path: &Path, create_parent: bool) -> Result<()> {
+/// Creates nothing, so an aborted command leaves no config directory behind.
+pub fn preflight_config_write(path: &Path) -> Result<()> {
     let parent = path.parent().unwrap_or_else(|| Path::new("."));
-    if create_parent {
-        fs::create_dir_all(parent)
-            .with_context(|| format!("Could not create config directory {}", parent.display()))?;
+    // `save_file` creates missing parents, so permissions hinge on this one.
+    let existing = nearest_existing_dir(parent);
+
+    if !existing.is_dir() {
+        bail!(
+            "Could not create config directory {}: {} is not a directory",
+            parent.display(),
+            existing.display()
+        );
     }
 
-    let probe = tempfile::NamedTempFile::new_in(parent)
-        .with_context(|| format!("Could not write to config directory {}", parent.display()))?;
+    let probe = tempfile::NamedTempFile::new_in(&existing)
+        .with_context(|| format!("Could not write to config directory {}", existing.display()))?;
     probe
         .close()
-        .with_context(|| format!("Could not clean up write test in {}", parent.display()))?;
+        .with_context(|| format!("Could not clean up write test in {}", existing.display()))?;
+
+    // Unix renames over a read-only target fine; Windows does not.
+    #[cfg(windows)]
+    if path
+        .metadata()
+        .is_ok_and(|meta| meta.permissions().readonly())
+    {
+        bail!(
+            "Could not write config file {}: it is read-only",
+            path.display()
+        );
+    }
+
     Ok(())
+}
+
+fn nearest_existing_dir(dir: &Path) -> PathBuf {
+    let mut current = if dir.as_os_str().is_empty() {
+        PathBuf::from(".")
+    } else {
+        dir.to_path_buf()
+    };
+    loop {
+        if current.exists() {
+            return current;
+        }
+        match current.parent() {
+            Some(parent) if !parent.as_os_str().is_empty() => current = parent.to_path_buf(),
+            _ => return PathBuf::from("."),
+        }
+    }
 }
 
 pub fn save_local(config: &Config, create_dir: bool) -> Result<PathBuf> {
@@ -572,27 +608,46 @@ mod tests {
     }
 
     #[test]
-    fn preflight_config_write_creates_and_tests_parent() {
+    fn preflight_config_write_checks_parent_without_creating_it() {
         let tmp = TempDir::new().unwrap();
-        let parent = tmp.path().join(".bt");
-        let path = parent.join("config.json");
+        let missing = tmp.path().join(".bt");
+        let existing = tmp.path().join("config.json");
+        save_file(&existing, &Config::default()).unwrap();
 
-        preflight_config_write(&path, true).unwrap();
+        preflight_config_write(&missing.join("config.json")).unwrap();
+        preflight_config_write(&existing).unwrap();
+        assert!(!missing.exists());
 
-        assert!(parent.is_dir());
-        assert!(!path.exists());
-    }
-
-    #[test]
-    fn preflight_config_write_fails_when_parent_cannot_be_created() {
-        let tmp = TempDir::new().unwrap();
-        let parent = tmp.path().join(".bt");
-        fs::write(&parent, "not a directory").unwrap();
-
-        let error = preflight_config_write(&parent.join("config.json"), true).unwrap_err();
-
+        let file_parent = tmp.path().join("not-a-dir");
+        fs::write(&file_parent, "").unwrap();
+        let error = preflight_config_write(&file_parent.join("config.json")).unwrap_err();
         assert!(error
             .to_string()
             .contains("Could not create config directory"));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn preflight_config_write_fails_when_parent_is_not_writable() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let tmp = TempDir::new().unwrap();
+        let parent = tmp.path().join("locked");
+        fs::create_dir(&parent).unwrap();
+        fs::set_permissions(&parent, fs::Permissions::from_mode(0o555)).unwrap();
+        // Root ignores the mode bits, so the probe would succeed there.
+        let permissions_enforced = fs::write(parent.join("root-check"), "").is_err();
+
+        let result = preflight_config_write(&parent.join(".bt").join("config.json"));
+
+        // Restore write access so cleanup can remove the temp dir.
+        fs::set_permissions(&parent, fs::Permissions::from_mode(0o755)).unwrap();
+
+        if permissions_enforced {
+            assert!(result
+                .unwrap_err()
+                .to_string()
+                .contains("Could not write to config directory"));
+        }
     }
 }

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -1,4 +1,4 @@
-use anyhow::{anyhow, bail, Result};
+use anyhow::{anyhow, bail, Context, Result};
 use clap::{Args, Subcommand};
 use std::{
     env, fs,
@@ -267,6 +267,22 @@ pub fn resolve_write_path(global: bool, local: bool) -> Result<PathBuf> {
 
 pub fn local_save_path() -> Result<PathBuf> {
     Ok(std::env::current_dir()?.join(".bt").join("config.json"))
+}
+
+/// Verify that a config can be written before doing slower work such as API calls.
+pub fn preflight_config_write(path: &Path, create_parent: bool) -> Result<()> {
+    let parent = path.parent().unwrap_or_else(|| Path::new("."));
+    if create_parent {
+        fs::create_dir_all(parent)
+            .with_context(|| format!("Could not create config directory {}", parent.display()))?;
+    }
+
+    let probe = tempfile::NamedTempFile::new_in(parent)
+        .with_context(|| format!("Could not write to config directory {}", parent.display()))?;
+    probe
+        .close()
+        .with_context(|| format!("Could not clean up write test in {}", parent.display()))?;
+    Ok(())
 }
 
 pub fn save_local(config: &Config, create_dir: bool) -> Result<PathBuf> {
@@ -553,5 +569,30 @@ mod tests {
 
         save_file(&path, &config).unwrap();
         assert!(path.exists());
+    }
+
+    #[test]
+    fn preflight_config_write_creates_and_tests_parent() {
+        let tmp = TempDir::new().unwrap();
+        let parent = tmp.path().join(".bt");
+        let path = parent.join("config.json");
+
+        preflight_config_write(&path, true).unwrap();
+
+        assert!(parent.is_dir());
+        assert!(!path.exists());
+    }
+
+    #[test]
+    fn preflight_config_write_fails_when_parent_cannot_be_created() {
+        let tmp = TempDir::new().unwrap();
+        let parent = tmp.path().join(".bt");
+        fs::write(&parent, "not a directory").unwrap();
+
+        let error = preflight_config_write(&parent.join("config.json"), true).unwrap_err();
+
+        assert!(error
+            .to_string()
+            .contains("Could not create config directory"));
     }
 }

--- a/src/init.rs
+++ b/src/init.rs
@@ -36,6 +36,9 @@ pub async fn run(base: BaseArgs, _args: InitArgs) -> Result<()> {
         return Ok(());
     }
 
+    // Create and test the local config directory before profile/project discovery.
+    config::preflight_config_write(&config_path, true)?;
+
     eprintln!("Link to a Braintrust project...");
 
     let (org, project, profile) = if let (Some(o), Some(p)) = (&base.org_name, &base.project) {
@@ -48,6 +51,10 @@ pub async fn run(base: BaseArgs, _args: InitArgs) -> Result<()> {
             if let Some(profile) = auth::select_profile_interactive(None)? {
                 login_base.profile = Some(profile);
             }
+        }
+        if login_base.org_name.is_none() {
+            login_base.org_name =
+                Some(crate::switch::select_org_for_switch(&login_base, None).await?);
         }
         let ctx = login(&login_base).await?;
         let client = ApiClient::new(&ctx)?;

--- a/src/init.rs
+++ b/src/init.rs
@@ -36,8 +36,7 @@ pub async fn run(base: BaseArgs, _args: InitArgs) -> Result<()> {
         return Ok(());
     }
 
-    // Create and test the local config directory before profile/project discovery.
-    config::preflight_config_write(&config_path, true)?;
+    config::preflight_config_write(&config_path)?;
 
     eprintln!("Link to a Braintrust project...");
 
@@ -52,11 +51,13 @@ pub async fn run(base: BaseArgs, _args: InitArgs) -> Result<()> {
                 login_base.profile = Some(profile);
             }
         }
-        if login_base.org_name.is_none() {
-            login_base.org_name =
-                Some(crate::switch::select_org_for_switch(&login_base, None).await?);
-        }
-        let ctx = login(&login_base).await?;
+        let ctx = if login_base.org_name.is_none() {
+            let (options, org) = crate::switch::select_org_for_switch(&login_base, None).await?;
+            login_base.org_name = Some(org.name.clone());
+            options.login_context(&login_base, &org).await
+        } else {
+            login(&login_base).await?
+        };
         let client = ApiClient::new(&ctx)?;
 
         let org = client.org_name().to_string();

--- a/src/switch.rs
+++ b/src/switch.rs
@@ -62,6 +62,22 @@ pub async fn run(base: BaseArgs, args: SwitchArgs) -> Result<()> {
     if resolved_project.is_none() && is_interactive() {
         interactive = true;
     }
+
+    // Resolve and test an explicitly requested filesystem target before any API calls.
+    let forced_scope = if args.local {
+        let path = config::local_path().ok_or_else(|| {
+            anyhow::anyhow!(
+                "No local .bt directory found. Use bt init to initialize this directory."
+            )
+        })?;
+        config::preflight_config_write(&path, false)?;
+        Some((path, "local"))
+    } else if args.global {
+        Some((config::global_path()?, "global"))
+    } else {
+        None
+    };
+
     let requested_profile = if has_api_key_override {
         None
     } else if base.profile.is_some() {
@@ -112,17 +128,8 @@ pub async fn run(base: BaseArgs, args: SwitchArgs) -> Result<()> {
         }
     };
 
-    let (path, scope) = if args.local {
-        (
-            config::local_path().ok_or_else(|| {
-                anyhow::anyhow!(
-                    "No local .bt directory found. Use bt init to initialize this directory."
-                )
-            })?,
-            "local",
-        )
-    } else if args.global {
-        (config::global_path()?, "global")
+    let (path, scope) = if let Some(scope) = forced_scope {
+        scope
     } else if interactive && config::local_path().is_some() {
         select_scope()?
     } else {
@@ -162,7 +169,10 @@ pub async fn run(base: BaseArgs, args: SwitchArgs) -> Result<()> {
     Ok(())
 }
 
-async fn select_org_for_switch(base: &BaseArgs, current_org: Option<&str>) -> Result<String> {
+pub(crate) async fn select_org_for_switch(
+    base: &BaseArgs,
+    current_org: Option<&str>,
+) -> Result<String> {
     let orgs = auth::list_available_orgs(base).await?;
     if orgs.len() == 1 {
         return Ok(orgs[0].name.clone());

--- a/src/switch.rs
+++ b/src/switch.rs
@@ -63,17 +63,20 @@ pub async fn run(base: BaseArgs, args: SwitchArgs) -> Result<()> {
         interactive = true;
     }
 
-    // Resolve and test an explicitly requested filesystem target before any API calls.
+    // Test an explicit target before any API calls. An implicit scope isn't
+    // known until after project selection, so it is checked at write time.
     let forced_scope = if args.local {
         let path = config::local_path().ok_or_else(|| {
             anyhow::anyhow!(
                 "No local .bt directory found. Use bt init to initialize this directory."
             )
         })?;
-        config::preflight_config_write(&path, false)?;
+        config::preflight_config_write(&path)?;
         Some((path, "local"))
     } else if args.global {
-        Some((config::global_path()?, "global"))
+        let path = config::global_path()?;
+        config::preflight_config_write(&path)?;
+        Some((path, "global"))
     } else {
         None
     };
@@ -91,23 +94,27 @@ pub async fn run(base: BaseArgs, args: SwitchArgs) -> Result<()> {
         config::trimmed_option(current_cfg.profile.as_deref()).map(str::to_string)
     };
 
-    let selected_org = if resolved_org.is_some() {
-        resolved_org.clone()
-    } else if interactive {
+    let picked_org = if resolved_org.is_none() && interactive {
         let mut org_base = base.clone();
         org_base.profile = requested_profile.clone();
         org_base.org_name = None;
         Some(select_org_for_switch(&org_base, current_cfg.org.as_deref()).await?)
     } else {
-        current_cfg.org.clone()
+        None
     };
 
     let mut login_base = base.clone();
     login_base.profile = requested_profile;
-    login_base.org_name = selected_org;
+    login_base.org_name = match &picked_org {
+        Some((_, org)) => Some(org.name.clone()),
+        None => resolved_org.clone().or_else(|| current_cfg.org.clone()),
+    };
     login_base.project = resolved_project.clone();
 
-    let ctx = login(&login_base).await?;
+    let ctx = match &picked_org {
+        Some((options, org)) => options.login_context(&login_base, org).await,
+        None => login(&login_base).await?,
+    };
     let client = ApiClient::new(&ctx)?;
     let org_name = client.org_name().to_string();
 
@@ -169,22 +176,28 @@ pub async fn run(base: BaseArgs, args: SwitchArgs) -> Result<()> {
     Ok(())
 }
 
+/// Returns the [`auth::OrgOptions`] too, so the caller can build a login
+/// context from it.
 pub(crate) async fn select_org_for_switch(
     base: &BaseArgs,
     current_org: Option<&str>,
-) -> Result<String> {
-    let orgs = auth::list_available_orgs(base).await?;
-    if orgs.len() == 1 {
-        return Ok(orgs[0].name.clone());
-    }
+) -> Result<(auth::OrgOptions, auth::AvailableOrg)> {
+    let options = auth::resolve_org_options(base).await?;
+    let orgs = &options.orgs;
     if orgs.is_empty() {
         bail!("no organizations available for the selected profile");
     }
 
-    let labels = orgs.iter().map(|org| org.name.as_str()).collect::<Vec<_>>();
-    let default = default_org_selection(&orgs, current_org);
-    let selected = fuzzy_select("Select organization", &labels, default)?;
-    Ok(orgs[selected].name.clone())
+    let selected = if orgs.len() == 1 {
+        0
+    } else {
+        let labels = orgs.iter().map(|org| org.name.as_str()).collect::<Vec<_>>();
+        let default = default_org_selection(orgs, current_org);
+        fuzzy_select("Select organization", &labels, default)?
+    };
+
+    let org = orgs[selected].clone();
+    Ok((options, org))
 }
 
 fn default_org_selection(orgs: &[auth::AvailableOrg], current_org: Option<&str>) -> usize {


### PR DESCRIPTION
also asks for the org between profile and project


### Checking the filesystem before making network call:
Before, the user has to make 2 choices and bt does a network call before the failure:
```
❯ bt init
Link to a Braintrust project...
✔ Select profile · Cedric-Halber
✔ Link to project · Alex Z Eval Emporium
error: Read-only file system (os error 30)
```

After:
```
❯ bt init
error: Could not write to config directory /
```


### Asking for the org:
Before, used the org currently in use but neither the profile nor the project in use:
```
❯ bt status
org: BT Staging
project: cedric-traces
project_id: ee83debf-c852-4788-9ac5-470029e8b04d
profile: Cedric-Halber-2
app_url: https://www.braintrust.dev
api_url: https://staging-api.braintrust.dev
auth: oauth — Cedric Halber (cedric@braintrustdata.com)
source: /Users/cedric@braintrustdata.com/.config/bt/config.json
❯ bt init
Link to a Braintrust project...
✔ Select profile · Cedric-Halber
✔ Link to project · My Project
✓ Project linked to BT Staging/My Project
✓ Created .bt/config.json
```

After:
```
❯ bt init
Link to a Braintrust project...
✔ Select profile · Cedric-Halber
✔ Select organization · -/
✔ Link to project · My Project
✓ Project linked to -//My Project
✓ Created .bt/config.json
```