### PR TITLE
feat: Add auto instrumentation for js eval runner

### DIFF
--- a/scripts/eval-runner-impl.ts
+++ b/scripts/eval-runner-impl.ts
@@ -121,6 +121,7 @@ type RunnerConfig = {
   jsonl: boolean;
   list: boolean;
   terminateOnFailure: boolean;
+  autoInstrumentation: boolean;
   filters: EvalFilter[];
   first: number | null;
   sample: number | null;
@@ -420,6 +421,7 @@ function readRunnerConfig(): RunnerConfig {
     jsonl: envFlag("BT_EVAL_JSONL"),
     list: envFlag("BT_EVAL_LIST"),
     terminateOnFailure: envFlag("BT_EVAL_TERMINATE_ON_FAILURE"),
+    autoInstrumentation: !envFlag("BT_EVAL_NO_AUTO_INSTRUMENTATION"),
     filters: parseSerializedFilters(process.env.BT_EVAL_FILTER_PARSED),
     first: parsePositiveIntegerEnv("BT_EVAL_FIRST"),
     sample: parsePositiveIntegerEnv("BT_EVAL_SAMPLE"),
@@ -953,6 +955,21 @@ function initRegistry() {
 
 function ensureBraintrustAvailable() {
   resolveBraintrustPath();
+}
+
+function applyAutoInstrumentation() {
+  try {
+    const braintrustPath = resolveBraintrustPath();
+    const requireFromBraintrust = createRequire(
+      pathToFileURL(braintrustPath).href,
+    );
+    requireFromBraintrust("braintrust/apply-auto-instrumentation");
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    console.error(
+      `Warning: Failed to apply Braintrust auto-instrumentation; continuing without it: ${message}`,
+    );
+  }
 }
 
 function resolveBraintrustPath(): string {
@@ -2437,6 +2454,11 @@ export async function main() {
   }
   collectStaticLocalDependencies(normalized);
   ensureBraintrustAvailable();
+  // Install loader hooks before the SDK or eval modules can load instrumented
+  // dependencies, including clients constructed inside third-party packages.
+  if (config.autoInstrumentation) {
+    applyAutoInstrumentation();
+  }
   injectRuntimeValues(config);
   const braintrust = await loadBraintrust();
   propagateInheritedBraintrustState(braintrust);

--- a/src/eval.rs
+++ b/src/eval.rs
@@ -1021,7 +1021,10 @@ where
                 });
             }
             EvalEvent::Console { stream, message } => {
-                if stream == "stderr" && matches!(console_policy, ConsolePolicy::BufferStderr) {
+                if stream == "stderr"
+                    && !message.starts_with("Warning:")
+                    && matches!(console_policy, ConsolePolicy::BufferStderr)
+                {
                     stderr_lines.push(message);
                 } else {
                     on_event(EvalEvent::Console { stream, message });
@@ -2898,9 +2901,11 @@ impl EvalUi {
             }
             EvalEvent::Dependencies { .. } => {}
             EvalEvent::Console { stream, message } => {
-                if stream == "stdout" && (self.list || self.jsonl) {
+                if stream == "stderr" && message.starts_with("Warning:") {
+                    self.print_persistent_line(message);
+                } else if stream == "stdout" && (self.list || self.jsonl) {
                     println!("{message}");
-                } else if stream == "stderr" && !self.verbose && !message.starts_with("Warning:") {
+                } else if stream == "stderr" && !self.verbose {
                     self.suppressed_stderr_lines += 1;
                 } else {
                     let _ = self.progress.println(message);

--- a/src/eval.rs
+++ b/src/eval.rs
@@ -394,6 +394,15 @@ pub struct EvalArgs {
     #[arg(last = true, value_name = "ARG")]
     pub extra_args: Vec<String>,
 
+    /// Disable automatic instrumentation of supported JavaScript LLM SDKs.
+    #[arg(
+        long,
+        env = "BT_EVAL_NO_AUTO_INSTRUMENTATION",
+        value_parser = clap::builder::BoolishValueParser::new(),
+        default_value_t = false
+    )]
+    pub no_auto_instrumentation: bool,
+
     /// Start the eval dev web server.
     #[arg(
         long,
@@ -443,6 +452,7 @@ struct EvalRunOptions {
     sampling: EvalSamplingMode,
     verbose: bool,
     extra_args: Vec<String>,
+    auto_instrumentation: bool,
     params: Vec<String>,
     matrix_axes: Vec<(String, Vec<serde_json::Value>)>,
 }
@@ -494,6 +504,7 @@ pub async fn run(base: BaseArgs, args: EvalArgs) -> Result<()> {
         verbose: base.verbose,
         sampling,
         extra_args: args.extra_args,
+        auto_instrumentation: !args.no_auto_instrumentation,
         params: args.param,
         matrix_axes,
     };
@@ -878,6 +889,9 @@ async fn spawn_eval_runner(
             RunnerKind::Other => "other",
         };
         cmd.env("BT_EVAL_RUNNER_KIND", runner_name);
+        if !options.auto_instrumentation {
+            cmd.env("BT_EVAL_NO_AUTO_INSTRUMENTATION", "1");
+        }
     }
     if !options.extra_args.is_empty() {
         let serialized =
@@ -4838,6 +4852,7 @@ mod tests {
             "BT_EVAL_SAMPLE",
             "BT_EVAL_SAMPLE_SEED",
             "BT_EVAL_WATCH",
+            "BT_EVAL_NO_AUTO_INSTRUMENTATION",
             "BT_EVAL_DEV",
             "BT_EVAL_DEV_HOST",
             "BT_EVAL_DEV_PORT",
@@ -4851,6 +4866,7 @@ mod tests {
         set_env_var("BT_EVAL_LIST", "yes");
         set_env_var("BT_EVAL_FILTER", "metadata.case=smoke.*,metadata.kind=fast");
         set_env_var("BT_EVAL_WATCH", "on");
+        set_env_var("BT_EVAL_NO_AUTO_INSTRUMENTATION", "true");
         set_env_var("BT_EVAL_DEV", "true");
         set_env_var("BT_EVAL_DEV_HOST", "127.0.0.1");
         set_env_var("BT_EVAL_DEV_PORT", "9999");
@@ -4870,6 +4886,7 @@ mod tests {
             ]
         );
         assert!(parsed.eval.watch);
+        assert!(parsed.eval.no_auto_instrumentation);
         assert!(parsed.eval.dev);
         assert_eq!(parsed.eval.dev_host, "127.0.0.1");
         assert_eq!(parsed.eval.dev_port, 9999);

--- a/src/eval.rs
+++ b/src/eval.rs
@@ -2900,7 +2900,7 @@ impl EvalUi {
             EvalEvent::Console { stream, message } => {
                 if stream == "stdout" && (self.list || self.jsonl) {
                     println!("{message}");
-                } else if stream == "stderr" && !self.verbose {
+                } else if stream == "stderr" && !self.verbose && !message.starts_with("Warning:") {
                     self.suppressed_stderr_lines += 1;
                 } else {
                     let _ = self.progress.println(message);

--- a/tests/eval_fixtures.rs
+++ b/tests/eval_fixtures.rs
@@ -205,6 +205,46 @@ fn eval_fixtures() {
 }
 
 #[test]
+fn eval_auto_instrumentation_failure_warns_and_continues() {
+    let _guard = test_lock();
+    if !command_exists("node") {
+        if required_runtimes().contains("node") {
+            panic!("node runtime is required but not installed");
+        }
+        eprintln!("Skipping auto-instrumentation failure test (node not installed).");
+        return;
+    }
+
+    let root = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    let fixture_dir = root
+        .join("tests")
+        .join("evals")
+        .join("js")
+        .join("eval-sample-init-dataset");
+    ensure_dependencies(&fixture_dir);
+
+    let output = Command::new(bt_binary_path(&root))
+        .args(["eval", "--sample", "5", "sample-init-dataset.eval.cjs"])
+        .current_dir(&fixture_dir)
+        .env("BT_EVAL_LOCAL", "1")
+        .env("BT_TEST_AUTO_INSTRUMENTATION_FAILURE", "1")
+        .output()
+        .expect("run eval with synthetic auto-instrumentation failure");
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        output.status.success(),
+        "auto-instrumentation failure should not fail the eval\nstderr:\n{stderr}"
+    );
+    assert!(
+        stderr.contains(
+            "Warning: Failed to apply Braintrust auto-instrumentation; continuing without it:"
+        ),
+        "auto-instrumentation failure should be logged\nstderr:\n{stderr}"
+    );
+}
+
+#[test]
 fn eval_watch_js_dependency_retriggers() {
     let _guard = test_lock();
     if !command_exists("node") {

--- a/tests/evals/js/eval-sample-init-dataset/auto-instrumentation.eval.mjs
+++ b/tests/evals/js/eval-sample-init-dataset/auto-instrumentation.eval.mjs
@@ -1,0 +1,19 @@
+import { Eval } from "braintrust";
+import { autoInstrumented } from "esm-instrumentation-target";
+
+if (!autoInstrumented) {
+  throw new Error(
+    "Braintrust auto-instrumentation did not transform an ESM import",
+  );
+}
+
+Eval("auto-instrumentation-esm", {
+  data: [{ input: "instrumented", expected: "instrumented" }],
+  task: async (input) => input,
+  scores: [
+    ({ output, expected }) => ({
+      name: "exact_match",
+      score: output === expected ? 1 : 0,
+    }),
+  ],
+});

--- a/tests/evals/js/eval-sample-init-dataset/esm-instrumentation-target/index.mjs
+++ b/tests/evals/js/eval-sample-init-dataset/esm-instrumentation-target/index.mjs
@@ -1,0 +1,1 @@
+export const autoInstrumented = false;

--- a/tests/evals/js/eval-sample-init-dataset/esm-instrumentation-target/package.json
+++ b/tests/evals/js/eval-sample-init-dataset/esm-instrumentation-target/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "esm-instrumentation-target",
+  "version": "0.0.0-test",
+  "type": "module",
+  "exports": "./index.mjs"
+}

--- a/tests/evals/js/eval-sample-init-dataset/fixture.json
+++ b/tests/evals/js/eval-sample-init-dataset/fixture.json
@@ -1,4 +1,5 @@
 {
-  "files": ["sample-init-dataset.eval.cjs"],
+  "files": ["auto-instrumentation.eval.mjs", "sample-init-dataset.eval.cjs"],
+  "runners": ["tsx", "vite-node"],
   "args": ["--sample", "5"]
 }

--- a/tests/evals/js/eval-sample-init-dataset/local-braintrust/dist/apply-auto-instrumentation.js
+++ b/tests/evals/js/eval-sample-init-dataset/local-braintrust/dist/apply-auto-instrumentation.js
@@ -1,0 +1,11 @@
+if (process.env.BT_TEST_AUTO_INSTRUMENTATION_FAILURE) {
+  throw new Error("synthetic auto-instrumentation failure");
+}
+
+const { register } = require("node:module");
+const { pathToFileURL } = require("node:url");
+
+register("./esm-auto-instrumentation-hook.mjs", {
+  parentURL: pathToFileURL(__filename).href,
+});
+globalThis.__btAutoInstrumentationApplied = true;

--- a/tests/evals/js/eval-sample-init-dataset/local-braintrust/dist/esm-auto-instrumentation-hook.mjs
+++ b/tests/evals/js/eval-sample-init-dataset/local-braintrust/dist/esm-auto-instrumentation-hook.mjs
@@ -1,0 +1,18 @@
+export async function load(url, context, nextLoad) {
+  const result = await nextLoad(url, context);
+  if (!url.endsWith("/esm-instrumentation-target/index.mjs")) {
+    return result;
+  }
+
+  const source =
+    typeof result.source === "string"
+      ? result.source
+      : new TextDecoder().decode(result.source);
+  return {
+    ...result,
+    source: source.replace(
+      "export const autoInstrumented = false;",
+      "export const autoInstrumented = true;",
+    ),
+  };
+}

--- a/tests/evals/js/eval-sample-init-dataset/local-braintrust/package.json
+++ b/tests/evals/js/eval-sample-init-dataset/local-braintrust/package.json
@@ -3,6 +3,7 @@
   "version": "0.0.0-local",
   "main": "./dist/index.js",
   "exports": {
-    ".": "./dist/index.js"
+    ".": "./dist/index.js",
+    "./apply-auto-instrumentation": "./dist/apply-auto-instrumentation.js"
   }
 }

--- a/tests/evals/js/eval-sample-init-dataset/package.json
+++ b/tests/evals/js/eval-sample-init-dataset/package.json
@@ -2,7 +2,7 @@
   "name": "bt-eval-sample-init-dataset",
   "private": true,
   "dependencies": {
-    "braintrust": "link:./local-braintrust",
+    "braintrust": "file:./local-braintrust",
     "esm-instrumentation-target": "file:./esm-instrumentation-target"
   },
   "devDependencies": {

--- a/tests/evals/js/eval-sample-init-dataset/package.json
+++ b/tests/evals/js/eval-sample-init-dataset/package.json
@@ -2,9 +2,11 @@
   "name": "bt-eval-sample-init-dataset",
   "private": true,
   "dependencies": {
-    "braintrust": "link:./local-braintrust"
+    "braintrust": "link:./local-braintrust",
+    "esm-instrumentation-target": "file:./esm-instrumentation-target"
   },
   "devDependencies": {
-    "tsx": "^4.16.2"
+    "tsx": "^4.16.2",
+    "vite-node": "^6.0.0"
   }
 }

--- a/tests/evals/js/eval-sample-init-dataset/sample-init-dataset.eval.cjs
+++ b/tests/evals/js/eval-sample-init-dataset/sample-init-dataset.eval.cjs
@@ -1,5 +1,14 @@
 const { Eval, initDataset } = require("braintrust");
 
+if (
+  !globalThis.__btAutoInstrumentationApplied &&
+  !process.env.BT_TEST_AUTO_INSTRUMENTATION_FAILURE
+) {
+  throw new Error(
+    "Braintrust auto-instrumentation was not applied before loading the eval file",
+  );
+}
+
 function exactMatch({ output, expected }) {
   return { name: "exact_match", score: output === expected ? 1 : 0 };
 }


### PR DESCRIPTION
Ref [SDK-149](https://linear.app/braintrustdata/issue/SDK-149/support-auto-instrumentation-in-js-remote-evals-for-bundled)