### PR TITLE
chore: merge tempfile functions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -588,7 +588,6 @@ dependencies = [
  "unicode-width 0.1.14",
  "urlencoding",
  "uuid",
- "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -66,6 +66,3 @@ members = ["."]
 [dev-dependencies]
 assert_cmd = "2.2.0"
 predicates = "3.1.4"
-
-[target.'cfg(windows)'.dependencies]
-windows-sys = { version = "0.59", features = ["Win32_Storage_FileSystem"] }

--- a/src/auth.rs
+++ b/src/auth.rs
@@ -1,7 +1,9 @@
 use std::collections::{BTreeMap, BTreeSet};
 use std::error::Error as StdError;
 use std::fs;
-use std::io::{IsTerminal, Write};
+use std::io::IsTerminal;
+#[cfg(target_os = "linux")]
+use std::io::Write;
 use std::net::TcpListener;
 use std::path::{Path, PathBuf};
 use std::process::Command;
@@ -542,17 +544,7 @@ fn load_ai_provider_warning_state() -> AiProviderKeyStalenessWarningState {
 }
 
 fn save_ai_provider_warning_state(state: &AiProviderKeyStalenessWarningState) -> Result<()> {
-    let path = ai_provider_warning_state_path()?;
-    let parent = path.parent().unwrap_or_else(|| Path::new("."));
-    fs::create_dir_all(parent)?;
-
-    let json = serde_json::to_string_pretty(state)?;
-    let mut file = tempfile::NamedTempFile::new_in(parent)?;
-    file.write_all(json.as_bytes())?;
-    file.write_all(b"\n")?;
-    file.as_file().sync_all()?;
-    file.persist(path)?;
-    Ok(())
+    crate::utils::write_json_atomic(&ai_provider_warning_state_path()?, state)
 }
 
 fn stale_ai_provider_secrets(
@@ -2858,53 +2850,8 @@ fn load_secret_store() -> Result<SecretStore> {
 
 fn save_secret_store(store: &SecretStore) -> Result<()> {
     let path = secret_store_path()?;
-    if let Some(parent) = path.parent() {
-        fs::create_dir_all(parent)
-            .with_context(|| format!("failed to create directory {}", parent.display()))?;
-    }
-
-    let data = serde_json::to_string_pretty(store).context("failed to serialize secret store")?;
-    let temp_path = path.with_extension("tmp");
-    let mut file = fs::File::create(&temp_path)
-        .with_context(|| format!("failed to write temp secret store {}", temp_path.display()))?;
-    file.write_all(data.as_bytes())
-        .with_context(|| format!("failed to write temp secret store {}", temp_path.display()))?;
-    file.write_all(b"\n")
-        .with_context(|| format!("failed to write temp secret store {}", temp_path.display()))?;
-    file.sync_all()
-        .with_context(|| format!("failed to flush temp secret store {}", temp_path.display()))?;
-
-    #[cfg(unix)]
-    {
-        use std::os::unix::fs::PermissionsExt;
-        fs::set_permissions(&temp_path, fs::Permissions::from_mode(0o600)).with_context(|| {
-            format!(
-                "failed to set permissions on temp secret store {}",
-                temp_path.display()
-            )
-        })?;
-    }
-
-    fs::rename(&temp_path, &path).with_context(|| {
-        format!(
-            "failed to move temp secret store {} to {}",
-            temp_path.display(),
-            path.display()
-        )
-    })?;
-
-    #[cfg(unix)]
-    {
-        use std::os::unix::fs::PermissionsExt;
-        fs::set_permissions(&path, fs::Permissions::from_mode(0o600)).with_context(|| {
-            format!(
-                "failed to set permissions on secret store {}",
-                path.display()
-            )
-        })?;
-    }
-
-    Ok(())
+    crate::utils::write_json_atomic_private(&path, store)
+        .with_context(|| format!("failed to write secret store {}", path.display()))
 }
 
 fn secret_store_path() -> Result<PathBuf> {
@@ -3280,53 +3227,8 @@ fn save_auth_store(store: &AuthStore) -> Result<()> {
 }
 
 fn save_auth_store_to_path(path: &Path, store: &AuthStore) -> Result<()> {
-    if let Some(parent) = path.parent() {
-        fs::create_dir_all(parent)
-            .with_context(|| format!("failed to create directory {}", parent.display()))?;
-    }
-
-    let data = serde_json::to_string_pretty(store).context("failed to serialize auth config")?;
-    let temp_path = path.with_extension("tmp");
-    let mut file = fs::File::create(&temp_path)
-        .with_context(|| format!("failed to write temp auth config {}", temp_path.display()))?;
-    file.write_all(data.as_bytes())
-        .with_context(|| format!("failed to write temp auth config {}", temp_path.display()))?;
-    file.write_all(b"\n")
-        .with_context(|| format!("failed to write temp auth config {}", temp_path.display()))?;
-    file.sync_all()
-        .with_context(|| format!("failed to flush temp auth config {}", temp_path.display()))?;
-
-    #[cfg(unix)]
-    {
-        use std::os::unix::fs::PermissionsExt;
-        fs::set_permissions(&temp_path, fs::Permissions::from_mode(0o600)).with_context(|| {
-            format!(
-                "failed to set permissions on temp auth config {}",
-                temp_path.display()
-            )
-        })?;
-    }
-
-    fs::rename(&temp_path, path).with_context(|| {
-        format!(
-            "failed to move temp auth config {} to {}",
-            temp_path.display(),
-            path.display()
-        )
-    })?;
-
-    #[cfg(unix)]
-    {
-        use std::os::unix::fs::PermissionsExt;
-        fs::set_permissions(path, fs::Permissions::from_mode(0o600)).with_context(|| {
-            format!(
-                "failed to set permissions on auth config {}",
-                path.display()
-            )
-        })?;
-    }
-
-    Ok(())
+    crate::utils::write_json_atomic_private(path, store)
+        .with_context(|| format!("failed to write auth config {}", path.display()))
 }
 
 fn auth_store_path() -> Result<PathBuf> {

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -1,8 +1,7 @@
 use anyhow::{anyhow, bail, Result};
 use clap::{Args, Subcommand};
 use std::{
-    env, fs,
-    io::{self, Write as _},
+    env, fs, io,
     path::{Path, PathBuf},
 };
 
@@ -194,17 +193,7 @@ pub(crate) fn trimmed_option(value: Option<&str>) -> Option<&str> {
 }
 
 pub fn save_file(path: &Path, config: &Config) -> Result<()> {
-    let parent = path.parent().unwrap_or_else(|| Path::new("."));
-    fs::create_dir_all(parent)?;
-
-    let json = serde_json::to_string_pretty(config)?;
-    let mut file = tempfile::NamedTempFile::new_in(parent)?;
-    file.write_all(json.as_bytes())?;
-    file.write_all(b"\n")?;
-    file.as_file().sync_all()?;
-    file.persist(path)?;
-
-    Ok(())
+    crate::utils::write_json_atomic(path, config)
 }
 
 pub fn save_global(config: &Config) -> Result<()> {

--- a/src/datasets/pipeline.rs
+++ b/src/datasets/pipeline.rs
@@ -28,9 +28,9 @@ use crate::sync::discovery::{
 };
 use crate::sync::{
     artifact_base_dir, artifact_spec_dir, create_jsonl_file_writer, epoch_seconds, read_json_file,
-    read_jsonl_values, stable_spec_hash, write_json_atomic, write_jsonl_value, SyncPushFileArgs,
+    read_jsonl_values, stable_spec_hash, write_jsonl_value, SyncPushFileArgs,
 };
-use crate::utils::parse_duration_to_seconds;
+use crate::utils::{parse_duration_to_seconds, write_json_atomic};
 use tokio::sync::mpsc;
 
 use super::{api as datasets_api, records, utils, ResolvedContext};

--- a/src/setup/mod.rs
+++ b/src/setup/mod.rs
@@ -22,7 +22,7 @@ use crate::auth::LoginContext;
 use crate::config;
 use crate::http::ApiClient;
 use crate::ui::{self, with_spinner};
-use crate::utils::app_project_url;
+use crate::utils::{app_project_url, write_json_atomic, write_text_atomic};
 
 mod agent_stream;
 mod docs;
@@ -5008,45 +5008,19 @@ fn load_toml_table_or_default(path: &Path) -> Result<toml::map::Map<String, Toml
 }
 
 fn write_json_object(path: &Path, object: &Map<String, Value>) -> Result<()> {
-    let data = serde_json::to_string_pretty(&Value::Object(object.clone()))
-        .with_context(|| format!("failed to serialize JSON for {}", path.display()))?;
-
-    if let Some(parent) = path.parent() {
-        fs::create_dir_all(parent)
-            .with_context(|| format!("failed to create directory {}", parent.display()))?;
-    }
-
-    let tmp = path.with_extension("tmp");
-    fs::write(&tmp, format!("{data}\n"))
-        .with_context(|| format!("failed to finalize temp JSON file {}", tmp.display()))?;
-    fs::rename(&tmp, path).with_context(|| format!("failed to replace {}", path.display()))?;
-
-    Ok(())
+    write_json_atomic(path, object)
 }
 
 fn write_toml_table(path: &Path, table: &toml::map::Map<String, TomlValue>) -> Result<()> {
     let data = toml::to_string_pretty(&TomlValue::Table(table.clone()))
         .with_context(|| format!("failed to serialize TOML for {}", path.display()))?;
 
-    if let Some(parent) = path.parent() {
-        fs::create_dir_all(parent)
-            .with_context(|| format!("failed to create directory {}", parent.display()))?;
-    }
-
-    let tmp = path.with_extension("tmp");
-    fs::write(&tmp, format!("{data}\n"))
-        .with_context(|| format!("failed to finalize temp TOML file {}", tmp.display()))?;
-    fs::rename(&tmp, path).with_context(|| format!("failed to replace {}", path.display()))?;
-
-    Ok(())
+    write_text_atomic(path, &format!("{data}\n"))
 }
 
 pub(super) fn write_text_file(path: &Path, content: &str) -> Result<()> {
-    if let Some(parent) = path.parent() {
-        fs::create_dir_all(parent)
-            .with_context(|| format!("failed to create directory {}", parent.display()))?;
-    }
-    fs::write(path, format!("{}\n", content.trim_end()))
+    let normalized = format!("{}\n", content.trim_end());
+    write_text_atomic(path, &normalized)
         .with_context(|| format!("failed to write {}", path.display()))
 }
 

--- a/src/sync.rs
+++ b/src/sync.rs
@@ -26,7 +26,7 @@ use crate::experiments::api::create_experiment;
 use crate::http::ApiClient;
 use crate::projects::api::{create_project, list_projects, Project};
 use crate::ui::{animations_enabled, fuzzy_select, is_quiet};
-use crate::utils::{app_project_url, parse_duration_to_seconds};
+use crate::utils::{app_project_url, parse_duration_to_seconds, write_json_atomic};
 
 pub(crate) mod discovery;
 
@@ -4594,25 +4594,6 @@ fn value_as_string(value: Option<&Value>) -> Option<String> {
         Some(Value::Number(n)) => Some(n.to_string()),
         _ => None,
     }
-}
-
-pub(crate) fn write_json_atomic<T: Serialize>(path: &Path, value: &T) -> Result<()> {
-    let parent = path
-        .parent()
-        .ok_or_else(|| anyhow!("path has no parent: {}", path.display()))?;
-    fs::create_dir_all(parent).with_context(|| format!("failed to create {}", parent.display()))?;
-
-    let bytes = serde_json::to_vec_pretty(value).context("failed to serialize JSON")?;
-    let tmp = path.with_extension("tmp");
-    fs::write(&tmp, bytes).with_context(|| format!("failed to write {}", tmp.display()))?;
-    fs::rename(&tmp, path).with_context(|| {
-        format!(
-            "failed to move temporary file {} to {}",
-            tmp.display(),
-            path.display()
-        )
-    })?;
-    Ok(())
 }
 
 pub(crate) fn read_json_file<T: DeserializeOwned>(path: &Path) -> Result<T> {

--- a/src/utils/fs_atomic.rs
+++ b/src/utils/fs_atomic.rs
@@ -1,12 +1,50 @@
+use std::io::Write as _;
 use std::path::Path;
 
 use anyhow::{Context, Result};
+use serde::Serialize;
+use tempfile::Builder;
+
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum Visibility {
+    Default,
+    Private,
+}
+
+#[cfg(unix)]
+impl Visibility {
+    fn mode(self) -> u32 {
+        match self {
+            Visibility::Default => 0o644,
+            Visibility::Private => 0o600,
+        }
+    }
+}
 
 pub fn write_text_atomic(path: &Path, contents: &str) -> Result<()> {
     write_bytes_atomic(path, contents.as_bytes())
 }
 
+pub fn write_json_atomic<T: Serialize>(path: &Path, value: &T) -> Result<()> {
+    write_json(path, value, Visibility::Default)
+}
+
+pub fn write_json_atomic_private<T: Serialize>(path: &Path, value: &T) -> Result<()> {
+    write_json(path, value, Visibility::Private)
+}
+
+fn write_json<T: Serialize>(path: &Path, value: &T, visibility: Visibility) -> Result<()> {
+    let mut json = serde_json::to_string_pretty(value)
+        .with_context(|| format!("failed to serialize {}", path.display()))?;
+    json.push('\n');
+    write_atomic(path, json.as_bytes(), visibility)
+}
+
 pub fn write_bytes_atomic(path: &Path, contents: &[u8]) -> Result<()> {
+    write_atomic(path, contents, Visibility::Default)
+}
+
+fn write_atomic(path: &Path, contents: &[u8], visibility: Visibility) -> Result<()> {
     let parent = path.parent().ok_or_else(|| {
         anyhow::anyhow!(
             "cannot atomically write {} because it has no parent directory",
@@ -17,104 +55,25 @@ pub fn write_bytes_atomic(path: &Path, contents: &[u8]) -> Result<()> {
     std::fs::create_dir_all(parent)
         .with_context(|| format!("failed to create parent directory {}", parent.display()))?;
 
-    let nonce = std::time::SystemTime::now()
-        .duration_since(std::time::UNIX_EPOCH)
-        .context("failed to read system time for atomic write")?
-        .as_nanos();
-    let pid = std::process::id();
-
-    let file_name = path
-        .file_name()
-        .and_then(|name| name.to_str())
-        .ok_or_else(|| anyhow::anyhow!("invalid target file name: {}", path.display()))?;
-
-    let tmp = parent.join(format!(".{file_name}.tmp.{pid}.{nonce}"));
-
-    std::fs::write(&tmp, contents)
-        .with_context(|| format!("failed to write temporary file {}", tmp.display()))?;
-
-    replace_file_atomic(&tmp, path)?;
-
-    Ok(())
-}
-
-#[cfg(not(windows))]
-fn replace_file_atomic(tmp: &Path, path: &Path) -> Result<()> {
-    std::fs::rename(tmp, path).with_context(|| {
-        format!(
-            "failed to replace {} with temporary file {}",
-            path.display(),
-            tmp.display()
-        )
-    })?;
-    Ok(())
-}
-
-#[cfg(windows)]
-fn replace_file_atomic(tmp: &Path, path: &Path) -> Result<()> {
-    if path.exists() {
-        replace_existing_file_windows(tmp, path)?;
-        return Ok(());
+    let mut builder = Builder::new();
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        builder.permissions(std::fs::Permissions::from_mode(visibility.mode()));
     }
+    #[cfg(not(unix))]
+    let _ = visibility;
 
-    let rename_attempt = std::fs::rename(tmp, path);
-    if rename_attempt.is_ok() {
-        return Ok(());
-    }
+    let mut file = builder
+        .tempfile_in(parent)
+        .with_context(|| format!("failed to create temporary file in {}", parent.display()))?;
 
-    if path.exists() {
-        replace_existing_file_windows(tmp, path)?;
-        return Ok(());
-    }
+    file.write_all(contents)
+        .with_context(|| format!("failed to write temporary file for {}", path.display()))?;
 
-    rename_attempt.with_context(|| {
-        format!(
-            "failed to replace {} with temporary file {}",
-            path.display(),
-            tmp.display()
-        )
-    })?;
-    Ok(())
-}
-
-#[cfg(windows)]
-fn replace_existing_file_windows(tmp: &Path, path: &Path) -> Result<()> {
-    use std::iter;
-    use std::os::windows::ffi::OsStrExt;
-    use windows_sys::Win32::Storage::FileSystem::ReplaceFileW;
-
-    let target = path
-        .as_os_str()
-        .encode_wide()
-        .chain(iter::once(0))
-        .collect::<Vec<u16>>();
-    let replacement = tmp
-        .as_os_str()
-        .encode_wide()
-        .chain(iter::once(0))
-        .collect::<Vec<u16>>();
-
-    // SAFETY: Both paths are null-terminated UTF-16 strings with stable backing
-    // storage for the duration of the call, and optional pointers are null.
-    let replaced = unsafe {
-        ReplaceFileW(
-            target.as_ptr(),
-            replacement.as_ptr(),
-            std::ptr::null(),
-            0,
-            std::ptr::null_mut(),
-            std::ptr::null_mut(),
-        )
-    };
-    if replaced == 0 {
-        return Err(std::io::Error::last_os_error()).with_context(|| {
-            format!(
-                "failed to replace {} with temporary file {}",
-                path.display(),
-                tmp.display()
-            )
-        });
-    }
+    file.persist(path)
+        .map_err(|err| err.error)
+        .with_context(|| format!("failed to replace {}", path.display()))?;
 
     Ok(())
 }
@@ -127,21 +86,45 @@ mod tests {
     #[test]
     fn write_text_atomic_creates_file() {
         let tmp = tempdir().expect("tempdir");
-        let path = tmp.path().join("file.txt");
+        let path = tmp.path().join("nested").join("out.txt");
 
         write_text_atomic(&path, "hello").expect("write");
-        let contents = std::fs::read_to_string(&path).expect("read");
-        assert_eq!(contents, "hello");
+
+        assert_eq!(std::fs::read_to_string(&path).expect("read"), "hello");
     }
 
     #[test]
     fn write_text_atomic_overwrites_existing_file() {
         let tmp = tempdir().expect("tempdir");
-        let path = tmp.path().join("file.txt");
+        let path = tmp.path().join("out.txt");
         std::fs::write(&path, "old").expect("seed file");
 
-        write_text_atomic(&path, "new").expect("overwrite");
-        let contents = std::fs::read_to_string(&path).expect("read");
-        assert_eq!(contents, "new");
+        write_text_atomic(&path, "new").expect("write");
+
+        assert_eq!(std::fs::read_to_string(&path).expect("read"), "new");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn write_json_atomic_private_tightens_existing_permissions() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let tmp = tempdir().expect("tempdir");
+        let path = tmp.path().join("secrets.json");
+        std::fs::write(&path, "{}").expect("seed file");
+        std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o644))
+            .expect("seed permissions");
+
+        write_json_atomic_private(&path, &serde_json::json!({"secrets": {}})).expect("write");
+
+        let mode = std::fs::metadata(&path)
+            .expect("metadata")
+            .permissions()
+            .mode();
+        assert_eq!(mode & 0o777, 0o600);
+        assert_eq!(
+            std::fs::read_to_string(&path).expect("read"),
+            "{\n  \"secrets\": {}\n}\n"
+        );
     }
 }

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -9,7 +9,9 @@ mod profile;
 
 pub(crate) use app_url::{app_project_url, app_project_url_with_encoded_path};
 pub use duration::parse_duration_to_seconds;
-pub use fs_atomic::{write_bytes_atomic, write_text_atomic};
+pub use fs_atomic::{
+    write_bytes_atomic, write_json_atomic, write_json_atomic_private, write_text_atomic,
+};
 pub use git::GitRepo;
 pub(crate) use ids::new_uuid_id;
 pub(crate) use json_object::lookup_object_path;


### PR DESCRIPTION
We were both using the tempfile crate and reinventing what it does.
The reinvention has been removed. They were the only place where windows-sys was directly called, thus the Cargo.toml change.

## AI summary:

The changes consolidate file-writing logic around shared atomic-write helpers in src/utils/fs_atomic.rs.

### Main behavior changes

- Adds shared helpers:
    - write_json_atomic
    - write_json_atomic_private
    - Existing write_text_atomic / write_bytes_atomic now use the same implementation.
- Writes now:
    1. Create missing parent directories.
    2. Create a uniquely named temporary file in the destination directory.
    3. Write the full contents.
    4. Atomically persist/rename it over the destination.
- JSON output is pretty-printed and ends with a newline.
- Private JSON files use Unix permissions 0600; normal files use 0644.

### Call sites migrated

The shared helpers now write:

- Auth config and secret stores (src/auth.rs)
- AI provider warning state
- Global/project config (src/config/mod.rs)
- Dataset/sync JSON artifacts
- Setup-generated JSON, TOML, and text files (src/setup/mod.rs)

This removes several duplicated implementations that used fixed .tmp filenames or direct writes. Setup text files, previously written directly, are now atomic too.

### Platform/dependency changes

- Removes the Windows-specific ReplaceFileW implementation.
- Removes the direct windows-sys dependency.
- Uses tempfile::NamedTempFile::persist on all platforms instead.

### Tests

Tests now cover:

- Creation of nested parent directories.
- Overwriting existing files.
- Tightening private JSON file permissions to 0600.

One notable semantic difference is that the new common writer no longer explicitly calls sync_all() before persisting, unlike some of the
previous implementations. It protects against partial-file visibility, but provides weaker guarantees against sudden power loss.