### PR TITLE
feat(functions): update functions tools and scorers

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,7 +150,9 @@ Remove-Item -Recurse -Force (Join-Path $env:APPDATA "bt") -ErrorAction SilentlyC
 | `bt projects` | Manage projects (list, create, view, delete)                       |
 | `bt datasets` | Manage remote datasets (list, create, update, view, delete)        |
 | `bt prompts`  | Manage prompts (list, view, delete)                                |
-| `bt scorers`  | Manage scorers (list, create, view, invoke, delete)                |
+| `bt functions` | Manage functions (list, view, invoke, update, push, pull, delete) |
+| `bt tools`     | Manage tools (list, view, invoke, update, delete)                  |
+| `bt scorers`  | Manage scorers (list, create, view, invoke, update, delete)        |
 | `bt sync`     | Synchronize project logs between Braintrust and local NDJSON files |
 | `bt update`   | Update bt in-place                                                 |
 
@@ -174,6 +176,17 @@ bt scorers create "Safety label" \
 Use `--if-exists error|ignore|replace` to control slug conflicts. Text and structured input flags accept an inline value, `@PATH`, or `-` for stdin; only one flag per command may read stdin. Use `--template-format mustache|jinja|none`; `nunjucks` and `jinja2` are accepted aliases for Jinja. Model options include `--use-cache[=true|false]` and `--response-format text|json-object|<SOURCE>`; structured output accepts a full `response_format` JSON object inline or from `@PATH`.
 
 Before writing a scorer, `bt` sends the complete candidate definition to Braintrust for validation. The backend applies the same model-parameter and replacement checks as the write and returns structured issues with normalization suggestions when available.
+
+Update only the fields you specify, or use `--patch` for fields without dedicated flags:
+
+```bash
+bt scorers update helpfulness --messages @messages.json
+bt scorers update helpfulness --model gpt-5.4-nano
+bt functions update my-function --description "Updated"
+bt tools update my-tool --patch @tool-patch.json
+```
+
+The API replaces `prompt_data` rather than merging it, so `bt` reads the current definition and sends a materialized replacement with your changes. A concurrent edit can therefore be overwritten.
 
 For TypeScript and Python code scorers, use the Braintrust SDK and `bt functions push`.
 

--- a/README.md
+++ b/README.md
@@ -181,9 +181,9 @@ Update only the fields you specify, or use `--patch` for fields without dedicate
 
 ```bash
 bt scorers update helpfulness --messages @messages.json
-bt scorers update helpfulness --model gpt-5.4-nano
-bt functions update my-function --description "Updated"
-bt tools update my-tool --patch @tool-patch.json
+bt scorers update helpfulness --new-slug answer-helpfulness
+bt functions update my-function --name "Updated function" --description "Updated"
+bt tools update my-tool --prompt @prompt.txt --new-slug lookup-order
 ```
 
 The API replaces `prompt_data` rather than merging it, so `bt` reads the current definition and sends a materialized replacement with your changes. A concurrent edit can therefore be overwritten.

--- a/README.md
+++ b/README.md
@@ -135,26 +135,26 @@ Remove-Item -Recurse -Force (Join-Path $env:APPDATA "bt") -ErrorAction SilentlyC
 
 ## Commands
 
-| Command       | Description                                                        |
-| ------------- | ------------------------------------------------------------------ |
-| `bt init`     | Initialize `.bt/` config directory and link to a project           |
-| `bt login`    | Log in to Braintrust or refresh an OAuth login                     |
-| `bt logout`   | Remove a saved Braintrust login                                    |
-| `bt profiles` | List, delete, and rename saved login profiles                      |
-| `bt switch`   | Switch org and project context                                     |
-| `bt status`   | Show current org and project context                               |
-| `bt datasets` | Manage datasets and dataset pipelines                              |
-| `bt eval`     | Run eval files (Unix only)                                         |
-| `bt sql`      | Run SQL queries against Braintrust                                 |
-| `bt view`     | View logs, traces, and spans                                       |
-| `bt projects` | Manage projects (list, create, view, delete)                       |
-| `bt datasets` | Manage remote datasets (list, create, update, view, delete)        |
-| `bt prompts`  | Manage prompts (list, view, delete)                                |
-| `bt functions` | Manage functions (list, view, invoke, update, push, pull, delete) |
+| Command        | Description                                                        |
+| -------------- | ------------------------------------------------------------------ |
+| `bt init`      | Initialize `.bt/` config directory and link to a project           |
+| `bt login`     | Log in to Braintrust or refresh an OAuth login                     |
+| `bt logout`    | Remove a saved Braintrust login                                    |
+| `bt profiles`  | List, delete, and rename saved login profiles                      |
+| `bt switch`    | Switch org and project context                                     |
+| `bt status`    | Show current org and project context                               |
+| `bt datasets`  | Manage datasets and dataset pipelines                              |
+| `bt eval`      | Run eval files (Unix only)                                         |
+| `bt sql`       | Run SQL queries against Braintrust                                 |
+| `bt view`      | View logs, traces, and spans                                       |
+| `bt projects`  | Manage projects (list, create, view, delete)                       |
+| `bt datasets`  | Manage remote datasets (list, create, update, view, delete)        |
+| `bt prompts`   | Manage prompts (list, view, delete)                                |
+| `bt functions` | Manage functions (list, view, invoke, update, push, pull, delete)  |
 | `bt tools`     | Manage tools (list, view, invoke, update, delete)                  |
-| `bt scorers`  | Manage scorers (list, create, view, invoke, update, delete)        |
-| `bt sync`     | Synchronize project logs between Braintrust and local NDJSON files |
-| `bt update`   | Update bt in-place                                                 |
+| `bt scorers`   | Manage scorers (list, create, view, invoke, update, delete)        |
+| `bt sync`      | Synchronize project logs between Braintrust and local NDJSON files |
+| `bt update`    | Update bt in-place                                                 |
 
 ## `bt scorers`
 

--- a/README.md
+++ b/README.md
@@ -173,6 +173,8 @@ bt scorers create "Safety label" \
 
 Use `--if-exists error|ignore|replace` to control slug conflicts. Text and structured input flags accept an inline value, `@PATH`, or `-` for stdin; only one flag per command may read stdin. Use `--template-format mustache|jinja|none`; `nunjucks` and `jinja2` are accepted aliases for Jinja. Model options include `--use-cache[=true|false]` and `--response-format text|json-object|<SOURCE>`; structured output accepts a full `response_format` JSON object inline or from `@PATH`.
 
+Before writing a scorer, `bt` sends the complete candidate definition to Braintrust for validation. The backend applies the same model-parameter and replacement checks as the write and returns structured issues with normalization suggestions when available.
+
 For TypeScript and Python code scorers, use the Braintrust SDK and `bt functions push`.
 
 ## `bt eval`

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,0 +1,27 @@
+use std::fmt;
+
+/// An expected error caused by command input rather than an internal failure.
+#[derive(Debug)]
+pub(crate) struct UserError {
+    source: Box<dyn std::error::Error + Send + Sync>,
+}
+
+impl From<anyhow::Error> for UserError {
+    fn from(error: anyhow::Error) -> Self {
+        Self {
+            source: error.into_boxed_dyn_error(),
+        }
+    }
+}
+
+impl fmt::Display for UserError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.source.fmt(formatter)
+    }
+}
+
+impl std::error::Error for UserError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        Some(self.source.as_ref())
+    }
+}

--- a/src/error.rs
+++ b/src/error.rs
@@ -3,25 +3,18 @@ use std::fmt;
 /// An expected error caused by command input rather than an internal failure.
 #[derive(Debug)]
 pub(crate) struct UserError {
-    source: Box<dyn std::error::Error + Send + Sync>,
-}
-
-impl From<anyhow::Error> for UserError {
-    fn from(error: anyhow::Error) -> Self {
-        Self {
-            source: error.into_boxed_dyn_error(),
-        }
-    }
+    message: String,
 }
 
 impl fmt::Display for UserError {
     fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
-        self.source.fmt(formatter)
+        formatter.write_str(&self.message)
     }
 }
 
-impl std::error::Error for UserError {
-    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
-        Some(self.source.as_ref())
-    }
+impl std::error::Error for UserError {}
+
+pub(crate) fn user_error(error: anyhow::Error) -> anyhow::Error {
+    let message = error.to_string();
+    error.context(UserError { message })
 }

--- a/src/functions/api.rs
+++ b/src/functions/api.rs
@@ -4,7 +4,7 @@ use serde_json::Value;
 use urlencoding::encode;
 
 use crate::{
-    error::UserError,
+    error::user_error,
     http::{ApiClient, HttpError},
 };
 
@@ -206,7 +206,7 @@ pub async fn invoke_function(
                 .downcast_ref::<HttpError>()
                 .is_some_and(is_provider_auth_response) =>
         {
-            Err(UserError::from(error).into())
+            Err(user_error(error))
         }
         Err(error) => Err(error),
     }

--- a/src/functions/api.rs
+++ b/src/functions/api.rs
@@ -252,6 +252,20 @@ pub async fn delete_function(client: &ApiClient, function_id: &str) -> Result<()
     client.delete(&path).await
 }
 
+/// Partially update a function (scorer/tool/prompt/...) by id.
+///
+/// Top-level fields are patched, but object-valued fields such as `prompt_data`
+/// are replaced wholesale. Callers updating `prompt_data` must materialize the
+/// complete value before sending the request.
+pub async fn patch_function(
+    client: &ApiClient,
+    function_id: &str,
+    body: &serde_json::Value,
+) -> Result<serde_json::Value> {
+    let path = format!("/v1/function/{}", encode(function_id));
+    client.patch(&path, body).await
+}
+
 pub async fn list_functions_page(
     client: &ApiClient,
     query: &FunctionListQuery,

--- a/src/functions/api.rs
+++ b/src/functions/api.rs
@@ -3,7 +3,10 @@ use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use urlencoding::encode;
 
-use crate::http::ApiClient;
+use crate::{
+    error::UserError,
+    http::{ApiClient, HttpError},
+};
 
 fn escape_sql(s: &str) -> String {
     s.replace('\'', "''")
@@ -64,6 +67,34 @@ pub struct InsertedFunctionResult {
     pub project_id: String,
     pub slug: String,
     pub found_existing: bool,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct FunctionValidationSuggestion {
+    pub action: String,
+    #[serde(default)]
+    pub value: Option<Value>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct FunctionValidationIssue {
+    pub code: String,
+    pub path: Vec<Value>,
+    pub message: String,
+    pub blocking: bool,
+    #[serde(default)]
+    pub suggestion: Option<FunctionValidationSuggestion>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct FunctionValidationResult {
+    pub issues: Vec<FunctionValidationIssue>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct FunctionValidationReport {
+    pub valid: bool,
+    pub results: Vec<FunctionValidationResult>,
 }
 
 #[derive(Debug, Clone)]
@@ -164,9 +195,43 @@ pub async fn invoke_function(
         Vec::new()
     };
     let timeout = std::time::Duration::from_secs(300);
-    client
+    let result = client
         .post_with_headers_timeout("/function/invoke", body, &headers, Some(timeout))
-        .await
+        .await;
+
+    match result {
+        Ok(value) => Ok(value),
+        Err(error)
+            if error
+                .downcast_ref::<HttpError>()
+                .is_some_and(is_provider_auth_response) =>
+        {
+            Err(UserError::from(error).into())
+        }
+        Err(error) => Err(error),
+    }
+}
+
+fn is_provider_auth_response(error: &HttpError) -> bool {
+    if error.status != reqwest::StatusCode::UNAUTHORIZED
+        && error.status != reqwest::StatusCode::FORBIDDEN
+    {
+        return false;
+    }
+
+    let Ok(body) = serde_json::from_str::<Value>(&error.body) else {
+        return false;
+    };
+    let provider_error = body.get("error").unwrap_or(&body);
+    provider_error.get("code").and_then(Value::as_str) == Some("invalid_api_key")
+        || provider_error
+            .get("message")
+            .and_then(Value::as_str)
+            .is_some_and(|message| {
+                let message = message.to_ascii_lowercase();
+                message.contains("incorrect api key provided")
+                    || message.contains("llm provider") && message.contains("credential")
+            })
 }
 
 pub async fn delete_function(client: &ApiClient, function_id: &str) -> Result<()> {
@@ -278,6 +343,26 @@ pub async fn upload_bundle(
         .context("failed to upload code bundle to signed URL")
 }
 
+pub async fn validate_functions(
+    client: &ApiClient,
+    functions: &[Value],
+) -> Result<FunctionValidationReport> {
+    let body = insert_functions_body(functions);
+    match client.post("/validate-functions", &body).await {
+        Ok(report) => Ok(report),
+        Err(error) => {
+            let Some(http_error) = error.downcast_ref::<HttpError>() else {
+                return Err(error).context("failed to validate functions");
+            };
+            if http_error.status != reqwest::StatusCode::UNPROCESSABLE_ENTITY {
+                return Err(error).context("failed to validate functions");
+            }
+            serde_json::from_str(&http_error.body)
+                .context("unexpected validate-functions error response shape")
+        }
+    }
+}
+
 pub async fn insert_functions(
     client: &ApiClient,
     functions: &[Value],
@@ -332,6 +417,27 @@ fn ignored_count_from_function_results(raw: &Value, requests: &[Value]) -> Optio
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn provider_auth_detection_requires_an_auth_status_and_provider_shape() {
+        let provider_error = HttpError {
+            status: reqwest::StatusCode::UNAUTHORIZED,
+            body: serde_json::json!({
+                "error": {
+                    "message": "Incorrect API key provided: synthetic-key",
+                    "code": "invalid_api_key"
+                }
+            })
+            .to_string(),
+        };
+        assert!(is_provider_auth_response(&provider_error));
+
+        let bad_request = HttpError {
+            status: reqwest::StatusCode::BAD_REQUEST,
+            body: provider_error.body,
+        };
+        assert!(!is_provider_auth_response(&bad_request));
+    }
 
     #[test]
     fn scorer_list_query_matches_web_ui_filter() {

--- a/src/functions/api.rs
+++ b/src/functions/api.rs
@@ -97,6 +97,19 @@ pub struct FunctionValidationReport {
     pub results: Vec<FunctionValidationResult>,
 }
 
+#[derive(Debug)]
+pub struct FunctionValidationError {
+    pub report: FunctionValidationReport,
+}
+
+impl std::fmt::Display for FunctionValidationError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str("the backend rejected the function definition")
+    }
+}
+
+impl std::error::Error for FunctionValidationError {}
+
 #[derive(Debug, Clone)]
 pub struct InsertFunctionsResult {
     pub ignored_entries: Option<usize>,
@@ -343,35 +356,25 @@ pub async fn upload_bundle(
         .context("failed to upload code bundle to signed URL")
 }
 
-pub async fn validate_functions(
-    client: &ApiClient,
-    functions: &[Value],
-) -> Result<FunctionValidationReport> {
-    let body = insert_functions_body(functions);
-    match client.post("/validate-functions", &body).await {
-        Ok(report) => Ok(report),
-        Err(error) => {
-            let Some(http_error) = error.downcast_ref::<HttpError>() else {
-                return Err(error).context("failed to validate functions");
-            };
-            if http_error.status != reqwest::StatusCode::UNPROCESSABLE_ENTITY {
-                return Err(error).context("failed to validate functions");
-            }
-            serde_json::from_str(&http_error.body)
-                .context("unexpected validate-functions error response shape")
-        }
-    }
-}
-
 pub async fn insert_functions(
     client: &ApiClient,
     functions: &[Value],
 ) -> Result<InsertFunctionsResult> {
     let body = insert_functions_body(functions);
-    let raw: Value = client
-        .post("/insert-functions", &body)
-        .await
-        .context("failed to insert functions")?;
+    let raw: Value = match client.post("/insert-functions", &body).await {
+        Ok(raw) => raw,
+        Err(error) => {
+            let Some(http_error) = error.downcast_ref::<HttpError>() else {
+                return Err(error).context("failed to insert functions");
+            };
+            if http_error.status != reqwest::StatusCode::UNPROCESSABLE_ENTITY {
+                return Err(error).context("failed to insert functions");
+            }
+            let report = serde_json::from_str(&http_error.body)
+                .context("unexpected insert-functions validation error response shape")?;
+            return Err(FunctionValidationError { report }.into());
+        }
+    };
 
     let response: InsertFunctionsResponse = serde_json::from_value(raw.clone())
         .context("unexpected insert-functions response shape")?;

--- a/src/functions/create.rs
+++ b/src/functions/create.rs
@@ -4,6 +4,7 @@ use dialoguer::Input;
 use serde_json::{json, Map, Value};
 
 use crate::{
+    error::UserError,
     ui::{is_interactive, print_command_status, with_spinner, CommandStatus},
     utils::{merge_json_objects, read_text_source, read_yaml_object_source},
 };
@@ -49,10 +50,10 @@ TypeScript and Python code scorers:
 ")]
 pub(crate) struct CreateArgs {
     /// Scorer name.
-    #[arg(value_name = "NAME", conflicts_with = "name")]
+    #[arg(value_name = "NAME")]
     name_positional: Option<String>,
 
-    /// Scorer name (alternative to the positional name).
+    /// Scorer name (named form).
     #[arg(long, value_name = "NAME")]
     name: Option<String>,
 
@@ -116,9 +117,16 @@ pub(crate) struct CreateArgs {
 }
 
 pub(crate) async fn run(ctx: &ResolvedContext, args: &CreateArgs, json_output: bool) -> Result<()> {
-    let name = resolve_name(args)?;
-    let slug = resolve_slug(args, &name)?;
-    let definition = build_scorer_definition(args, &ctx.project.id, &name, &slug)?;
+    let name = resolve_name(args).map_err(UserError::from)?;
+    let slug = resolve_slug(args, &name).map_err(UserError::from)?;
+    let definition =
+        build_scorer_definition(args, &ctx.project.id, &name, &slug).map_err(UserError::from)?;
+    let validation = with_spinner(
+        "Validating scorer...",
+        api::validate_functions(&ctx.client, std::slice::from_ref(&definition)),
+    )
+    .await?;
+    report_validation_issues(&validation).map_err(UserError::from)?;
 
     let result = match with_spinner(
         "Creating scorer...",
@@ -168,16 +176,62 @@ pub(crate) async fn run(ctx: &ResolvedContext, args: &CreateArgs, json_output: b
     Ok(())
 }
 
+fn report_validation_issues(report: &api::FunctionValidationReport) -> Result<()> {
+    let mut blocking = Vec::new();
+    for result in &report.results {
+        for issue in &result.issues {
+            let path = issue
+                .path
+                .iter()
+                .map(|part| {
+                    part.as_str()
+                        .map(ToOwned::to_owned)
+                        .unwrap_or_else(|| part.to_string())
+                })
+                .collect::<Vec<_>>()
+                .join(".");
+            let location = if path.is_empty() {
+                issue.code.clone()
+            } else {
+                path
+            };
+            let suggestion = issue
+                .suggestion
+                .as_ref()
+                .map(
+                    |suggestion| match (suggestion.action.as_str(), &suggestion.value) {
+                        ("remove", _) => "; suggestion: remove this parameter".to_string(),
+                        ("set", Some(value)) => format!("; suggestion: set it to {value}"),
+                        _ => String::new(),
+                    },
+                )
+                .unwrap_or_default();
+            let message = format!("{location}: {}{suggestion}", issue.message);
+            if issue.blocking {
+                blocking.push(message);
+            } else {
+                print_command_status(CommandStatus::Warning, &message);
+            }
+        }
+    }
+    if blocking.is_empty() && report.valid {
+        Ok(())
+    } else if blocking.is_empty() {
+        bail!("the backend rejected the scorer definition")
+    } else {
+        bail!(blocking.join("; "))
+    }
+}
+
 fn resolve_name(args: &CreateArgs) -> Result<String> {
-    let name = match (&args.name_positional, &args.name) {
-        (Some(_), Some(_)) => bail!("use either a positional name or --name, not both"),
-        (Some(name), None) | (None, Some(name)) => name.trim().to_string(),
-        (None, None) if is_interactive() => Input::<String>::new()
+    let name = match args.name_positional.as_deref().or(args.name.as_deref()) {
+        Some(name) => name.trim().to_string(),
+        None if is_interactive() => Input::<String>::new()
             .with_prompt("Scorer name")
             .interact_text()?
             .trim()
             .to_string(),
-        (None, None) => bail!("scorer name required. Use: bt scorers create <name> ..."),
+        None => bail!("scorer name required. Use: bt scorers create <name> ..."),
     };
 
     if name.is_empty() {
@@ -395,20 +449,6 @@ mod tests {
     }
 
     #[test]
-    fn builds_chat_prompt_definition() {
-        let args = args();
-
-        let body =
-            build_scorer_definition(&args, "test-project", "Test", "test").expect("definition");
-
-        assert_eq!(body["prompt_data"]["prompt"]["type"], "chat");
-        assert_eq!(
-            body["prompt_data"]["prompt"]["messages"],
-            json!([{ "role": "user", "content": "Judge {{output}}." }])
-        );
-    }
-
-    #[test]
     fn rejects_non_array_messages() {
         let mut args = args();
         args.messages = r#"{"role":"user","content":"Judge {{output}}"}"#.to_string();
@@ -469,6 +509,84 @@ mod tests {
         assert_eq!(
             body["metadata"],
             json!({ "owner": "test-team", "__pass_threshold": 0.7 })
+        );
+    }
+
+    #[test]
+    fn builds_model_params_template_metadata_and_pass_threshold() {
+        let parsed = CreateArgsHarness::try_parse_from([
+            "bt-scorers-create",
+            "Test scorer",
+            "--model",
+            "gpt-test",
+            "--messages",
+            r#"[{"role":"user","content":"Judge {{output}}"}]"#,
+            "--choice-scores",
+            r#"{"yes":1,"no":0}"#,
+            "--temperature",
+            "0.1",
+            "--max-tokens",
+            "256",
+            "--top-p",
+            "0.8",
+            "--frequency-penalty",
+            "0.25",
+            "--presence-penalty",
+            "0.5",
+            "--stop-sequence",
+            "END",
+            "--tool-choice",
+            "required",
+            "--reasoning-effort",
+            "medium",
+            "--verbosity",
+            "high",
+            "--template-format",
+            "jinja",
+            "--pass-threshold",
+            "0.7",
+            "--metadata",
+            "owner: test-team",
+        ])
+        .expect("parse create args");
+
+        let body =
+            build_scorer_definition(&parsed.args, "test-project", "Test scorer", "test-scorer")
+                .expect("definition");
+        let params = &body["prompt_data"]["options"]["params"];
+        assert_eq!(params["temperature"], 0.1);
+        assert_eq!(params["max_tokens"], 256);
+        assert_eq!(params["top_p"], 0.8);
+        assert_eq!(params["frequency_penalty"], 0.25);
+        assert_eq!(params["presence_penalty"], 0.5);
+        assert_eq!(params["stop"], json!(["END"]));
+        assert_eq!(params["tool_choice"], "required");
+        assert_eq!(params["reasoning_effort"], "medium");
+        assert_eq!(params["verbosity"], "high");
+        assert_eq!(body["prompt_data"]["template_format"], "nunjucks");
+        assert_eq!(body["metadata"]["owner"], "test-team");
+        assert_eq!(body["metadata"]["__pass_threshold"], 0.7);
+    }
+
+    #[test]
+    fn positional_name_takes_precedence_over_named_form() {
+        let parsed = CreateArgsHarness::try_parse_from([
+            "bt-scorers-create",
+            "Positional name",
+            "--name",
+            "Named form",
+            "--model",
+            "gpt-test",
+            "--messages",
+            r#"[{"role":"user","content":"Judge {{output}}"}]"#,
+            "--choice-scores",
+            r#"{"yes":1,"no":0}"#,
+        ])
+        .expect("parse both name forms");
+
+        assert_eq!(
+            resolve_name(&parsed.args).expect("resolve name"),
+            "Positional name"
         );
     }
 

--- a/src/functions/create.rs
+++ b/src/functions/create.rs
@@ -1,20 +1,17 @@
 use anyhow::{bail, Context, Result};
 use clap::{builder::BoolishValueParser, ArgGroup, Args};
 use dialoguer::Input;
-use serde_json::{json, Map, Value};
+use serde_json::{json, Value};
 
 use crate::{
     error::user_error,
     ui::{is_interactive, print_command_status, with_spinner, CommandStatus},
-    utils::{merge_json_objects, read_text_source, read_yaml_object_source},
 };
 
 use super::{
     api,
-    prompt_config::{
-        parse_choice_scores_source, parse_classifications_source, validate_unit_interval,
-        PromptConfigArgs,
-    },
+    prompt_config::PromptConfigArgs,
+    scorer_config::{build_scorer_config, ScorerConfig},
     IfExistsMode, ResolvedContext,
 };
 
@@ -275,99 +272,39 @@ fn build_scorer_definition(
     name: &str,
     slug: &str,
 ) -> Result<Value> {
-    let prompt = resolve_prompt_block(args)?;
-    let (function_type, parser) = resolve_output_parser(args)?;
-
-    let mut prompt_data = json!({
-        "prompt": prompt,
-        "parser": parser,
-    })
-    .as_object()
-    .expect("prompt data is an object")
-    .clone();
-    let prompt_config = args
-        .prompt_config
-        .build_prompt_data_patch(Some(&args.model))?;
-    merge_json_objects(&mut prompt_data, &prompt_config);
+    let config = build_scorer_config(
+        &ScorerConfig {
+            messages: Some(&args.messages),
+            model: Some(&args.model),
+            prompt_config: &args.prompt_config,
+            choice_scores: args.choice_scores.as_deref(),
+            classifications: args.classifications.as_deref(),
+            use_cot: Some(args.use_cot),
+            allow_no_match: args.classifications.as_ref().map(|_| args.allow_no_match),
+            pass_threshold: args.pass_threshold,
+            metadata: args.metadata.as_deref(),
+            metadata_label: "scorer metadata",
+        },
+        true,
+    )?;
 
     let mut definition = json!({
         "project_id": project_id,
         "name": name,
         "slug": slug,
-        "function_data": {
-            "type": "prompt",
-        },
-        "prompt_data": prompt_data,
+        "function_data": { "type": "prompt" },
         "if_exists": args.if_exists.as_str(),
-        "function_type": function_type,
     });
+    definition
+        .as_object_mut()
+        .expect("scorer definition is an object")
+        .extend(config);
 
     if let Some(description) = args.description.as_deref() {
         definition["description"] = Value::String(description.to_string());
     }
 
-    let metadata = resolve_metadata(args)?;
-    if !metadata.is_empty() {
-        definition["metadata"] = Value::Object(metadata);
-    }
-
     Ok(definition)
-}
-
-fn resolve_output_parser(args: &CreateArgs) -> Result<(&'static str, Value)> {
-    match (
-        args.choice_scores.as_deref(),
-        args.classifications.as_deref(),
-    ) {
-        (Some(source), None) => Ok((
-            "scorer",
-            json!({
-                "type": "llm_classifier",
-                "use_cot": args.use_cot,
-                "choice_scores": parse_choice_scores_source(source)?,
-            }),
-        )),
-        (None, Some(source)) => Ok((
-            "classifier",
-            json!({
-                "type": "llm_classifier",
-                "use_cot": args.use_cot,
-                "choice": parse_classifications_source(source)?,
-                "allow_no_match": args.allow_no_match,
-            }),
-        )),
-        (Some(_), Some(_)) => bail!(
-            "use either --choice-scores for score output or --classifications for classification output, not both"
-        ),
-        (None, None) => bail!(
-            "output choices required. Pass --choice-scores <SOURCE> or --classifications <SOURCE>"
-        ),
-    }
-}
-
-fn resolve_metadata(args: &CreateArgs) -> Result<Map<String, Value>> {
-    let mut metadata = match args.metadata.as_deref() {
-        Some(source) => read_yaml_object_source(source, "scorer metadata")?,
-        None => Map::new(),
-    };
-    if let Some(pass_threshold) = args.pass_threshold {
-        validate_unit_interval(pass_threshold, "--pass-threshold")?;
-        metadata.insert("__pass_threshold".to_string(), json!(pass_threshold));
-    }
-    Ok(metadata)
-}
-
-fn resolve_prompt_block(args: &CreateArgs) -> Result<Value> {
-    let raw = read_text_source(&args.messages, "messages")?;
-    parse_messages(&raw)
-}
-
-fn parse_messages(raw: &str) -> Result<Value> {
-    let messages: Value = serde_json::from_str(raw).context("invalid JSON in scorer messages")?;
-    match messages {
-        Value::Array(_) => Ok(json!({ "type": "chat", "messages": messages })),
-        _ => bail!("scorer messages must be a JSON array"),
-    }
 }
 
 #[cfg(test)]

--- a/src/functions/create.rs
+++ b/src/functions/create.rs
@@ -170,7 +170,7 @@ pub(crate) async fn run(ctx: &ResolvedContext, args: &CreateArgs, json_output: b
     Ok(())
 }
 
-pub(super) fn report_validation_issues(report: &api::FunctionValidationReport) -> Result<()> {
+fn report_validation_issues(report: &api::FunctionValidationReport) -> Result<()> {
     let mut blocking = Vec::new();
     for result in &report.results {
         for issue in &result.issues {

--- a/src/functions/create.rs
+++ b/src/functions/create.rs
@@ -173,7 +173,7 @@ pub(crate) async fn run(ctx: &ResolvedContext, args: &CreateArgs, json_output: b
     Ok(())
 }
 
-fn report_validation_issues(report: &api::FunctionValidationReport) -> Result<()> {
+pub(super) fn report_validation_issues(report: &api::FunctionValidationReport) -> Result<()> {
     let mut blocking = Vec::new();
     for result in &report.results {
         for issue in &result.issues {

--- a/src/functions/create.rs
+++ b/src/functions/create.rs
@@ -4,7 +4,7 @@ use dialoguer::Input;
 use serde_json::{json, Map, Value};
 
 use crate::{
-    error::UserError,
+    error::user_error,
     ui::{is_interactive, print_command_status, with_spinner, CommandStatus},
     utils::{merge_json_objects, read_text_source, read_yaml_object_source},
 };
@@ -117,16 +117,16 @@ pub(crate) struct CreateArgs {
 }
 
 pub(crate) async fn run(ctx: &ResolvedContext, args: &CreateArgs, json_output: bool) -> Result<()> {
-    let name = resolve_name(args).map_err(UserError::from)?;
-    let slug = resolve_slug(args, &name).map_err(UserError::from)?;
+    let name = resolve_name(args).map_err(user_error)?;
+    let slug = resolve_slug(args, &name).map_err(user_error)?;
     let definition =
-        build_scorer_definition(args, &ctx.project.id, &name, &slug).map_err(UserError::from)?;
+        build_scorer_definition(args, &ctx.project.id, &name, &slug).map_err(user_error)?;
     let validation = with_spinner(
         "Validating scorer...",
         api::validate_functions(&ctx.client, std::slice::from_ref(&definition)),
     )
     .await?;
-    report_validation_issues(&validation).map_err(UserError::from)?;
+    report_validation_issues(&validation).map_err(user_error)?;
 
     let result = match with_spinner(
         "Creating scorer...",

--- a/src/functions/create.rs
+++ b/src/functions/create.rs
@@ -121,12 +121,6 @@ pub(crate) async fn run(ctx: &ResolvedContext, args: &CreateArgs, json_output: b
     let slug = resolve_slug(args, &name).map_err(user_error)?;
     let definition =
         build_scorer_definition(args, &ctx.project.id, &name, &slug).map_err(user_error)?;
-    let validation = with_spinner(
-        "Validating scorer...",
-        api::validate_functions(&ctx.client, std::slice::from_ref(&definition)),
-    )
-    .await?;
-    report_validation_issues(&validation).map_err(user_error)?;
 
     let result = match with_spinner(
         "Creating scorer...",
@@ -136,6 +130,9 @@ pub(crate) async fn run(ctx: &ResolvedContext, args: &CreateArgs, json_output: b
     {
         Ok(result) => result,
         Err(error) => {
+            if let Some(validation_error) = error.downcast_ref::<api::FunctionValidationError>() {
+                return report_validation_issues(&validation_error.report).map_err(user_error);
+            }
             print_command_status(CommandStatus::Error, &format!("Failed to create '{name}'"));
             return Err(error);
         }

--- a/src/functions/invoke.rs
+++ b/src/functions/invoke.rs
@@ -128,17 +128,9 @@ mod tests {
     use super::resolve_mode;
 
     #[test]
-    fn json_output_requests_json_invoke_mode() {
+    fn resolves_invoke_mode() {
         assert_eq!(resolve_mode(None, true), Some("json"));
-    }
-
-    #[test]
-    fn explicit_invoke_mode_takes_precedence_over_json_output() {
         assert_eq!(resolve_mode(Some("text"), true), Some("text"));
-    }
-
-    #[test]
-    fn default_output_does_not_set_invoke_mode() {
         assert_eq!(resolve_mode(None, false), None);
     }
 }

--- a/src/functions/mod.rs
+++ b/src/functions/mod.rs
@@ -18,9 +18,11 @@ mod delete;
 mod invoke;
 mod list;
 pub(crate) mod prompt_config;
+pub(crate) mod prompt_patch;
 mod pull;
 mod push;
 pub(crate) mod report;
+mod update;
 mod view;
 
 use api::Function;
@@ -173,8 +175,7 @@ Examples:
   bt tools view my-tool
   bt tools view fn_123
   bt tools view --id fn_123
-  bt scorers list
-  bt scorers delete my-scorer
+  bt tools update my-tool --patch @tool-patch.json
 ")]
 pub struct FunctionArgs {
     #[command(subcommand)]
@@ -191,6 +192,8 @@ pub(crate) enum FunctionCommands {
     Delete(DeleteArgs),
     /// Invoke by slug
     Invoke(invoke::InvokeArgs),
+    /// Update a function in place (prompt configuration, metadata, or arbitrary patch)
+    Update(Box<update::UpdateArgs>),
 }
 
 #[derive(Debug, Clone, Args)]
@@ -223,6 +226,8 @@ enum FunctionsCommands {
     Delete(FunctionsDeleteArgs),
     /// Invoke a function
     Invoke(FunctionsInvokeArgs),
+    /// Update a function in place (prompt configuration, metadata, or arbitrary patch)
+    Update(Box<FunctionsUpdateArgs>),
     /// Push local function definitions
     Push(PushArgs),
     /// Pull remote function definitions
@@ -267,6 +272,15 @@ impl FunctionsDeleteArgs {
 struct FunctionsInvokeArgs {
     #[command(flatten)]
     inner: invoke::InvokeArgs,
+    /// Filter by function type (for interactive selection)
+    #[arg(long = "type", short = 't', value_enum)]
+    function_type: Option<FunctionTypeFilter>,
+}
+
+#[derive(Debug, Clone, Args)]
+struct FunctionsUpdateArgs {
+    #[command(flatten)]
+    inner: update::UpdateArgs,
     /// Filter by function type (for interactive selection)
     #[arg(long = "type", short = 't', value_enum)]
     function_type: Option<FunctionTypeFilter>,
@@ -657,6 +671,7 @@ pub(crate) async fn run_typed_command(
                 None | Some(FunctionCommands::List) => list::run(&ctx, base.json, ft).await,
                 Some(FunctionCommands::Delete(d)) => delete::run(&ctx, d.slug(), d.force, ft).await,
                 Some(FunctionCommands::Invoke(i)) => invoke::run(&ctx, &i, base.json, ft).await,
+                Some(FunctionCommands::Update(u)) => update::run(&ctx, &u, base.json, ft).await,
                 Some(FunctionCommands::View(_)) => {
                     unreachable!("handled before context resolution")
                 }
@@ -719,6 +734,9 @@ pub async fn run(base: BaseArgs, args: FunctionsArgs) -> Result<()> {
                 }
                 Some(FunctionsCommands::Invoke(i)) => {
                     invoke::run(&ctx, &i.inner, base.json, i.function_type.or(function_type)).await
+                }
+                Some(FunctionsCommands::Update(u)) => {
+                    update::run(&ctx, &u.inner, base.json, u.function_type.or(function_type)).await
                 }
                 Some(FunctionsCommands::Push(_))
                 | Some(FunctionsCommands::Pull(_))
@@ -1199,6 +1217,31 @@ mod tests {
             command,
             None | Some(FunctionsCommands::List(_)) | Some(FunctionsCommands::View(_))
         )
+    }
+
+    #[test]
+    fn typed_function_update_command_is_not_read_only() {
+        let _guard = test_lock();
+        let parsed = FunctionArgsHarness::try_parse_from(["bt-tools", "update", "my-tool", "-y"])
+            .expect("parse");
+        assert!(!function_command_is_read_only(parsed.args.command.as_ref()));
+    }
+
+    #[test]
+    fn functions_update_command_is_not_read_only() {
+        let _guard = test_lock();
+        let parsed = FunctionsArgsHarness::try_parse_from([
+            "bt-functions",
+            "update",
+            "my-fn",
+            "--description",
+            "x",
+            "-y",
+        ])
+        .expect("parse");
+        assert!(!functions_command_is_read_only(
+            parsed.args.command.as_ref()
+        ));
     }
 
     #[test]

--- a/src/functions/mod.rs
+++ b/src/functions/mod.rs
@@ -185,11 +185,11 @@ pub struct FunctionArgs {
 pub(crate) enum FunctionCommands {
     /// List all in the current project
     List,
-    /// View a function's details
+    /// View details
     View(ViewArgs),
-    /// Delete a function
+    /// Delete by slug
     Delete(DeleteArgs),
-    /// Invoke a function
+    /// Invoke by slug
     Invoke(invoke::InvokeArgs),
 }
 

--- a/src/functions/mod.rs
+++ b/src/functions/mod.rs
@@ -117,7 +117,6 @@ pub enum PushLanguage {
 fn build_web_path(function: &Function) -> String {
     let id = &function.id;
     match function.function_type.as_deref() {
-        Some("tool") => format!("tools?pr={}", urlencoding::encode(id)),
         Some("scorer") => format!("scorers/{}", urlencoding::encode(id)),
         Some("classifier") if function.prompt_data.is_some() => {
             format!("scorers/{}", urlencoding::encode(id))
@@ -131,7 +130,8 @@ fn build_web_path(function: &Function) -> String {
             )
         }
         Some("parameters") => format!("parameters/{}", urlencoding::encode(id)),
-        _ => format!("functions/{}", urlencoding::encode(id)),
+        Some("llm") => format!("prompts/{}", urlencoding::encode(id)),
+        _ => format!("tools?pr={}", urlencoding::encode(id)),
     }
 }
 

--- a/src/functions/mod.rs
+++ b/src/functions/mod.rs
@@ -22,6 +22,7 @@ pub(crate) mod prompt_patch;
 mod pull;
 mod push;
 pub(crate) mod report;
+mod scorer_config;
 mod update;
 mod view;
 

--- a/src/functions/mod.rs
+++ b/src/functions/mod.rs
@@ -176,7 +176,7 @@ Examples:
   bt tools view my-tool
   bt tools view fn_123
   bt tools view --id fn_123
-  bt tools update my-tool --patch @tool-patch.json
+  bt tools update my-tool --name \"Lookup order\" --new-slug lookup-order
 ")]
 pub struct FunctionArgs {
     #[command(subcommand)]
@@ -193,8 +193,22 @@ pub(crate) enum FunctionCommands {
     Delete(DeleteArgs),
     /// Invoke by slug
     Invoke(invoke::InvokeArgs),
-    /// Update a function in place (prompt configuration, metadata, or arbitrary patch)
-    Update(Box<update::UpdateArgs>),
+    /// Update tool fields or prompt content
+    Update(Box<update::ToolUpdateArgs>),
+}
+
+#[derive(Debug, Clone, Subcommand)]
+pub(crate) enum ScorerFunctionCommands {
+    /// List all in the current project
+    List,
+    /// View details
+    View(ViewArgs),
+    /// Delete by slug
+    Delete(DeleteArgs),
+    /// Invoke by slug
+    Invoke(invoke::InvokeArgs),
+    /// Update scorer configuration
+    Update(Box<update::ScorerUpdateArgs>),
 }
 
 #[derive(Debug, Clone, Args)]
@@ -227,7 +241,7 @@ enum FunctionsCommands {
     Delete(FunctionsDeleteArgs),
     /// Invoke a function
     Invoke(FunctionsInvokeArgs),
-    /// Update a function in place (prompt configuration, metadata, or arbitrary patch)
+    /// Update common function fields or apply an arbitrary patch
     Update(Box<FunctionsUpdateArgs>),
     /// Push local function definitions
     Push(PushArgs),
@@ -281,7 +295,7 @@ struct FunctionsInvokeArgs {
 #[derive(Debug, Clone, Args)]
 struct FunctionsUpdateArgs {
     #[command(flatten)]
-    inner: update::UpdateArgs,
+    inner: update::GenericUpdateArgs,
     /// Filter by function type (for interactive selection)
     #[arg(long = "type", short = 't', value_enum)]
     function_type: Option<FunctionTypeFilter>,
@@ -672,7 +686,7 @@ pub(crate) async fn run_typed_command(
                 None | Some(FunctionCommands::List) => list::run(&ctx, base.json, ft).await,
                 Some(FunctionCommands::Delete(d)) => delete::run(&ctx, d.slug(), d.force, ft).await,
                 Some(FunctionCommands::Invoke(i)) => invoke::run(&ctx, &i, base.json, ft).await,
-                Some(FunctionCommands::Update(u)) => update::run(&ctx, &u, base.json, ft).await,
+                Some(FunctionCommands::Update(u)) => update::run_tool(&ctx, &u, base.json).await,
                 Some(FunctionCommands::View(_)) => {
                     unreachable!("handled before context resolution")
                 }
@@ -685,6 +699,59 @@ pub(crate) async fn run_scorer_create(base: BaseArgs, args: create::CreateArgs) 
     let json_output = base.json;
     let ctx = resolve_context(&base).await?;
     create::run(&ctx, &args, json_output).await
+}
+
+pub(crate) async fn run_scorer_command(
+    base: BaseArgs,
+    command: Option<ScorerFunctionCommands>,
+) -> Result<()> {
+    let ft = Some(FunctionTypeFilter::Scorer);
+    match command {
+        Some(ScorerFunctionCommands::View(v)) => match v.selector()? {
+            ViewSelector::Id(id) => {
+                let auth_ctx = resolve_auth_context(&base).await?;
+                view::run_by_id(
+                    &auth_ctx,
+                    id,
+                    v.version.as_deref(),
+                    base.json,
+                    v.web,
+                    base.verbose,
+                    ft,
+                )
+                .await
+            }
+            ViewSelector::Slug(slug) => {
+                let ctx = resolve_context(&base).await?;
+                view::run(
+                    &ctx,
+                    slug,
+                    v.version.as_deref(),
+                    base.json,
+                    v.web,
+                    base.verbose,
+                    ft,
+                )
+                .await
+            }
+        },
+        command => {
+            let ctx = resolve_context(&base).await?;
+            match command {
+                None | Some(ScorerFunctionCommands::List) => list::run(&ctx, base.json, ft).await,
+                Some(ScorerFunctionCommands::Delete(d)) => {
+                    delete::run(&ctx, d.slug(), d.force, ft).await
+                }
+                Some(ScorerFunctionCommands::Invoke(i)) => {
+                    invoke::run(&ctx, &i, base.json, ft).await
+                }
+                Some(ScorerFunctionCommands::Update(u)) => {
+                    update::run_scorer(&ctx, &u, base.json).await
+                }
+                Some(ScorerFunctionCommands::View(_)) => unreachable!("handled above"),
+            }
+        }
+    }
 }
 
 pub async fn run(base: BaseArgs, args: FunctionsArgs) -> Result<()> {
@@ -737,7 +804,13 @@ pub async fn run(base: BaseArgs, args: FunctionsArgs) -> Result<()> {
                     invoke::run(&ctx, &i.inner, base.json, i.function_type.or(function_type)).await
                 }
                 Some(FunctionsCommands::Update(u)) => {
-                    update::run(&ctx, &u.inner, base.json, u.function_type.or(function_type)).await
+                    update::run_generic(
+                        &ctx,
+                        &u.inner,
+                        base.json,
+                        u.function_type.or(function_type),
+                    )
+                    .await
                 }
                 Some(FunctionsCommands::Push(_))
                 | Some(FunctionsCommands::Pull(_))

--- a/src/functions/prompt_config.rs
+++ b/src/functions/prompt_config.rs
@@ -8,23 +8,29 @@ use crate::utils::read_text_source;
 
 #[derive(Debug, Clone, Default, Args)]
 pub(crate) struct PromptConfigArgs {
-    /// Sampling temperature.
+    /// Sampling temperature, between 0 and 2. Some models support a smaller
+    /// range or do not support custom temperatures.
     #[arg(long, value_name = "NUMBER")]
     temperature: Option<f64>,
 
-    /// Maximum number of generated tokens.
+    /// Maximum number of generated tokens. Must be greater than 0.
     #[arg(long, value_name = "N")]
     max_tokens: Option<u64>,
 
-    /// Nucleus sampling probability.
+    /// Nucleus sampling probability, between 0 and 1.
     #[arg(long, value_name = "NUMBER")]
     top_p: Option<f64>,
 
-    /// Frequency penalty.
+    /// Top-k sampling value, between 1 and 100. Availability depends on the
+    /// model provider.
+    #[arg(long, value_name = "N")]
+    top_k: Option<u64>,
+
+    /// Frequency penalty. Availability and range depend on the model.
     #[arg(long, value_name = "NUMBER", allow_hyphen_values = true)]
     frequency_penalty: Option<f64>,
 
-    /// Presence penalty.
+    /// Presence penalty. Availability and range depend on the model.
     #[arg(long, value_name = "NUMBER", allow_hyphen_values = true)]
     presence_penalty: Option<f64>,
 
@@ -39,6 +45,20 @@ pub(crate) struct PromptConfigArgs {
     /// Reasoning effort for supported models.
     #[arg(long, value_enum)]
     reasoning_effort: Option<ReasoningEffort>,
+
+    /// Enable reasoning for models that configure reasoning with a token
+    /// budget rather than an effort level.
+    #[arg(
+        long,
+        num_args = 0..=1,
+        default_missing_value = "true",
+        value_parser = BoolishValueParser::new()
+    )]
+    reasoning_enabled: Option<bool>,
+
+    /// Reasoning token budget, between 0 and 32768, for supported models.
+    #[arg(long, value_name = "N")]
+    reasoning_budget: Option<u64>,
 
     /// Response verbosity for supported models.
     #[arg(long, value_enum)]
@@ -139,20 +159,13 @@ impl PromptConfigArgs {
             options.insert("model".to_string(), Value::String(model.to_string()));
         }
 
-        let temperature = match (self.temperature, self.use_cache) {
-            (None, Some(true)) => Some(0.0),
-            (Some(temperature), Some(true)) if temperature != 0.0 => {
-                bail!("--use-cache=true requires --temperature=0")
-            }
-            (temperature, _) => temperature,
-        };
-        insert_optional_number(&mut params, "temperature", temperature)?;
+        insert_optional_number(&mut params, "temperature", self.temperature)?;
         if let Some(max_tokens) = self.max_tokens {
             params.insert("max_tokens".to_string(), Value::Number(max_tokens.into()));
         }
-        if let Some(top_p) = self.top_p {
-            validate_unit_interval(top_p, "--top-p")?;
-            insert_number(&mut params, "top_p", top_p, "--top-p")?;
+        insert_optional_number(&mut params, "top_p", self.top_p)?;
+        if let Some(top_k) = self.top_k {
+            params.insert("top_k".to_string(), Value::Number(top_k.into()));
         }
         insert_optional_number(&mut params, "frequency_penalty", self.frequency_penalty)?;
         insert_optional_number(&mut params, "presence_penalty", self.presence_penalty)?;
@@ -188,6 +201,15 @@ impl PromptConfigArgs {
             params.insert(
                 "reasoning_effort".to_string(),
                 Value::String(reasoning_effort.as_str().to_string()),
+            );
+        }
+        if let Some(reasoning_enabled) = self.reasoning_enabled {
+            params.insert("reasoning_enabled".to_string(), reasoning_enabled.into());
+        }
+        if let Some(reasoning_budget) = self.reasoning_budget {
+            params.insert(
+                "reasoning_budget".to_string(),
+                Value::Number(reasoning_budget.into()),
             );
         }
         if let Some(verbosity) = self.verbosity {
@@ -380,7 +402,7 @@ mod tests {
             "--top-p",
             "0.9",
             "--frequency-penalty",
-            "-0.5",
+            "0.5",
             "--presence-penalty",
             "0.25",
             "--stop-sequence",
@@ -409,7 +431,7 @@ mod tests {
         assert_eq!(patch["options"]["params"]["temperature"], 0.2);
         assert_eq!(patch["options"]["params"]["max_tokens"], 512);
         assert_eq!(patch["options"]["params"]["top_p"], 0.9);
-        assert_eq!(patch["options"]["params"]["frequency_penalty"], -0.5);
+        assert_eq!(patch["options"]["params"]["frequency_penalty"], 0.5);
         assert_eq!(patch["options"]["params"]["presence_penalty"], 0.25);
         assert_eq!(patch["options"]["params"]["stop"], json!(["END", "DONE"]));
         assert_eq!(
@@ -434,29 +456,16 @@ mod tests {
     }
 
     #[test]
-    fn enabling_cache_sets_the_temperature_required_by_the_web_ui() {
-        let args = Harness::try_parse_from(["test", "--use-cache=true"]).expect("parse arguments");
-
-        let patch = args
-            .config
-            .build_prompt_data_patch(Some("claude-test"))
-            .expect("prompt data");
-        assert_eq!(patch["options"]["params"]["temperature"], 0.0);
-        assert_eq!(patch["options"]["params"]["use_cache"], true);
-    }
-
-    #[test]
-    fn rejects_cache_with_nonzero_temperature() {
+    fn sends_cache_and_temperature_values_without_client_normalization() {
         let args = Harness::try_parse_from(["test", "--temperature", "0.5", "--use-cache=true"])
             .expect("parse arguments");
 
-        let error = args
+        let patch = args
             .config
-            .build_prompt_data_patch(Some("claude-test"))
-            .expect_err("nonzero temperature should conflict with caching");
-        assert!(error
-            .to_string()
-            .contains("--use-cache=true requires --temperature=0"));
+            .build_prompt_data_patch(Some("test-model"))
+            .expect("prompt data");
+        assert_eq!(patch["options"]["params"]["temperature"], 0.5);
+        assert_eq!(patch["options"]["params"]["use_cache"], true);
     }
 
     #[test]

--- a/src/functions/prompt_patch.rs
+++ b/src/functions/prompt_patch.rs
@@ -20,6 +20,20 @@ pub(crate) fn materialize_prompt_data_patch(
         .cloned()
         .unwrap_or_default();
     merge_json_objects(&mut merged, &patch_prompt_data);
+
+    if let (Some(requested), Some(parser)) = (
+        patch_prompt_data.get("parser").and_then(Value::as_object),
+        merged.get_mut("parser").and_then(Value::as_object_mut),
+    ) {
+        if let Some(scores) = requested.get("choice_scores") {
+            parser.remove("choice");
+            parser.remove("allow_no_match");
+            parser.insert("choice_scores".to_string(), scores.clone());
+        } else if requested.contains_key("choice") {
+            parser.remove("choice_scores");
+        }
+    }
+
     patch["prompt_data"] = Value::Object(merged);
 }
 
@@ -33,17 +47,23 @@ mod tests {
     fn materializes_complete_prompt_data_for_patch() {
         let existing = json!({
             "prompt": {"type": "chat", "messages": []},
-            "parser": {"type": "llm_classifier"},
+            "parser": {"type": "llm_classifier", "choice_scores": {"old": 0}},
             "options": {"model": "test-model", "params": {"temperature": 0.5}}
         });
         let mut patch = json!({
-            "prompt_data": {"options": {"params": {"temperature": 0.2}}}
+            "prompt_data": {
+                "parser": {"choice_scores": {"new": 1}},
+                "options": {"params": {"temperature": 0.2}}
+            }
         });
 
         materialize_prompt_data_patch(&mut patch, Some(&existing));
 
         assert_eq!(patch["prompt_data"]["prompt"], existing["prompt"]);
-        assert_eq!(patch["prompt_data"]["parser"], existing["parser"]);
+        assert_eq!(
+            patch["prompt_data"]["parser"]["choice_scores"],
+            json!({"new": 1})
+        );
         assert_eq!(patch["prompt_data"]["options"]["model"], "test-model");
         assert_eq!(
             patch["prompt_data"]["options"]["params"]["temperature"],

--- a/src/functions/prompt_patch.rs
+++ b/src/functions/prompt_patch.rs
@@ -21,6 +21,20 @@ pub(crate) fn materialize_prompt_data_patch(
         .unwrap_or_default();
     merge_json_objects(&mut merged, &patch_prompt_data);
 
+    // Prompt blocks are a discriminated union. Deep-merging a completion block
+    // into a chat block (or vice versa) leaves fields from both variants and
+    // produces invalid prompt data.
+    if let Some(requested_prompt) = patch_prompt_data.get("prompt") {
+        let requested_type = requested_prompt.get("type").and_then(Value::as_str);
+        let existing_type = existing_prompt_data
+            .and_then(|data| data.get("prompt"))
+            .and_then(|prompt| prompt.get("type"))
+            .and_then(Value::as_str);
+        if requested_type.is_some() && requested_type != existing_type {
+            merged.insert("prompt".to_string(), requested_prompt.clone());
+        }
+    }
+
     if let (Some(requested), Some(parser)) = (
         patch_prompt_data.get("parser").and_then(Value::as_object),
         merged.get_mut("parser").and_then(Value::as_object_mut),
@@ -42,6 +56,33 @@ mod tests {
     use serde_json::json;
 
     use super::*;
+
+    #[test]
+    fn replaces_prompt_block_when_switching_prompt_kinds() {
+        let existing = json!({
+            "prompt": {"type": "completion", "content": "Original"},
+            "options": {"model": "test-model"}
+        });
+        let mut patch = json!({
+            "prompt_data": {
+                "prompt": {
+                    "type": "chat",
+                    "messages": [{"role": "user", "content": "Hello"}]
+                }
+            }
+        });
+
+        materialize_prompt_data_patch(&mut patch, Some(&existing));
+
+        assert_eq!(
+            patch["prompt_data"]["prompt"],
+            json!({
+                "type": "chat",
+                "messages": [{"role": "user", "content": "Hello"}]
+            })
+        );
+        assert_eq!(patch["prompt_data"]["options"]["model"], "test-model");
+    }
 
     #[test]
     fn materializes_complete_prompt_data_for_patch() {

--- a/src/functions/prompt_patch.rs
+++ b/src/functions/prompt_patch.rs
@@ -1,0 +1,53 @@
+use serde_json::Value;
+
+use crate::utils::merge_json_objects;
+
+/// Replace a partial `prompt_data` patch with the full merged object.
+///
+/// The function and prompt PATCH endpoints merge top-level fields but replace
+/// `prompt_data` wholesale. Materializing it before the request preserves fields
+/// that the user did not change.
+pub(crate) fn materialize_prompt_data_patch(
+    patch: &mut Value,
+    existing_prompt_data: Option<&Value>,
+) {
+    let Some(patch_prompt_data) = patch.get("prompt_data").and_then(Value::as_object).cloned()
+    else {
+        return;
+    };
+    let mut merged = existing_prompt_data
+        .and_then(Value::as_object)
+        .cloned()
+        .unwrap_or_default();
+    merge_json_objects(&mut merged, &patch_prompt_data);
+    patch["prompt_data"] = Value::Object(merged);
+}
+
+#[cfg(test)]
+mod tests {
+    use serde_json::json;
+
+    use super::*;
+
+    #[test]
+    fn materializes_complete_prompt_data_for_patch() {
+        let existing = json!({
+            "prompt": {"type": "chat", "messages": []},
+            "parser": {"type": "llm_classifier"},
+            "options": {"model": "test-model", "params": {"temperature": 0.5}}
+        });
+        let mut patch = json!({
+            "prompt_data": {"options": {"params": {"temperature": 0.2}}}
+        });
+
+        materialize_prompt_data_patch(&mut patch, Some(&existing));
+
+        assert_eq!(patch["prompt_data"]["prompt"], existing["prompt"]);
+        assert_eq!(patch["prompt_data"]["parser"], existing["parser"]);
+        assert_eq!(patch["prompt_data"]["options"]["model"], "test-model");
+        assert_eq!(
+            patch["prompt_data"]["options"]["params"]["temperature"],
+            0.2
+        );
+    }
+}

--- a/src/functions/scorer_config.rs
+++ b/src/functions/scorer_config.rs
@@ -1,0 +1,153 @@
+use anyhow::{bail, Context, Result};
+use serde_json::{json, Map, Value};
+
+use crate::utils::{merge_json_objects, read_text_source, read_yaml_object_source};
+
+use super::prompt_config::{
+    parse_choice_scores_source, parse_classifications_source, validate_unit_interval,
+    PromptConfigArgs,
+};
+
+/// Inputs shared by scorer creation and partial scorer updates.
+///
+/// Creation supplies all required values, while update leaves unchanged values
+/// as `None`. Keeping this independent of the clap structs lets both commands
+/// share schema construction without weakening create-time CLI requirements.
+pub(crate) struct ScorerConfig<'a> {
+    pub(crate) messages: Option<&'a str>,
+    pub(crate) model: Option<&'a str>,
+    pub(crate) prompt_config: &'a PromptConfigArgs,
+    pub(crate) choice_scores: Option<&'a str>,
+    pub(crate) classifications: Option<&'a str>,
+    pub(crate) use_cot: Option<bool>,
+    pub(crate) allow_no_match: Option<bool>,
+    pub(crate) pass_threshold: Option<f64>,
+    pub(crate) metadata: Option<&'a str>,
+    pub(crate) metadata_label: &'a str,
+}
+
+/// Build the top-level fields containing a scorer's prompt configuration.
+///
+/// The result is a complete set of fields for create when `require_output` is
+/// true and a partial patch for update otherwise.
+pub(crate) fn build_scorer_config(
+    config: &ScorerConfig<'_>,
+    require_output: bool,
+) -> Result<Map<String, Value>> {
+    validate_output_selection(config, require_output)?;
+
+    let mut result = Map::new();
+    let mut prompt_data = Map::new();
+
+    if let Some(source) = config.messages {
+        prompt_data.insert(
+            "prompt".to_string(),
+            json!({
+                "type": "chat",
+                "messages": parse_messages_source(source)?,
+            }),
+        );
+    }
+
+    if let Some(output) = build_output_parser(config)? {
+        if let Some(function_type) = output.function_type {
+            result.insert(
+                "function_type".to_string(),
+                Value::String(function_type.to_string()),
+            );
+        }
+        prompt_data.insert("parser".to_string(), Value::Object(output.parser));
+    }
+
+    let prompt_config = config.prompt_config.build_prompt_data_patch(config.model)?;
+    merge_json_objects(&mut prompt_data, &prompt_config);
+    if !prompt_data.is_empty() {
+        result.insert("prompt_data".to_string(), Value::Object(prompt_data));
+    }
+
+    let metadata = build_metadata(config)?;
+    if !metadata.is_empty() {
+        result.insert("metadata".to_string(), Value::Object(metadata));
+    }
+
+    Ok(result)
+}
+
+fn validate_output_selection(config: &ScorerConfig<'_>, require_output: bool) -> Result<()> {
+    match (config.choice_scores, config.classifications) {
+        (Some(_), Some(_)) => bail!(
+            "use either --choice-scores for score output or --classifications for classification output, not both"
+        ),
+        (None, None) if require_output => bail!(
+            "output choices required. Pass --choice-scores <SOURCE> or --classifications <SOURCE>"
+        ),
+        _ => {}
+    }
+
+    if config.choice_scores.is_some() && config.allow_no_match.is_some() {
+        bail!("--allow-no-match applies to classification output, not --choice-scores");
+    }
+    if config.classifications.is_some() && config.pass_threshold.is_some() {
+        bail!("--pass-threshold applies to score output and cannot be used with --classifications");
+    }
+    Ok(())
+}
+
+struct OutputParser {
+    function_type: Option<&'static str>,
+    parser: Map<String, Value>,
+}
+
+fn build_output_parser(config: &ScorerConfig<'_>) -> Result<Option<OutputParser>> {
+    let mut parser = Map::new();
+    let mut function_type = None;
+
+    if let Some(source) = config.choice_scores {
+        parser.insert("type".to_string(), json!("llm_classifier"));
+        parser.insert(
+            "choice_scores".to_string(),
+            Value::Object(parse_choice_scores_source(source)?),
+        );
+        function_type = Some("scorer");
+    }
+    if let Some(source) = config.classifications {
+        parser.insert("type".to_string(), json!("llm_classifier"));
+        parser.insert(
+            "choice".to_string(),
+            Value::Array(parse_classifications_source(source)?),
+        );
+        function_type = Some("classifier");
+    }
+    if let Some(use_cot) = config.use_cot {
+        parser.insert("use_cot".to_string(), Value::Bool(use_cot));
+    }
+    if let Some(allow_no_match) = config.allow_no_match {
+        parser.insert("allow_no_match".to_string(), Value::Bool(allow_no_match));
+    }
+
+    Ok((!parser.is_empty()).then_some(OutputParser {
+        function_type,
+        parser,
+    }))
+}
+
+fn parse_messages_source(source: &str) -> Result<Value> {
+    let raw = read_text_source(source, "messages")?;
+    let messages: Value = serde_json::from_str(&raw).context("invalid JSON in messages")?;
+    match messages {
+        Value::Array(_) => Ok(messages),
+        _ => bail!("messages must be a JSON array of chat messages"),
+    }
+}
+
+fn build_metadata(config: &ScorerConfig<'_>) -> Result<Map<String, Value>> {
+    let mut metadata = match config.metadata {
+        Some(source) => read_yaml_object_source(source, config.metadata_label)?,
+        None => Map::new(),
+    };
+    if let Some(pass_threshold) = config.pass_threshold {
+        validate_unit_interval(pass_threshold, "--pass-threshold")?;
+        metadata.insert("__pass_threshold".to_string(), json!(pass_threshold));
+    }
+    Ok(metadata)
+}

--- a/src/functions/update.rs
+++ b/src/functions/update.rs
@@ -1,22 +1,19 @@
 use anyhow::{anyhow, bail, Context, Result};
 use clap::{builder::BoolishValueParser, Args};
 use dialoguer::Confirm;
-use serde_json::{json, Map, Value};
+use serde_json::{Map, Value};
 
 use crate::{
-    error::user_error,
     ui::{is_interactive, print_command_status, with_spinner, CommandStatus},
     utils::{merge_json_objects, read_text_source},
 };
 
 use super::{
-    api, create::report_validation_issues, label, label_plural, select_function_interactive,
-};
-use super::{
+    api, label, label_plural,
     prompt_config::PromptConfigArgs,
     prompt_patch::materialize_prompt_data_patch,
     scorer_config::{build_scorer_config, ScorerConfig},
-    FunctionTypeFilter, ResolvedContext,
+    select_function_interactive, FunctionTypeFilter, ResolvedContext,
 };
 
 /// Update a function's prompt configuration or metadata in place.
@@ -57,12 +54,13 @@ pub struct UpdateArgs {
     #[command(flatten)]
     prompt_config: PromptConfigArgs,
 
-    /// Replace choice-to-score mappings for score output. Accepts inline JSON,
-    /// @PATH to read from a file, or - for stdin.
+    /// Replace choice-to-score mappings for an existing score-output scorer.
+    /// Accepts inline JSON, @PATH to read from a file, or - for stdin.
     #[arg(long, value_name = "SOURCE", conflicts_with = "classifications")]
     choice_scores: Option<String>,
 
-    /// Replace labels for classification output. Accepts an inline JSON array,
+    /// Replace labels for an existing classifier. This cannot change a
+    /// score-output scorer into a classifier. Accepts an inline JSON array,
     /// @PATH to read from a file, or - for stdin.
     #[arg(long, value_name = "SOURCE", conflicts_with = "choice_scores")]
     classifications: Option<String>,
@@ -85,7 +83,8 @@ pub struct UpdateArgs {
     )]
     allow_no_match: Option<bool>,
 
-    /// Update the score threshold for passing, between 0 and 1.
+    /// Update the score threshold for an existing score-output scorer, between
+    /// 0 and 1.
     #[arg(long, value_name = "NUMBER", conflicts_with = "classifications")]
     pass_threshold: Option<f64>,
 
@@ -156,46 +155,6 @@ enum UpdateSelector<'a> {
     Slug(Option<&'a str>),
 }
 
-fn validation_candidate(function: &api::Function, patch: &Value) -> Value {
-    let mut candidate = json!({
-        "project_id": function.project_id,
-        "name": function.name,
-        "slug": function.slug,
-    });
-    let object = candidate
-        .as_object_mut()
-        .expect("validation candidate is an object");
-
-    for (key, value) in [
-        (
-            "description",
-            function.description.as_ref().map(|v| json!(v)),
-        ),
-        (
-            "function_type",
-            function.function_type.as_ref().map(|v| json!(v)),
-        ),
-        ("prompt_data", function.prompt_data.clone()),
-        ("function_data", function.function_data.clone()),
-        ("tags", function.tags.as_ref().map(|v| json!(v))),
-        ("metadata", function.metadata.clone()),
-    ] {
-        if let Some(value) = value {
-            object.insert(key.to_string(), value);
-        }
-    }
-
-    // PATCH replaces each top-level value. `prompt_data` has already been
-    // materialized into a complete value before this helper is called.
-    for (key, value) in patch
-        .as_object()
-        .expect("function update patch is an object")
-    {
-        object.insert(key.clone(), value.clone());
-    }
-    candidate
-}
-
 pub async fn run(
     ctx: &ResolvedContext,
     args: &UpdateArgs,
@@ -205,66 +164,50 @@ pub async fn run(
     let mut body = build_patch_body(args)?;
 
     let function = resolve_target_function(ctx, args, ft).await?;
+    if !function_matches_filter(&function, ft) {
+        bail!("'{}' is not a {}", function.name, label(ft));
+    }
 
-    // LLM scorer/classifier output flags only apply to prompt-based scorers and
-    // classifiers. Reject them on other function kinds (for example tools) so an
-    // unrelated function is not silently patched with a parser it cannot use.
-    let is_scorer_like = matches!(
-        function.function_type.as_deref(),
-        Some("scorer") | Some("classifier")
-    );
-    let scorer_flags = args.scorer_output_flags();
-    if !scorer_flags.is_empty() && !is_scorer_like {
+    let implementation = function
+        .function_data
+        .as_ref()
+        .and_then(|data| data.get("type"))
+        .and_then(Value::as_str)
+        .unwrap_or("prompt");
+    if body.get("prompt_data").is_some() && implementation != "prompt" {
         bail!(
-            "{} apply to LLM scorers and classifiers, not {} '{}'. \
-             Run `bt scorers update` on a scorer instead.",
-            scorer_flags.join(", "),
-            label(ft),
-            function.name,
+            "prompt configuration cannot update {}-backed function '{}'",
+            implementation,
+            function.name
         );
     }
 
-    // Mirrors `create`, where --allow-no-match requires --classifications: a
-    // score parser would never consult it.
-    let produces_classifications =
-        args.classifications.is_some() || function.function_type.as_deref() == Some("classifier");
-    if args.allow_no_match.is_some() && !produces_classifications {
+    let function_type = function.function_type.as_deref();
+    let scorer_flags = args.scorer_output_flags();
+    if !scorer_flags.is_empty() && !matches!(function_type, Some("scorer") | Some("classifier")) {
         bail!(
-            "--allow-no-match applies to classification output, but '{}' produces scores. \
-             Pass --classifications to switch it to labels.",
-            function.name,
+            "{} apply only to scorers and classifiers",
+            scorer_flags.join(", ")
         );
+    }
+    if matches!(
+        (
+            function_type,
+            args.choice_scores.is_some(),
+            args.classifications.is_some()
+        ),
+        (Some("classifier"), true, _) | (Some("scorer"), _, true)
+    ) {
+        bail!("PATCH cannot change between score and classification output");
+    }
+    if args.allow_no_match.is_some() && function_type != Some("classifier") {
+        bail!("--allow-no-match applies only to classification output");
+    }
+    if args.pass_threshold.is_some() && function_type == Some("classifier") {
+        bail!("--pass-threshold applies only to score output");
     }
 
     materialize_prompt_data_patch(&mut body, function.prompt_data.as_ref());
-
-    // Last of the up-front checks because it hits the network. Validate the
-    // complete candidate rather than the partial PATCH body so the backend can
-    // apply the same model-parameter checks as it does for scorer creation.
-    let candidate = validation_candidate(&function, &body);
-    let validation = with_spinner(
-        "Validating function...",
-        api::validate_functions(&ctx.client, std::slice::from_ref(&candidate)),
-    )
-    .await?;
-    report_validation_issues(&validation).map_err(user_error)?;
-
-    // Switching output mode updates function_type, but materialization merges
-    // the parser and does not drop the previous mode's keys. Warn so the
-    // user can review or recreate for a clean switch.
-    if !crate::ui::is_quiet() {
-        match function.function_type.as_deref() {
-            Some("classifier") if args.choice_scores.is_some() => print_command_status(
-                CommandStatus::Warning,
-                "Switching to score output; previous classification labels may remain in the definition. Review with `bt scorers view`.",
-            ),
-            Some("scorer") if args.classifications.is_some() => print_command_status(
-                CommandStatus::Warning,
-                "Switching to classification output; previous choice scores may remain in the definition. Review with `bt scorers view`.",
-            ),
-            _ => {}
-        }
-    }
 
     if !args.yes && is_interactive() {
         let confirm = Confirm::new()
@@ -316,6 +259,24 @@ pub async fn run(
     Ok(())
 }
 
+fn function_matches_filter(function: &api::Function, ft: Option<FunctionTypeFilter>) -> bool {
+    match ft {
+        None => true,
+        Some(FunctionTypeFilter::Scorer) => {
+            function.function_type.as_deref() == Some("scorer")
+                || function.function_type.as_deref() == Some("classifier")
+                    && function.prompt_data.is_some()
+                    && function
+                        .function_data
+                        .as_ref()
+                        .and_then(|data| data.get("type"))
+                        .and_then(Value::as_str)
+                        != Some("topic_map")
+        }
+        Some(expected) => function.function_type.as_deref() == Some(expected.as_str()),
+    }
+}
+
 async fn resolve_target_function(
     ctx: &ResolvedContext,
     args: &UpdateArgs,
@@ -360,6 +321,9 @@ fn build_patch_body(args: &UpdateArgs) -> Result<Value> {
         },
         false,
     )?;
+    // PATCH /v1/function does not support changing function_type. Output-mode
+    // changes are rejected after resolving the current function.
+    patch.remove("function_type");
 
     if let Some(description) = args.description.as_deref() {
         patch.insert(
@@ -398,6 +362,7 @@ fn parse_patch_object(raw: &str) -> Result<Map<String, Value>> {
 #[cfg(test)]
 mod tests {
     use clap::Parser;
+    use serde_json::json;
 
     use super::*;
 
@@ -427,36 +392,6 @@ mod tests {
             patch: None,
             yes: true,
         }
-    }
-
-    #[test]
-    fn validation_candidate_applies_top_level_patch_to_existing_function() {
-        let function = api::Function {
-            id: "fn_test_update".to_string(),
-            name: "Test scorer".to_string(),
-            slug: "test-scorer".to_string(),
-            project_id: "test-project".to_string(),
-            description: Some("Old description".to_string()),
-            function_type: Some("scorer".to_string()),
-            prompt_data: Some(json!({"options": {"model": "test-model"}})),
-            function_data: Some(json!({"type": "prompt"})),
-            tags: Some(vec!["test-tag".to_string()]),
-            metadata: Some(json!({"owner": "test-user"})),
-            created: None,
-            _xact_id: None,
-        };
-        let patch = json!({
-            "description": "New description",
-            "prompt_data": {"options": {"model": "test-model-2"}}
-        });
-
-        let candidate = validation_candidate(&function, &patch);
-
-        assert_eq!(candidate["project_id"], "test-project");
-        assert_eq!(candidate["description"], "New description");
-        assert_eq!(candidate["prompt_data"], patch["prompt_data"]);
-        assert_eq!(candidate["function_data"], function.function_data.unwrap());
-        assert!(candidate.get("id").is_none());
     }
 
     #[test]
@@ -580,7 +515,7 @@ mod tests {
         args.metadata = Some("owner: test-team".to_string());
 
         let body = build_patch_body(&args).expect("patch body");
-        assert_eq!(body["function_type"], "classifier");
+        assert!(body.get("function_type").is_none());
         assert_eq!(
             body["prompt_data"]["parser"]["choice"],
             json!(["safe", "unsafe"])
@@ -596,7 +531,7 @@ mod tests {
         args.pass_threshold = Some(0.8);
 
         let body = build_patch_body(&args).expect("patch body");
-        assert_eq!(body["function_type"], "scorer");
+        assert!(body.get("function_type").is_none());
         assert_eq!(
             body["prompt_data"]["parser"]["choice_scores"],
             json!({"pass": 1, "fail": 0})

--- a/src/functions/update.rs
+++ b/src/functions/update.rs
@@ -1,0 +1,806 @@
+use anyhow::{anyhow, bail, Context, Result};
+use clap::{builder::BoolishValueParser, Args};
+use dialoguer::Confirm;
+use serde_json::{json, Map, Value};
+
+use crate::{
+    error::user_error,
+    ui::{is_interactive, print_command_status, with_spinner, CommandStatus},
+    utils::{merge_json_objects, read_text_source, read_yaml_object_source},
+};
+
+use super::{
+    api, create::report_validation_issues, label, label_plural, select_function_interactive,
+};
+use super::{
+    prompt_config::{
+        parse_choice_scores_source, parse_classifications_source, validate_unit_interval,
+        PromptConfigArgs,
+    },
+    prompt_patch::materialize_prompt_data_patch,
+    FunctionTypeFilter, ResolvedContext,
+};
+
+/// Update a function's prompt configuration or metadata in place.
+///
+/// This wraps `PATCH /v1/function/{id}`. The endpoint replaces `prompt_data`
+/// wholesale, so the command reads the current definition and materializes a
+/// complete replacement while changing only the fields requested by the user.
+#[derive(Debug, Clone, Args)]
+#[command(after_help = "\
+Examples:
+  bt scorers update my-scorer --messages @messages.json
+  bt scorers update my-scorer --model gpt-5.4-nano --reasoning-effort none --temperature 0.1
+  bt scorers update my-scorer --template-format jinja --pass-threshold 0.7
+  bt scorers update my-scorer --classifications '[\"safe\",\"unsafe\"]'
+  bt scorers update my-scorer --metadata @metadata.yaml
+  bt scorers update my-scorer --description \"Helpfulness judge\"
+  bt scorers update my-scorer --patch '{\"prompt_data\":{\"options\":{\"model\":\"gpt-5.4-nano\"}}}'
+  bt scorers update --id fn_123 --patch @scorer-patch.json
+  bt tools update my-tool --patch @tool-patch.json
+")]
+pub struct UpdateArgs {
+    #[command(flatten)]
+    slug: super::SlugArgs,
+
+    /// Function id (alternative to slug). Auto-detected for `fn_`/`func_` prefixes.
+    #[arg(long = "id")]
+    id: Option<String>,
+
+    /// Replacement chat messages source: inline JSON, @PATH to read from a
+    /// file, or - for stdin.
+    #[arg(long, value_name = "SOURCE")]
+    messages: Option<String>,
+
+    /// Update the model used by an LLM scorer/prompt.
+    #[arg(long, short = 'm', value_name = "MODEL")]
+    model: Option<String>,
+
+    #[command(flatten)]
+    prompt_config: PromptConfigArgs,
+
+    /// Replace choice-to-score mappings for score output. Accepts inline JSON,
+    /// @PATH to read from a file, or - for stdin.
+    #[arg(long, value_name = "SOURCE", conflicts_with = "classifications")]
+    choice_scores: Option<String>,
+
+    /// Replace labels for classification output. Accepts an inline JSON array,
+    /// @PATH to read from a file, or - for stdin.
+    #[arg(long, value_name = "SOURCE", conflicts_with = "choice_scores")]
+    classifications: Option<String>,
+
+    /// Update chain-of-thought reasoning. Pass --use-cot=false to disable it.
+    #[arg(
+        long,
+        num_args = 0..=1,
+        default_missing_value = "true",
+        value_parser = BoolishValueParser::new()
+    )]
+    use_cot: Option<bool>,
+
+    /// Update whether a classifier may return no matching classification.
+    #[arg(
+        long,
+        num_args = 0..=1,
+        default_missing_value = "true",
+        value_parser = BoolishValueParser::new()
+    )]
+    allow_no_match: Option<bool>,
+
+    /// Update the score threshold for passing, between 0 and 1.
+    #[arg(long, value_name = "NUMBER", conflicts_with = "classifications")]
+    pass_threshold: Option<f64>,
+
+    /// Deep-merge metadata from inline YAML, @PATH, or stdin (-).
+    #[arg(long, value_name = "SOURCE")]
+    metadata: Option<String>,
+
+    /// Update the function description.
+    #[arg(long, short = 'd', value_name = "TEXT")]
+    description: Option<String>,
+
+    /// Arbitrary JSON object deep-merged into the function. Accepts inline
+    /// JSON, @PATH to read JSON from a file, or - for stdin.
+    #[arg(long, value_name = "SOURCE")]
+    patch: Option<String>,
+
+    /// Skip the confirmation prompt.
+    #[arg(long, short = 'y')]
+    yes: bool,
+}
+
+impl UpdateArgs {
+    /// Flags that only make sense for LLM scorers and classifiers.
+    ///
+    /// Returns the flag names that were set so callers can reject them on other
+    /// function kinds (for example tools) with an actionable message.
+    fn scorer_output_flags(&self) -> Vec<&'static str> {
+        let mut flags = Vec::new();
+        if self.choice_scores.is_some() {
+            flags.push("--choice-scores");
+        }
+        if self.classifications.is_some() {
+            flags.push("--classifications");
+        }
+        if self.allow_no_match.is_some() {
+            flags.push("--allow-no-match");
+        }
+        if self.use_cot.is_some() {
+            flags.push("--use-cot");
+        }
+        if self.pass_threshold.is_some() {
+            flags.push("--pass-threshold");
+        }
+        flags
+    }
+
+    fn selector(&self) -> Result<UpdateSelector<'_>> {
+        match (
+            self.id.as_deref(),
+            self.slug.slug_positional(),
+            self.slug.slug_flag(),
+        ) {
+            (Some(_), Some(_), _) | (Some(_), _, Some(_)) => {
+                bail!("use either --id or a slug, not both")
+            }
+            (Some(id), None, None) => Ok(UpdateSelector::Id(id)),
+            (None, Some(positional), None) if super::is_likely_function_id(positional) => {
+                Ok(UpdateSelector::Id(positional))
+            }
+            (None, positional, flag) => Ok(UpdateSelector::Slug(positional.or(flag))),
+        }
+    }
+}
+
+#[derive(Debug)]
+enum UpdateSelector<'a> {
+    Id(&'a str),
+    Slug(Option<&'a str>),
+}
+
+fn validation_candidate(function: &api::Function, patch: &Value) -> Value {
+    let mut candidate = json!({
+        "project_id": function.project_id,
+        "name": function.name,
+        "slug": function.slug,
+    });
+    let object = candidate
+        .as_object_mut()
+        .expect("validation candidate is an object");
+
+    for (key, value) in [
+        (
+            "description",
+            function.description.as_ref().map(|v| json!(v)),
+        ),
+        (
+            "function_type",
+            function.function_type.as_ref().map(|v| json!(v)),
+        ),
+        ("prompt_data", function.prompt_data.clone()),
+        ("function_data", function.function_data.clone()),
+        ("tags", function.tags.as_ref().map(|v| json!(v))),
+        ("metadata", function.metadata.clone()),
+    ] {
+        if let Some(value) = value {
+            object.insert(key.to_string(), value);
+        }
+    }
+
+    // PATCH replaces each top-level value. `prompt_data` has already been
+    // materialized into a complete value before this helper is called.
+    for (key, value) in patch
+        .as_object()
+        .expect("function update patch is an object")
+    {
+        object.insert(key.clone(), value.clone());
+    }
+    candidate
+}
+
+pub async fn run(
+    ctx: &ResolvedContext,
+    args: &UpdateArgs,
+    json_output: bool,
+    ft: Option<FunctionTypeFilter>,
+) -> Result<()> {
+    let mut body = build_patch_body(args)?;
+
+    let function = resolve_target_function(ctx, args, ft).await?;
+
+    // LLM scorer/classifier output flags only apply to prompt-based scorers and
+    // classifiers. Reject them on other function kinds (for example tools) so an
+    // unrelated function is not silently patched with a parser it cannot use.
+    let is_scorer_like = matches!(
+        function.function_type.as_deref(),
+        Some("scorer") | Some("classifier")
+    );
+    let scorer_flags = args.scorer_output_flags();
+    if !scorer_flags.is_empty() && !is_scorer_like {
+        bail!(
+            "{} apply to LLM scorers and classifiers, not {} '{}'. \
+             Run `bt scorers update` on a scorer instead.",
+            scorer_flags.join(", "),
+            label(ft),
+            function.name,
+        );
+    }
+
+    // Mirrors `create`, where --allow-no-match requires --classifications: a
+    // score parser would never consult it.
+    let produces_classifications =
+        args.classifications.is_some() || function.function_type.as_deref() == Some("classifier");
+    if args.allow_no_match.is_some() && !produces_classifications {
+        bail!(
+            "--allow-no-match applies to classification output, but '{}' produces scores. \
+             Pass --classifications to switch it to labels.",
+            function.name,
+        );
+    }
+
+    materialize_prompt_data_patch(&mut body, function.prompt_data.as_ref());
+
+    // Last of the up-front checks because it hits the network. Validate the
+    // complete candidate rather than the partial PATCH body so the backend can
+    // apply the same model-parameter checks as it does for scorer creation.
+    let candidate = validation_candidate(&function, &body);
+    let validation = with_spinner(
+        "Validating function...",
+        api::validate_functions(&ctx.client, std::slice::from_ref(&candidate)),
+    )
+    .await?;
+    report_validation_issues(&validation).map_err(user_error)?;
+
+    // Switching output mode updates function_type, but materialization merges
+    // the parser and does not drop the previous mode's keys. Warn so the
+    // user can review or recreate for a clean switch.
+    if !crate::ui::is_quiet() {
+        match function.function_type.as_deref() {
+            Some("classifier") if args.choice_scores.is_some() => print_command_status(
+                CommandStatus::Warning,
+                "Switching to score output; previous classification labels may remain in the definition. Review with `bt scorers view`.",
+            ),
+            Some("scorer") if args.classifications.is_some() => print_command_status(
+                CommandStatus::Warning,
+                "Switching to classification output; previous choice scores may remain in the definition. Review with `bt scorers view`.",
+            ),
+            _ => {}
+        }
+    }
+
+    if !args.yes && is_interactive() {
+        let confirm = Confirm::new()
+            .with_prompt(format!(
+                "Update {} '{}' in {}?",
+                label(ft),
+                function.name,
+                ctx.project.name
+            ))
+            .default(false)
+            .interact()?;
+        if !confirm {
+            return Ok(());
+        }
+    }
+
+    let updated = match with_spinner(
+        &format!("Updating {}...", label(ft)),
+        api::patch_function(&ctx.client, &function.id, &body),
+    )
+    .await
+    {
+        Ok(value) => {
+            print_command_status(
+                CommandStatus::Success,
+                &format!("Updated '{}'", function.name),
+            );
+            value
+        }
+        Err(error) => {
+            print_command_status(
+                CommandStatus::Error,
+                &format!("Failed to update '{}'", function.name),
+            );
+            return Err(error);
+        }
+    };
+
+    if json_output {
+        println!("{}", serde_json::to_string(&updated)?);
+    } else if !crate::ui::is_quiet() {
+        eprintln!(
+            "Run `bt {} view {}` to inspect the updated definition.",
+            label_plural(ft),
+            function.slug
+        );
+    }
+
+    Ok(())
+}
+
+async fn resolve_target_function(
+    ctx: &ResolvedContext,
+    args: &UpdateArgs,
+    ft: Option<FunctionTypeFilter>,
+) -> Result<api::Function> {
+    let project_id = &ctx.project.id;
+    match args.selector()? {
+        UpdateSelector::Id(id) => api::get_function_by_id(&ctx.client, id, None)
+            .await?
+            .ok_or_else(|| anyhow!("{} with id '{id}' not found", label(ft))),
+        UpdateSelector::Slug(Some(slug)) => {
+            api::get_function_by_slug(&ctx.client, project_id, slug, None)
+                .await?
+                .ok_or_else(|| anyhow!("{} with slug '{slug}' not found", label(ft)))
+        }
+        UpdateSelector::Slug(None) => {
+            if !is_interactive() {
+                bail!(
+                    "{} slug or --id required. Use: bt {} update <slug> [--patch ...]",
+                    label(ft),
+                    label_plural(ft),
+                );
+            }
+            Ok(select_function_interactive(&ctx.client, project_id, ft).await?)
+        }
+    }
+}
+
+fn build_patch_body(args: &UpdateArgs) -> Result<Value> {
+    let mut patch: Map<String, Value> = Map::new();
+
+    if let Some(description) = args.description.as_deref() {
+        patch.insert(
+            "description".to_string(),
+            Value::String(description.to_string()),
+        );
+    }
+
+    let metadata = resolve_metadata(args)?;
+    if !metadata.is_empty() {
+        patch.insert("metadata".to_string(), Value::Object(metadata));
+    }
+
+    if let Some(messages) = resolve_messages(args)? {
+        let prompt_data_patch = json!({
+            "prompt_data": {
+                "prompt": { "type": "chat", "messages": messages },
+            },
+        });
+        merge_json_objects(
+            &mut patch,
+            prompt_data_patch
+                .as_object()
+                .expect("prompt data patch is an object"),
+        );
+    }
+
+    let parser_patch = resolve_parser_patch(args)?;
+    if let Some((function_type, parser)) = parser_patch {
+        if let Some(function_type) = function_type {
+            patch.insert(
+                "function_type".to_string(),
+                Value::String(function_type.to_string()),
+            );
+        }
+        let prompt_data_patch = json!({ "prompt_data": { "parser": parser } });
+        merge_json_objects(
+            &mut patch,
+            prompt_data_patch
+                .as_object()
+                .expect("prompt data patch is an object"),
+        );
+    }
+
+    let prompt_config = args
+        .prompt_config
+        .build_prompt_data_patch(args.model.as_deref())?;
+    if !prompt_config.is_empty() {
+        let prompt_data_patch = json!({ "prompt_data": prompt_config });
+        merge_json_objects(
+            &mut patch,
+            prompt_data_patch
+                .as_object()
+                .expect("prompt data patch is an object"),
+        );
+    }
+
+    let extra = resolve_extra_patch(args)?;
+    if let Some(extra_obj) = extra {
+        merge_json_objects(&mut patch, &extra_obj);
+    }
+
+    if patch.is_empty() {
+        bail!("no updates requested. Pass an update flag; see `bt scorers update --help`");
+    }
+
+    Ok(Value::Object(patch))
+}
+
+fn resolve_metadata(args: &UpdateArgs) -> Result<Map<String, Value>> {
+    if args.classifications.is_some() && args.pass_threshold.is_some() {
+        bail!("--pass-threshold applies to score output and cannot be used with --classifications");
+    }
+
+    let mut metadata = match args.metadata.as_deref() {
+        Some(source) => read_yaml_object_source(source, "function metadata")?,
+        None => Map::new(),
+    };
+    if let Some(pass_threshold) = args.pass_threshold {
+        validate_unit_interval(pass_threshold, "--pass-threshold")?;
+        metadata.insert("__pass_threshold".to_string(), json!(pass_threshold));
+    }
+    Ok(metadata)
+}
+
+fn resolve_parser_patch(args: &UpdateArgs) -> Result<Option<(Option<&'static str>, Value)>> {
+    if args.choice_scores.is_some() && args.allow_no_match.is_some() {
+        bail!("--allow-no-match applies to classification output, not --choice-scores");
+    }
+
+    let mut parser = Map::new();
+    let mut function_type = None;
+
+    if let Some(source) = args.choice_scores.as_deref() {
+        parser.insert(
+            "type".to_string(),
+            Value::String("llm_classifier".to_string()),
+        );
+        parser.insert(
+            "choice_scores".to_string(),
+            Value::Object(parse_choice_scores_source(source)?),
+        );
+        function_type = Some("scorer");
+    }
+    if let Some(source) = args.classifications.as_deref() {
+        parser.insert(
+            "type".to_string(),
+            Value::String("llm_classifier".to_string()),
+        );
+        parser.insert(
+            "choice".to_string(),
+            Value::Array(parse_classifications_source(source)?),
+        );
+        function_type = Some("classifier");
+    }
+    if let Some(use_cot) = args.use_cot {
+        parser.insert("use_cot".to_string(), Value::Bool(use_cot));
+    }
+    if let Some(allow_no_match) = args.allow_no_match {
+        parser.insert("allow_no_match".to_string(), Value::Bool(allow_no_match));
+    }
+
+    if parser.is_empty() {
+        Ok(None)
+    } else {
+        Ok(Some((function_type, Value::Object(parser))))
+    }
+}
+
+fn resolve_messages(args: &UpdateArgs) -> Result<Option<Value>> {
+    match args.messages.as_deref() {
+        Some(source) => {
+            let raw = read_text_source(source, "messages")?;
+            let parsed: Value = serde_json::from_str(&raw).context("invalid JSON in --messages")?;
+            match parsed {
+                Value::Array(_) => Ok(Some(parsed)),
+                _ => bail!("--messages must be a JSON array of chat messages"),
+            }
+        }
+        None => Ok(None),
+    }
+}
+
+fn resolve_extra_patch(args: &UpdateArgs) -> Result<Option<Map<String, Value>>> {
+    let Some(source) = args.patch.as_deref() else {
+        return Ok(None);
+    };
+    let raw = read_text_source(source, "patch")?;
+    parse_patch_object(&raw).map(Some)
+}
+
+fn parse_patch_object(raw: &str) -> Result<Map<String, Value>> {
+    let value: Value = serde_json::from_str(raw).context("invalid JSON in --patch")?;
+    match value {
+        Value::Object(map) => Ok(map),
+        _ => bail!("--patch must be a JSON object"),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use clap::Parser;
+
+    use super::*;
+
+    #[derive(Debug, Parser)]
+    struct UpdateArgsHarness {
+        #[command(flatten)]
+        args: UpdateArgs,
+    }
+
+    fn args(model: Option<&str>, description: Option<&str>) -> UpdateArgs {
+        UpdateArgs {
+            slug: super::super::SlugArgs {
+                slug_positional: Some("test-slug".to_string()),
+                slug_flag: None,
+            },
+            id: None,
+            messages: None,
+            model: model.map(ToOwned::to_owned),
+            prompt_config: PromptConfigArgs::default(),
+            choice_scores: None,
+            classifications: None,
+            use_cot: None,
+            allow_no_match: None,
+            pass_threshold: None,
+            metadata: None,
+            description: description.map(ToOwned::to_owned),
+            patch: None,
+            yes: true,
+        }
+    }
+
+    #[test]
+    fn validation_candidate_applies_top_level_patch_to_existing_function() {
+        let function = api::Function {
+            id: "fn_test_update".to_string(),
+            name: "Test scorer".to_string(),
+            slug: "test-scorer".to_string(),
+            project_id: "test-project".to_string(),
+            description: Some("Old description".to_string()),
+            function_type: Some("scorer".to_string()),
+            prompt_data: Some(json!({"options": {"model": "test-model"}})),
+            function_data: Some(json!({"type": "prompt"})),
+            tags: Some(vec!["test-tag".to_string()]),
+            metadata: Some(json!({"owner": "test-user"})),
+            created: None,
+            _xact_id: None,
+        };
+        let patch = json!({
+            "description": "New description",
+            "prompt_data": {"options": {"model": "test-model-2"}}
+        });
+
+        let candidate = validation_candidate(&function, &patch);
+
+        assert_eq!(candidate["project_id"], "test-project");
+        assert_eq!(candidate["description"], "New description");
+        assert_eq!(candidate["prompt_data"], patch["prompt_data"]);
+        assert_eq!(candidate["function_data"], function.function_data.unwrap());
+        assert!(candidate.get("id").is_none());
+    }
+
+    #[test]
+    fn scorer_output_flags_reported_only_when_set() {
+        let base = args(None, None);
+        assert!(base.scorer_output_flags().is_empty());
+
+        let mut scored = args(None, None);
+        scored.choice_scores = Some(r#"{"pass":1}"#.to_string());
+        scored.pass_threshold = Some(0.5);
+        assert_eq!(
+            scored.scorer_output_flags(),
+            vec!["--choice-scores", "--pass-threshold"]
+        );
+
+        let mut labeled = args(None, None);
+        labeled.classifications = Some(r#"["a"]"#.to_string());
+        labeled.allow_no_match = Some(true);
+        labeled.use_cot = Some(false);
+        assert_eq!(
+            labeled.scorer_output_flags(),
+            vec!["--classifications", "--allow-no-match", "--use-cot"]
+        );
+    }
+
+    #[test]
+    fn build_patch_body_messages_writes_chat_block() {
+        let mut args = args(None, None);
+        args.messages = Some(r#"[{"role":"user","content":"hi"}]"#.to_string());
+        let body = build_patch_body(&args).expect("patch body");
+        assert_eq!(
+            body["prompt_data"]["prompt"]["type"],
+            serde_json::json!("chat")
+        );
+        assert_eq!(
+            body["prompt_data"]["prompt"]["messages"],
+            serde_json::json!([{"role":"user","content":"hi"}])
+        );
+    }
+
+    #[test]
+    fn build_patch_body_model_merges_into_prompt_data() {
+        let args = args(Some("gpt-4o-mini"), None);
+        let body = build_patch_body(&args).expect("patch body");
+        assert_eq!(
+            body["prompt_data"]["options"]["model"],
+            serde_json::json!("gpt-4o-mini")
+        );
+    }
+
+    #[test]
+    fn build_patch_body_messages_and_model_combine() {
+        let mut args = args(Some("gpt-4o-mini"), None);
+        args.messages = Some(r#"[{"role":"user","content":"Grade it."}]"#.to_string());
+        let body = build_patch_body(&args).expect("patch body");
+        assert_eq!(
+            body["prompt_data"]["prompt"]["messages"],
+            json!([{"role": "user", "content": "Grade it."}])
+        );
+        assert_eq!(
+            body["prompt_data"]["options"]["model"],
+            serde_json::json!("gpt-4o-mini")
+        );
+    }
+
+    #[test]
+    fn build_patch_body_updates_all_llm_configuration() {
+        let parsed = UpdateArgsHarness::try_parse_from([
+            "test",
+            "test-scorer",
+            "--model",
+            "gpt-test",
+            "--temperature",
+            "0.2",
+            "--max-tokens",
+            "128",
+            "--top-p",
+            "0.9",
+            "--frequency-penalty",
+            "0.5",
+            "--presence-penalty",
+            "0.25",
+            "--stop-sequence",
+            "END",
+            "--tool-choice",
+            "test_tool",
+            "--reasoning-effort",
+            "low",
+            "--verbosity",
+            "high",
+            "--template-format",
+            "none",
+            "--use-cot=false",
+        ])
+        .expect("parse update");
+
+        let body = build_patch_body(&parsed.args).expect("patch body");
+        let params = &body["prompt_data"]["options"]["params"];
+        assert_eq!(body["prompt_data"]["options"]["model"], "gpt-test");
+        assert_eq!(params["temperature"], 0.2);
+        assert_eq!(params["max_tokens"], 128);
+        assert_eq!(params["top_p"], 0.9);
+        assert_eq!(params["frequency_penalty"], 0.5);
+        assert_eq!(params["presence_penalty"], 0.25);
+        assert_eq!(params["stop"], json!(["END"]));
+        assert_eq!(
+            params["tool_choice"],
+            json!({"type": "function", "function": {"name": "test_tool"}})
+        );
+        assert_eq!(params["reasoning_effort"], "low");
+        assert_eq!(params["verbosity"], "high");
+        assert_eq!(body["prompt_data"]["template_format"], "none");
+        assert_eq!(body["prompt_data"]["parser"]["use_cot"], false);
+    }
+
+    #[test]
+    fn build_patch_body_switches_to_classification_output() {
+        let mut args = args(None, None);
+        args.classifications = Some(r#"["safe","unsafe"]"#.to_string());
+        args.allow_no_match = Some(true);
+        args.metadata = Some("owner: test-team".to_string());
+
+        let body = build_patch_body(&args).expect("patch body");
+        assert_eq!(body["function_type"], "classifier");
+        assert_eq!(
+            body["prompt_data"]["parser"]["choice"],
+            json!(["safe", "unsafe"])
+        );
+        assert_eq!(body["prompt_data"]["parser"]["allow_no_match"], true);
+        assert_eq!(body["metadata"]["owner"], "test-team");
+    }
+
+    #[test]
+    fn build_patch_body_updates_scores_and_pass_threshold() {
+        let mut args = args(None, None);
+        args.choice_scores = Some(r#"{"pass":1,"fail":0}"#.to_string());
+        args.pass_threshold = Some(0.8);
+
+        let body = build_patch_body(&args).expect("patch body");
+        assert_eq!(body["function_type"], "scorer");
+        assert_eq!(
+            body["prompt_data"]["parser"]["choice_scores"],
+            json!({"pass": 1, "fail": 0})
+        );
+        assert_eq!(body["metadata"]["__pass_threshold"], 0.8);
+    }
+
+    #[test]
+    fn build_patch_body_description_is_top_level() {
+        let args = args(None, Some("Helpfulness judge"));
+        let body = build_patch_body(&args).expect("patch body");
+        assert_eq!(body["description"], serde_json::json!("Helpfulness judge"));
+    }
+
+    #[test]
+    fn build_patch_body_reads_at_prefixed_messages_file() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("messages.json");
+        std::fs::write(&path, r#"[{"role":"user","content":"Grade from a file."}]"#)
+            .expect("write messages");
+        let source = format!("@{}", path.display());
+
+        let mut args = args(None, None);
+        args.messages = Some(source);
+        let body = build_patch_body(&args).expect("patch body");
+        assert_eq!(
+            body["prompt_data"]["prompt"]["messages"],
+            json!([{"role": "user", "content": "Grade from a file."}])
+        );
+    }
+
+    #[test]
+    fn build_patch_body_reads_at_prefixed_patch_file() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("patch.json");
+        std::fs::write(&path, r#"{"description":"From a file"}"#).expect("write patch");
+        let source = format!("@{}", path.display());
+
+        let mut args = args(None, None);
+        args.patch = Some(source);
+        let body = build_patch_body(&args).expect("patch body");
+        assert_eq!(body["description"], "From a file");
+    }
+
+    #[test]
+    fn build_patch_body_rejects_empty_update() {
+        let args = args(None, None);
+        let err = build_patch_body(&args).expect_err("should reject empty");
+        assert!(err.to_string().contains("no updates requested"));
+    }
+
+    #[test]
+    fn build_patch_body_extra_patch_merges_into_prompt_data() {
+        let mut args = args(None, None);
+        args.patch = Some(r#"{"prompt_data":{"parser":{"type":"llm_classifier","use_cot":true,"choice_scores":{"A":1.0,"B":0.0}}}}"#.to_string());
+        let body = build_patch_body(&args).expect("patch body");
+        assert_eq!(
+            body["prompt_data"]["parser"]["choice_scores"],
+            serde_json::json!({"A": 1.0, "B": 0.0})
+        );
+    }
+
+    #[test]
+    fn parse_patch_object_rejects_non_object() {
+        let err = parse_patch_object("[1,2,3]").expect_err("should reject");
+        assert!(err.to_string().contains("JSON object"));
+    }
+
+    #[test]
+    fn merge_objects_deep_merges_nested_maps() {
+        let mut target = serde_json::json!({
+            "prompt_data": { "options": { "model": "gpt-4o" } }
+        })
+        .as_object()
+        .expect("object")
+        .clone();
+        let source = serde_json::json!({
+            "prompt_data": { "options": { "temperature": 0 } }
+        })
+        .as_object()
+        .expect("object")
+        .clone();
+
+        merge_json_objects(&mut target, &source);
+
+        assert_eq!(
+            target["prompt_data"]["options"]["model"],
+            serde_json::json!("gpt-4o")
+        );
+        assert_eq!(
+            target["prompt_data"]["options"]["temperature"],
+            serde_json::json!(0)
+        );
+    }
+}

--- a/src/functions/update.rs
+++ b/src/functions/update.rs
@@ -6,18 +6,16 @@ use serde_json::{json, Map, Value};
 use crate::{
     error::user_error,
     ui::{is_interactive, print_command_status, with_spinner, CommandStatus},
-    utils::{merge_json_objects, read_text_source, read_yaml_object_source},
+    utils::{merge_json_objects, read_text_source},
 };
 
 use super::{
     api, create::report_validation_issues, label, label_plural, select_function_interactive,
 };
 use super::{
-    prompt_config::{
-        parse_choice_scores_source, parse_classifications_source, validate_unit_interval,
-        PromptConfigArgs,
-    },
+    prompt_config::PromptConfigArgs,
     prompt_patch::materialize_prompt_data_patch,
+    scorer_config::{build_scorer_config, ScorerConfig},
     FunctionTypeFilter, ResolvedContext,
 };
 
@@ -347,7 +345,21 @@ async fn resolve_target_function(
 }
 
 fn build_patch_body(args: &UpdateArgs) -> Result<Value> {
-    let mut patch: Map<String, Value> = Map::new();
+    let mut patch = build_scorer_config(
+        &ScorerConfig {
+            messages: args.messages.as_deref(),
+            model: args.model.as_deref(),
+            prompt_config: &args.prompt_config,
+            choice_scores: args.choice_scores.as_deref(),
+            classifications: args.classifications.as_deref(),
+            use_cot: args.use_cot,
+            allow_no_match: args.allow_no_match,
+            pass_threshold: args.pass_threshold,
+            metadata: args.metadata.as_deref(),
+            metadata_label: "function metadata",
+        },
+        false,
+    )?;
 
     if let Some(description) = args.description.as_deref() {
         patch.insert(
@@ -356,57 +368,7 @@ fn build_patch_body(args: &UpdateArgs) -> Result<Value> {
         );
     }
 
-    let metadata = resolve_metadata(args)?;
-    if !metadata.is_empty() {
-        patch.insert("metadata".to_string(), Value::Object(metadata));
-    }
-
-    if let Some(messages) = resolve_messages(args)? {
-        let prompt_data_patch = json!({
-            "prompt_data": {
-                "prompt": { "type": "chat", "messages": messages },
-            },
-        });
-        merge_json_objects(
-            &mut patch,
-            prompt_data_patch
-                .as_object()
-                .expect("prompt data patch is an object"),
-        );
-    }
-
-    let parser_patch = resolve_parser_patch(args)?;
-    if let Some((function_type, parser)) = parser_patch {
-        if let Some(function_type) = function_type {
-            patch.insert(
-                "function_type".to_string(),
-                Value::String(function_type.to_string()),
-            );
-        }
-        let prompt_data_patch = json!({ "prompt_data": { "parser": parser } });
-        merge_json_objects(
-            &mut patch,
-            prompt_data_patch
-                .as_object()
-                .expect("prompt data patch is an object"),
-        );
-    }
-
-    let prompt_config = args
-        .prompt_config
-        .build_prompt_data_patch(args.model.as_deref())?;
-    if !prompt_config.is_empty() {
-        let prompt_data_patch = json!({ "prompt_data": prompt_config });
-        merge_json_objects(
-            &mut patch,
-            prompt_data_patch
-                .as_object()
-                .expect("prompt data patch is an object"),
-        );
-    }
-
-    let extra = resolve_extra_patch(args)?;
-    if let Some(extra_obj) = extra {
+    if let Some(extra_obj) = resolve_extra_patch(args)? {
         merge_json_objects(&mut patch, &extra_obj);
     }
 
@@ -415,80 +377,6 @@ fn build_patch_body(args: &UpdateArgs) -> Result<Value> {
     }
 
     Ok(Value::Object(patch))
-}
-
-fn resolve_metadata(args: &UpdateArgs) -> Result<Map<String, Value>> {
-    if args.classifications.is_some() && args.pass_threshold.is_some() {
-        bail!("--pass-threshold applies to score output and cannot be used with --classifications");
-    }
-
-    let mut metadata = match args.metadata.as_deref() {
-        Some(source) => read_yaml_object_source(source, "function metadata")?,
-        None => Map::new(),
-    };
-    if let Some(pass_threshold) = args.pass_threshold {
-        validate_unit_interval(pass_threshold, "--pass-threshold")?;
-        metadata.insert("__pass_threshold".to_string(), json!(pass_threshold));
-    }
-    Ok(metadata)
-}
-
-fn resolve_parser_patch(args: &UpdateArgs) -> Result<Option<(Option<&'static str>, Value)>> {
-    if args.choice_scores.is_some() && args.allow_no_match.is_some() {
-        bail!("--allow-no-match applies to classification output, not --choice-scores");
-    }
-
-    let mut parser = Map::new();
-    let mut function_type = None;
-
-    if let Some(source) = args.choice_scores.as_deref() {
-        parser.insert(
-            "type".to_string(),
-            Value::String("llm_classifier".to_string()),
-        );
-        parser.insert(
-            "choice_scores".to_string(),
-            Value::Object(parse_choice_scores_source(source)?),
-        );
-        function_type = Some("scorer");
-    }
-    if let Some(source) = args.classifications.as_deref() {
-        parser.insert(
-            "type".to_string(),
-            Value::String("llm_classifier".to_string()),
-        );
-        parser.insert(
-            "choice".to_string(),
-            Value::Array(parse_classifications_source(source)?),
-        );
-        function_type = Some("classifier");
-    }
-    if let Some(use_cot) = args.use_cot {
-        parser.insert("use_cot".to_string(), Value::Bool(use_cot));
-    }
-    if let Some(allow_no_match) = args.allow_no_match {
-        parser.insert("allow_no_match".to_string(), Value::Bool(allow_no_match));
-    }
-
-    if parser.is_empty() {
-        Ok(None)
-    } else {
-        Ok(Some((function_type, Value::Object(parser))))
-    }
-}
-
-fn resolve_messages(args: &UpdateArgs) -> Result<Option<Value>> {
-    match args.messages.as_deref() {
-        Some(source) => {
-            let raw = read_text_source(source, "messages")?;
-            let parsed: Value = serde_json::from_str(&raw).context("invalid JSON in --messages")?;
-            match parsed {
-                Value::Array(_) => Ok(Some(parsed)),
-                _ => bail!("--messages must be a JSON array of chat messages"),
-            }
-        }
-        None => Ok(None),
-    }
 }
 
 fn resolve_extra_patch(args: &UpdateArgs) -> Result<Option<Map<String, Value>>> {

--- a/src/functions/update.rs
+++ b/src/functions/update.rs
@@ -16,31 +16,57 @@ use super::{
     select_function_interactive, FunctionTypeFilter, ResolvedContext,
 };
 
-/// Update a function's prompt configuration or metadata in place.
-///
-/// This wraps `PATCH /v1/function/{id}`. The endpoint replaces `prompt_data`
-/// wholesale, so the command reads the current definition and materializes a
-/// complete replacement while changing only the fields requested by the user.
+/// Fields shared by every function kind.
 #[derive(Debug, Clone, Args)]
-#[command(after_help = "\
-Examples:
-  bt scorers update my-scorer --messages @messages.json
-  bt scorers update my-scorer --model gpt-5.4-nano --reasoning-effort none --temperature 0.1
-  bt scorers update my-scorer --template-format jinja --pass-threshold 0.7
-  bt scorers update my-scorer --classifications '[\"safe\",\"unsafe\"]'
-  bt scorers update my-scorer --metadata @metadata.yaml
-  bt scorers update my-scorer --description \"Helpfulness judge\"
-  bt scorers update my-scorer --patch '{\"prompt_data\":{\"options\":{\"model\":\"gpt-5.4-nano\"}}}'
-  bt scorers update --id fn_123 --patch @scorer-patch.json
-  bt tools update my-tool --patch @tool-patch.json
-")]
-pub struct UpdateArgs {
+pub(crate) struct CommonUpdateArgs {
     #[command(flatten)]
     slug: super::SlugArgs,
 
     /// Function id (alternative to slug). Auto-detected for `fn_`/`func_` prefixes.
     #[arg(long = "id")]
     id: Option<String>,
+
+    /// Update the display name.
+    #[arg(long, value_name = "NAME")]
+    name: Option<String>,
+
+    /// Update the slug. `--slug` identifies the current function.
+    #[arg(long, value_name = "SLUG")]
+    new_slug: Option<String>,
+
+    /// Deep-merge metadata from inline YAML, @PATH, or stdin (-).
+    #[arg(long, value_name = "SOURCE")]
+    metadata: Option<String>,
+
+    /// Update the function description.
+    #[arg(long, short = 'd', value_name = "TEXT")]
+    description: Option<String>,
+
+    /// Arbitrary JSON object deep-merged into the function. Accepts inline
+    /// JSON, @PATH to read JSON from a file, or - for stdin.
+    #[arg(long, value_name = "SOURCE")]
+    patch: Option<String>,
+
+    /// Skip the confirmation prompt.
+    #[arg(long, short = 'y')]
+    yes: bool,
+}
+
+/// Update scorer prompt configuration and output behavior.
+#[derive(Debug, Clone, Args)]
+#[command(after_help = "\
+Examples:
+  bt scorers update my-scorer --name \"Helpfulness\" --new-slug helpfulness
+  bt scorers update my-scorer --messages @messages.json
+  bt scorers update my-scorer --model gpt-5.4-nano --reasoning-effort none --temperature 0.1
+  bt scorers update my-scorer --template-format jinja --pass-threshold 0.7
+  bt scorers update my-scorer --classifications '[\"safe\",\"unsafe\"]'
+  bt scorers update my-scorer --metadata @metadata.yaml
+  bt scorers update --id fn_123 --patch @scorer-patch.json
+")]
+pub(crate) struct ScorerUpdateArgs {
+    #[command(flatten)]
+    common: CommonUpdateArgs,
 
     /// Replacement chat messages source: inline JSON, @PATH to read from a
     /// file, or - for stdin.
@@ -87,50 +113,43 @@ pub struct UpdateArgs {
     /// 0 and 1.
     #[arg(long, value_name = "NUMBER", conflicts_with = "classifications")]
     pass_threshold: Option<f64>,
-
-    /// Deep-merge metadata from inline YAML, @PATH, or stdin (-).
-    #[arg(long, value_name = "SOURCE")]
-    metadata: Option<String>,
-
-    /// Update the function description.
-    #[arg(long, short = 'd', value_name = "TEXT")]
-    description: Option<String>,
-
-    /// Arbitrary JSON object deep-merged into the function. Accepts inline
-    /// JSON, @PATH to read JSON from a file, or - for stdin.
-    #[arg(long, value_name = "SOURCE")]
-    patch: Option<String>,
-
-    /// Skip the confirmation prompt.
-    #[arg(long, short = 'y')]
-    yes: bool,
 }
 
-impl UpdateArgs {
-    /// Flags that only make sense for LLM scorers and classifiers.
-    ///
-    /// Returns the flag names that were set so callers can reject them on other
-    /// function kinds (for example tools) with an actionable message.
-    fn scorer_output_flags(&self) -> Vec<&'static str> {
-        let mut flags = Vec::new();
-        if self.choice_scores.is_some() {
-            flags.push("--choice-scores");
-        }
-        if self.classifications.is_some() {
-            flags.push("--classifications");
-        }
-        if self.allow_no_match.is_some() {
-            flags.push("--allow-no-match");
-        }
-        if self.use_cot.is_some() {
-            flags.push("--use-cot");
-        }
-        if self.pass_threshold.is_some() {
-            flags.push("--pass-threshold");
-        }
-        flags
-    }
+#[derive(Debug, Clone, Args)]
+#[command(after_help = "\
+Examples:
+  bt tools update my-tool --name \"Lookup order\" --new-slug lookup-order
+  bt tools update my-tool --description \"Look up an order by id\"
+  bt tools update my-tool --prompt @prompt.txt
+  bt tools update --id fn_123 --patch @tool-patch.json
+")]
+pub(crate) struct ToolUpdateArgs {
+    #[command(flatten)]
+    common: CommonUpdateArgs,
 
+    /// Replace a completion prompt from inline text, @PATH, or stdin (-).
+    #[arg(long, value_name = "SOURCE", conflicts_with = "messages")]
+    prompt: Option<String>,
+
+    /// Replace chat messages from inline JSON/YAML, @PATH, or stdin (-).
+    #[arg(long, value_name = "SOURCE", conflicts_with = "prompt")]
+    messages: Option<String>,
+}
+
+#[derive(Debug, Clone, Args)]
+#[command(after_help = "\
+Examples:
+  bt functions update my-function --name \"New name\"
+  bt functions update my-function --new-slug new-slug
+  bt functions update my-function --description \"Updated description\"
+  bt functions update --id fn_123 --patch @function-patch.json
+")]
+pub(crate) struct GenericUpdateArgs {
+    #[command(flatten)]
+    common: CommonUpdateArgs,
+}
+
+impl CommonUpdateArgs {
     fn selector(&self) -> Result<UpdateSelector<'_>> {
         match (
             self.id.as_deref(),
@@ -155,15 +174,59 @@ enum UpdateSelector<'a> {
     Slug(Option<&'a str>),
 }
 
-pub async fn run(
+pub(crate) async fn run_scorer(
     ctx: &ResolvedContext,
-    args: &UpdateArgs,
+    args: &ScorerUpdateArgs,
+    json_output: bool,
+) -> Result<()> {
+    let body = build_scorer_patch_body(args)?;
+    run_update(
+        ctx,
+        &args.common,
+        body,
+        json_output,
+        Some(FunctionTypeFilter::Scorer),
+        Some(args),
+    )
+    .await
+}
+
+pub(crate) async fn run_tool(
+    ctx: &ResolvedContext,
+    args: &ToolUpdateArgs,
+    json_output: bool,
+) -> Result<()> {
+    let body = build_tool_patch_body(args)?;
+    run_update(
+        ctx,
+        &args.common,
+        body,
+        json_output,
+        Some(FunctionTypeFilter::Tool),
+        None,
+    )
+    .await
+}
+
+pub(crate) async fn run_generic(
+    ctx: &ResolvedContext,
+    args: &GenericUpdateArgs,
     json_output: bool,
     ft: Option<FunctionTypeFilter>,
 ) -> Result<()> {
-    let mut body = build_patch_body(args)?;
+    let body = build_common_patch_body(&args.common)?;
+    run_update(ctx, &args.common, body, json_output, ft, None).await
+}
 
-    let function = resolve_target_function(ctx, args, ft).await?;
+async fn run_update(
+    ctx: &ResolvedContext,
+    common: &CommonUpdateArgs,
+    mut body: Value,
+    json_output: bool,
+    ft: Option<FunctionTypeFilter>,
+    scorer_args: Option<&ScorerUpdateArgs>,
+) -> Result<()> {
+    let function = resolve_target_function(ctx, common, ft).await?;
     if !function_matches_filter(&function, ft) {
         bail!("'{}' is not a {}", function.name, label(ft));
     }
@@ -182,34 +245,29 @@ pub async fn run(
         );
     }
 
-    let function_type = function.function_type.as_deref();
-    let scorer_flags = args.scorer_output_flags();
-    if !scorer_flags.is_empty() && !matches!(function_type, Some("scorer") | Some("classifier")) {
-        bail!(
-            "{} apply only to scorers and classifiers",
-            scorer_flags.join(", ")
-        );
-    }
-    if matches!(
-        (
-            function_type,
-            args.choice_scores.is_some(),
-            args.classifications.is_some()
-        ),
-        (Some("classifier"), true, _) | (Some("scorer"), _, true)
-    ) {
-        bail!("PATCH cannot change between score and classification output");
-    }
-    if args.allow_no_match.is_some() && function_type != Some("classifier") {
-        bail!("--allow-no-match applies only to classification output");
-    }
-    if args.pass_threshold.is_some() && function_type == Some("classifier") {
-        bail!("--pass-threshold applies only to score output");
+    if let Some(args) = scorer_args {
+        let function_type = function.function_type.as_deref();
+        if matches!(
+            (
+                function_type,
+                args.choice_scores.is_some(),
+                args.classifications.is_some()
+            ),
+            (Some("classifier"), true, _) | (Some("scorer"), _, true)
+        ) {
+            bail!("PATCH cannot change between score and classification output");
+        }
+        if args.allow_no_match.is_some() && function_type != Some("classifier") {
+            bail!("--allow-no-match applies only to classification output");
+        }
+        if args.pass_threshold.is_some() && function_type == Some("classifier") {
+            bail!("--pass-threshold applies only to score output");
+        }
     }
 
     materialize_prompt_data_patch(&mut body, function.prompt_data.as_ref());
 
-    if !args.yes && is_interactive() {
+    if !common.yes && is_interactive() {
         let confirm = Confirm::new()
             .with_prompt(format!(
                 "Update {} '{}' in {}?",
@@ -252,7 +310,7 @@ pub async fn run(
         eprintln!(
             "Run `bt {} view {}` to inspect the updated definition.",
             label_plural(ft),
-            function.slug
+            common.new_slug.as_deref().unwrap_or(&function.slug)
         );
     }
 
@@ -279,7 +337,7 @@ fn function_matches_filter(function: &api::Function, ft: Option<FunctionTypeFilt
 
 async fn resolve_target_function(
     ctx: &ResolvedContext,
-    args: &UpdateArgs,
+    args: &CommonUpdateArgs,
     ft: Option<FunctionTypeFilter>,
 ) -> Result<api::Function> {
     let project_id = &ctx.project.id;
@@ -305,7 +363,7 @@ async fn resolve_target_function(
     }
 }
 
-fn build_patch_body(args: &UpdateArgs) -> Result<Value> {
+fn build_scorer_patch_body(args: &ScorerUpdateArgs) -> Result<Value> {
     let mut patch = build_scorer_config(
         &ScorerConfig {
             messages: args.messages.as_deref(),
@@ -316,35 +374,90 @@ fn build_patch_body(args: &UpdateArgs) -> Result<Value> {
             use_cot: args.use_cot,
             allow_no_match: args.allow_no_match,
             pass_threshold: args.pass_threshold,
-            metadata: args.metadata.as_deref(),
-            metadata_label: "function metadata",
+            metadata: args.common.metadata.as_deref(),
+            metadata_label: "scorer metadata",
         },
         false,
     )?;
     // PATCH /v1/function does not support changing function_type. Output-mode
-    // changes are rejected after resolving the current function.
+    // changes are rejected after resolving the current scorer.
     patch.remove("function_type");
+    merge_common_fields(&mut patch, &args.common, false)?;
+    finish_patch(patch, "bt scorers update --help")
+}
 
-    if let Some(description) = args.description.as_deref() {
+fn build_tool_patch_body(args: &ToolUpdateArgs) -> Result<Value> {
+    let mut patch = Map::new();
+
+    if let Some(source) = args.prompt.as_deref() {
+        let content = read_text_source(source, "prompt")?;
         patch.insert(
-            "description".to_string(),
-            Value::String(description.to_string()),
+            "prompt_data".to_string(),
+            serde_json::json!({"prompt": {"type": "completion", "content": content}}),
+        );
+    } else if let Some(source) = args.messages.as_deref() {
+        let raw = read_text_source(source, "messages")?;
+        let messages: Value =
+            yaml_serde::from_str(&raw).context("invalid JSON or YAML in --messages")?;
+        if !messages.is_array() {
+            bail!("--messages must contain an array");
+        }
+        patch.insert(
+            "prompt_data".to_string(),
+            serde_json::json!({"prompt": {"type": "chat", "messages": messages}}),
         );
     }
 
-    if let Some(extra_obj) = resolve_extra_patch(args)? {
-        merge_json_objects(&mut patch, &extra_obj);
+    merge_common_fields(&mut patch, &args.common, true)?;
+    finish_patch(patch, "bt tools update --help")
+}
+
+fn build_common_patch_body(args: &CommonUpdateArgs) -> Result<Value> {
+    let mut patch = Map::new();
+    merge_common_fields(&mut patch, args, true)?;
+    finish_patch(patch, "bt functions update --help")
+}
+
+fn merge_common_fields(
+    patch: &mut Map<String, Value>,
+    args: &CommonUpdateArgs,
+    include_metadata: bool,
+) -> Result<()> {
+    for (key, value) in [
+        ("name", args.name.as_deref()),
+        ("slug", args.new_slug.as_deref()),
+        ("description", args.description.as_deref()),
+    ] {
+        if let Some(value) = value {
+            if value.trim().is_empty() && key != "description" {
+                bail!("--{} cannot be empty", key.replace('_', "-"));
+            }
+            patch.insert(key.to_string(), Value::String(value.to_string()));
+        }
     }
 
+    if include_metadata {
+        if let Some(source) = args.metadata.as_deref() {
+            let metadata = crate::utils::read_yaml_object_source(source, "function metadata")?;
+            patch.insert("metadata".to_string(), Value::Object(metadata));
+        }
+    }
+
+    if let Some(extra_obj) = resolve_extra_patch(args.patch.as_deref())? {
+        merge_json_objects(patch, &extra_obj);
+    }
+    Ok(())
+}
+
+fn finish_patch(patch: Map<String, Value>, help_command: &str) -> Result<Value> {
     if patch.is_empty() {
-        bail!("no updates requested. Pass an update flag; see `bt scorers update --help`");
+        bail!("no updates requested. Pass an update flag; see `{help_command}`");
     }
-
     Ok(Value::Object(patch))
 }
 
-fn resolve_extra_patch(args: &UpdateArgs) -> Result<Option<Map<String, Value>>> {
-    let Some(source) = args.patch.as_deref() else {
+fn resolve_extra_patch(source: Option<&str>) -> Result<Option<Map<String, Value>>> {
+    let Some(source) = source else {
         return Ok(None);
     };
     let raw = read_text_source(source, "patch")?;
@@ -367,18 +480,26 @@ mod tests {
     use super::*;
 
     #[derive(Debug, Parser)]
-    struct UpdateArgsHarness {
+    struct ScorerUpdateArgsHarness {
         #[command(flatten)]
-        args: UpdateArgs,
+        args: ScorerUpdateArgs,
     }
 
-    fn args(model: Option<&str>, description: Option<&str>) -> UpdateArgs {
-        UpdateArgs {
-            slug: super::super::SlugArgs {
-                slug_positional: Some("test-slug".to_string()),
-                slug_flag: None,
+    fn args(model: Option<&str>, description: Option<&str>) -> ScorerUpdateArgs {
+        ScorerUpdateArgs {
+            common: CommonUpdateArgs {
+                slug: super::super::SlugArgs {
+                    slug_positional: Some("test-slug".to_string()),
+                    slug_flag: None,
+                },
+                id: None,
+                name: None,
+                new_slug: None,
+                metadata: None,
+                description: description.map(ToOwned::to_owned),
+                patch: None,
+                yes: true,
             },
-            id: None,
             messages: None,
             model: model.map(ToOwned::to_owned),
             prompt_config: PromptConfigArgs::default(),
@@ -387,41 +508,14 @@ mod tests {
             use_cot: None,
             allow_no_match: None,
             pass_threshold: None,
-            metadata: None,
-            description: description.map(ToOwned::to_owned),
-            patch: None,
-            yes: true,
         }
-    }
-
-    #[test]
-    fn scorer_output_flags_reported_only_when_set() {
-        let base = args(None, None);
-        assert!(base.scorer_output_flags().is_empty());
-
-        let mut scored = args(None, None);
-        scored.choice_scores = Some(r#"{"pass":1}"#.to_string());
-        scored.pass_threshold = Some(0.5);
-        assert_eq!(
-            scored.scorer_output_flags(),
-            vec!["--choice-scores", "--pass-threshold"]
-        );
-
-        let mut labeled = args(None, None);
-        labeled.classifications = Some(r#"["a"]"#.to_string());
-        labeled.allow_no_match = Some(true);
-        labeled.use_cot = Some(false);
-        assert_eq!(
-            labeled.scorer_output_flags(),
-            vec!["--classifications", "--allow-no-match", "--use-cot"]
-        );
     }
 
     #[test]
     fn build_patch_body_messages_writes_chat_block() {
         let mut args = args(None, None);
         args.messages = Some(r#"[{"role":"user","content":"hi"}]"#.to_string());
-        let body = build_patch_body(&args).expect("patch body");
+        let body = build_scorer_patch_body(&args).expect("patch body");
         assert_eq!(
             body["prompt_data"]["prompt"]["type"],
             serde_json::json!("chat")
@@ -435,7 +529,7 @@ mod tests {
     #[test]
     fn build_patch_body_model_merges_into_prompt_data() {
         let args = args(Some("gpt-4o-mini"), None);
-        let body = build_patch_body(&args).expect("patch body");
+        let body = build_scorer_patch_body(&args).expect("patch body");
         assert_eq!(
             body["prompt_data"]["options"]["model"],
             serde_json::json!("gpt-4o-mini")
@@ -446,7 +540,7 @@ mod tests {
     fn build_patch_body_messages_and_model_combine() {
         let mut args = args(Some("gpt-4o-mini"), None);
         args.messages = Some(r#"[{"role":"user","content":"Grade it."}]"#.to_string());
-        let body = build_patch_body(&args).expect("patch body");
+        let body = build_scorer_patch_body(&args).expect("patch body");
         assert_eq!(
             body["prompt_data"]["prompt"]["messages"],
             json!([{"role": "user", "content": "Grade it."}])
@@ -459,7 +553,7 @@ mod tests {
 
     #[test]
     fn build_patch_body_updates_all_llm_configuration() {
-        let parsed = UpdateArgsHarness::try_parse_from([
+        let parsed = ScorerUpdateArgsHarness::try_parse_from([
             "test",
             "test-scorer",
             "--model",
@@ -488,7 +582,7 @@ mod tests {
         ])
         .expect("parse update");
 
-        let body = build_patch_body(&parsed.args).expect("patch body");
+        let body = build_scorer_patch_body(&parsed.args).expect("patch body");
         let params = &body["prompt_data"]["options"]["params"];
         assert_eq!(body["prompt_data"]["options"]["model"], "gpt-test");
         assert_eq!(params["temperature"], 0.2);
@@ -512,9 +606,9 @@ mod tests {
         let mut args = args(None, None);
         args.classifications = Some(r#"["safe","unsafe"]"#.to_string());
         args.allow_no_match = Some(true);
-        args.metadata = Some("owner: test-team".to_string());
+        args.common.metadata = Some("owner: test-team".to_string());
 
-        let body = build_patch_body(&args).expect("patch body");
+        let body = build_scorer_patch_body(&args).expect("patch body");
         assert!(body.get("function_type").is_none());
         assert_eq!(
             body["prompt_data"]["parser"]["choice"],
@@ -530,7 +624,7 @@ mod tests {
         args.choice_scores = Some(r#"{"pass":1,"fail":0}"#.to_string());
         args.pass_threshold = Some(0.8);
 
-        let body = build_patch_body(&args).expect("patch body");
+        let body = build_scorer_patch_body(&args).expect("patch body");
         assert!(body.get("function_type").is_none());
         assert_eq!(
             body["prompt_data"]["parser"]["choice_scores"],
@@ -542,8 +636,50 @@ mod tests {
     #[test]
     fn build_patch_body_description_is_top_level() {
         let args = args(None, Some("Helpfulness judge"));
-        let body = build_patch_body(&args).expect("patch body");
+        let body = build_scorer_patch_body(&args).expect("patch body");
         assert_eq!(body["description"], serde_json::json!("Helpfulness judge"));
+    }
+
+    #[test]
+    fn common_fields_update_name_and_slug() {
+        let mut args = args(None, None);
+        args.common.name = Some("Updated scorer".to_string());
+        args.common.new_slug = Some("updated-scorer".to_string());
+
+        let body = build_scorer_patch_body(&args).expect("patch body");
+        assert_eq!(body["name"], "Updated scorer");
+        assert_eq!(body["slug"], "updated-scorer");
+    }
+
+    #[test]
+    fn tool_prompt_builds_completion_prompt_patch() {
+        let scorer = args(None, None);
+        let args = ToolUpdateArgs {
+            common: scorer.common,
+            prompt: Some("Look up {{order_id}}".to_string()),
+            messages: None,
+        };
+
+        let body = build_tool_patch_body(&args).expect("patch body");
+        assert_eq!(body["prompt_data"]["prompt"]["type"], "completion");
+        assert_eq!(
+            body["prompt_data"]["prompt"]["content"],
+            "Look up {{order_id}}"
+        );
+    }
+
+    #[test]
+    fn tool_messages_accept_yaml() {
+        let scorer = args(None, None);
+        let args = ToolUpdateArgs {
+            common: scorer.common,
+            prompt: None,
+            messages: Some("- role: user\n  content: Look up {{order_id}}\n".to_string()),
+        };
+
+        let body = build_tool_patch_body(&args).expect("patch body");
+        assert_eq!(body["prompt_data"]["prompt"]["type"], "chat");
+        assert_eq!(body["prompt_data"]["prompt"]["messages"][0]["role"], "user");
     }
 
     #[test]
@@ -556,7 +692,7 @@ mod tests {
 
         let mut args = args(None, None);
         args.messages = Some(source);
-        let body = build_patch_body(&args).expect("patch body");
+        let body = build_scorer_patch_body(&args).expect("patch body");
         assert_eq!(
             body["prompt_data"]["prompt"]["messages"],
             json!([{"role": "user", "content": "Grade from a file."}])
@@ -571,23 +707,23 @@ mod tests {
         let source = format!("@{}", path.display());
 
         let mut args = args(None, None);
-        args.patch = Some(source);
-        let body = build_patch_body(&args).expect("patch body");
+        args.common.patch = Some(source);
+        let body = build_scorer_patch_body(&args).expect("patch body");
         assert_eq!(body["description"], "From a file");
     }
 
     #[test]
     fn build_patch_body_rejects_empty_update() {
         let args = args(None, None);
-        let err = build_patch_body(&args).expect_err("should reject empty");
+        let err = build_scorer_patch_body(&args).expect_err("should reject empty");
         assert!(err.to_string().contains("no updates requested"));
     }
 
     #[test]
     fn build_patch_body_extra_patch_merges_into_prompt_data() {
         let mut args = args(None, None);
-        args.patch = Some(r#"{"prompt_data":{"parser":{"type":"llm_classifier","use_cot":true,"choice_scores":{"A":1.0,"B":0.0}}}}"#.to_string());
-        let body = build_patch_body(&args).expect("patch body");
+        args.common.patch = Some(r#"{"prompt_data":{"parser":{"type":"llm_classifier","use_cot":true,"choice_scores":{"A":1.0,"B":0.0}}}}"#.to_string());
+        let body = build_scorer_patch_body(&args).expect("patch body");
         assert_eq!(
             body["prompt_data"]["parser"]["choice_scores"],
             serde_json::json!({"A": 1.0, "B": 0.0})

--- a/src/functions/update.rs
+++ b/src/functions/update.rs
@@ -4,6 +4,7 @@ use dialoguer::Confirm;
 use serde_json::{Map, Value};
 
 use crate::{
+    error::user_error,
     ui::{is_interactive, print_command_status, with_spinner, CommandStatus},
     utils::{merge_json_objects, read_text_source},
 };
@@ -128,11 +129,21 @@ pub(crate) struct ToolUpdateArgs {
     common: CommonUpdateArgs,
 
     /// Replace a completion prompt from inline text, @PATH, or stdin (-).
-    #[arg(long, value_name = "SOURCE", conflicts_with = "messages")]
+    #[arg(
+        long,
+        value_name = "SOURCE",
+        conflicts_with = "messages",
+        allow_hyphen_values = true
+    )]
     prompt: Option<String>,
 
     /// Replace chat messages from inline JSON/YAML, @PATH, or stdin (-).
-    #[arg(long, value_name = "SOURCE", conflicts_with = "prompt")]
+    #[arg(
+        long,
+        value_name = "SOURCE",
+        conflicts_with = "prompt",
+        allow_hyphen_values = true
+    )]
     messages: Option<String>,
 }
 
@@ -179,7 +190,7 @@ pub(crate) async fn run_scorer(
     args: &ScorerUpdateArgs,
     json_output: bool,
 ) -> Result<()> {
-    let body = build_scorer_patch_body(args)?;
+    let body = build_scorer_patch_body(args).map_err(user_error)?;
     run_update(
         ctx,
         &args.common,
@@ -196,7 +207,7 @@ pub(crate) async fn run_tool(
     args: &ToolUpdateArgs,
     json_output: bool,
 ) -> Result<()> {
-    let body = build_tool_patch_body(args)?;
+    let body = build_tool_patch_body(args).map_err(user_error)?;
     run_update(
         ctx,
         &args.common,
@@ -214,7 +225,7 @@ pub(crate) async fn run_generic(
     json_output: bool,
     ft: Option<FunctionTypeFilter>,
 ) -> Result<()> {
-    let body = build_common_patch_body(&args.common)?;
+    let body = build_common_patch_body(&args.common).map_err(user_error)?;
     run_update(ctx, &args.common, body, json_output, ft, None).await
 }
 
@@ -228,7 +239,27 @@ async fn run_update(
 ) -> Result<()> {
     let function = resolve_target_function(ctx, common, ft).await?;
     if !function_matches_filter(&function, ft) {
-        bail!("'{}' is not a {}", function.name, label(ft));
+        return Err(user_error(anyhow!(
+            "'{}' is not a {}",
+            function.name,
+            label(ft)
+        )));
+    }
+
+    if let Some(new_slug) = common.new_slug.as_deref() {
+        if new_slug != function.slug {
+            if let Some(conflict) =
+                api::get_function_by_slug(&ctx.client, &ctx.project.id, new_slug, None).await?
+            {
+                if conflict.id != function.id {
+                    return Err(user_error(anyhow!(
+                        "--new-slug '{new_slug}' is already used by {} '{}'",
+                        conflict.function_type.as_deref().unwrap_or("function"),
+                        conflict.name
+                    )));
+                }
+            }
+        }
     }
 
     let implementation = function
@@ -238,11 +269,12 @@ async fn run_update(
         .and_then(Value::as_str)
         .unwrap_or("prompt");
     if body.get("prompt_data").is_some() && implementation != "prompt" {
-        bail!(
-            "prompt configuration cannot update {}-backed function '{}'",
+        return Err(user_error(anyhow!(
+            "prompt configuration cannot update {}-backed {} '{}'. Edit its source and run: bt functions push <path> --if-exists replace",
             implementation,
+            label(ft),
             function.name
-        );
+        )));
     }
 
     if let Some(args) = scorer_args {
@@ -255,17 +287,24 @@ async fn run_update(
             ),
             (Some("classifier"), true, _) | (Some("scorer"), _, true)
         ) {
-            bail!("PATCH cannot change between score and classification output");
+            return Err(user_error(anyhow!(
+                "cannot change between score and classification output"
+            )));
         }
         if args.allow_no_match.is_some() && function_type != Some("classifier") {
-            bail!("--allow-no-match applies only to classification output");
+            return Err(user_error(anyhow!(
+                "--allow-no-match applies only to classification output"
+            )));
         }
         if args.pass_threshold.is_some() && function_type == Some("classifier") {
-            bail!("--pass-threshold applies only to score output");
+            return Err(user_error(anyhow!(
+                "--pass-threshold applies only to score output"
+            )));
         }
     }
 
     materialize_prompt_data_patch(&mut body, function.prompt_data.as_ref());
+    materialize_metadata_patch(&mut body, function.metadata.as_ref());
 
     if !common.yes && is_interactive() {
         let confirm = Confirm::new()
@@ -423,14 +462,14 @@ fn merge_common_fields(
     args: &CommonUpdateArgs,
     include_metadata: bool,
 ) -> Result<()> {
-    for (key, value) in [
-        ("name", args.name.as_deref()),
-        ("slug", args.new_slug.as_deref()),
-        ("description", args.description.as_deref()),
+    for (key, flag, value) in [
+        ("name", "--name", args.name.as_deref()),
+        ("slug", "--new-slug", args.new_slug.as_deref()),
+        ("description", "--description", args.description.as_deref()),
     ] {
         if let Some(value) = value {
             if value.trim().is_empty() && key != "description" {
-                bail!("--{} cannot be empty", key.replace('_', "-"));
+                bail!("{flag} cannot be empty");
             }
             patch.insert(key.to_string(), Value::String(value.to_string()));
         }
@@ -447,6 +486,19 @@ fn merge_common_fields(
         merge_json_objects(patch, &extra_obj);
     }
     Ok(())
+}
+
+fn materialize_metadata_patch(patch: &mut Value, existing_metadata: Option<&Value>) {
+    let Some(patch_metadata) = patch.get("metadata").and_then(Value::as_object).cloned() else {
+        return;
+    };
+
+    let mut metadata = existing_metadata
+        .and_then(Value::as_object)
+        .cloned()
+        .unwrap_or_default();
+    merge_json_objects(&mut metadata, &patch_metadata);
+    patch["metadata"] = Value::Object(metadata);
 }
 
 fn finish_patch(patch: Map<String, Value>, help_command: &str) -> Result<Value> {
@@ -483,6 +535,12 @@ mod tests {
     struct ScorerUpdateArgsHarness {
         #[command(flatten)]
         args: ScorerUpdateArgs,
+    }
+
+    #[derive(Debug, Parser)]
+    struct ToolUpdateArgsHarness {
+        #[command(flatten)]
+        args: ToolUpdateArgs,
     }
 
     fn args(model: Option<&str>, description: Option<&str>) -> ScorerUpdateArgs {
@@ -669,15 +727,33 @@ mod tests {
     }
 
     #[test]
-    fn tool_messages_accept_yaml() {
-        let scorer = args(None, None);
-        let args = ToolUpdateArgs {
-            common: scorer.common,
-            prompt: None,
-            messages: Some("- role: user\n  content: Look up {{order_id}}\n".to_string()),
-        };
+    fn tool_prompt_accepts_text_beginning_with_a_dash() {
+        let parsed = ToolUpdateArgsHarness::try_parse_from([
+            "test",
+            "test-tool",
+            "--prompt",
+            "- instruction {{value}}",
+        ])
+        .expect("parse prompt beginning with a dash");
 
-        let body = build_tool_patch_body(&args).expect("patch body");
+        let body = build_tool_patch_body(&parsed.args).expect("patch body");
+        assert_eq!(
+            body["prompt_data"]["prompt"]["content"],
+            "- instruction {{value}}"
+        );
+    }
+
+    #[test]
+    fn tool_messages_accept_yaml() {
+        let parsed = ToolUpdateArgsHarness::try_parse_from([
+            "test",
+            "test-tool",
+            "--messages",
+            "- role: user\n  content: Look up {{order_id}}\n",
+        ])
+        .expect("parse inline YAML beginning with a dash");
+
+        let body = build_tool_patch_body(&parsed.args).expect("patch body");
         assert_eq!(body["prompt_data"]["prompt"]["type"], "chat");
         assert_eq!(body["prompt_data"]["prompt"]["messages"][0]["role"], "user");
     }
@@ -761,5 +837,31 @@ mod tests {
             target["prompt_data"]["options"]["temperature"],
             serde_json::json!(0)
         );
+    }
+
+    #[test]
+    fn metadata_patch_preserves_existing_fields() {
+        let mut patch = json!({"metadata": {"owner": "test-team"}});
+        let existing = json!({"__pass_threshold": 0.6, "phase": "test"});
+
+        materialize_metadata_patch(&mut patch, Some(&existing));
+
+        assert_eq!(
+            patch["metadata"],
+            json!({
+                "__pass_threshold": 0.6,
+                "phase": "test",
+                "owner": "test-team"
+            })
+        );
+    }
+
+    #[test]
+    fn empty_new_slug_names_the_correct_flag() {
+        let mut args = args(None, None);
+        args.common.new_slug = Some(String::new());
+
+        let error = build_scorer_patch_body(&args).expect_err("empty slug should fail");
+        assert_eq!(error.to_string(), "--new-slug cannot be empty");
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -547,8 +547,7 @@ fn has_io_error(err: &anyhow::Error) -> bool {
 }
 
 fn has_user_error(err: &anyhow::Error) -> bool {
-    err.chain()
-        .any(|source| source.downcast_ref::<crate::error::UserError>().is_some())
+    err.downcast_ref::<crate::error::UserError>().is_some()
 }
 
 fn looks_like_user_error(err: &anyhow::Error) -> bool {
@@ -762,29 +761,26 @@ mod tests {
 
     #[test]
     fn typed_user_errors_use_the_user_exit_code() {
-        let err = anyhow::Error::new(crate::error::UserError::from(anyhow::anyhow!(
-            "--temperature must be between 0 and 2"
-        )));
+        let err =
+            crate::error::user_error(anyhow::anyhow!("--temperature must be between 0 and 2"));
 
         assert_eq!(classify_error(&err, false), ExitCode::User);
     }
 
     #[test]
     fn provider_credential_errors_are_not_classified_as_bt_auth_errors() {
-        let err = anyhow::Error::new(crate::error::UserError::from(anyhow::Error::new(
-            crate::http::HttpError {
-                status: reqwest::StatusCode::UNAUTHORIZED,
-                body: serde_json::json!({
-                    "error": {
-                        "message": "Incorrect API key provided: synthetic-key",
-                        "type": "invalid_request_error",
-                        "code": "invalid_api_key"
-                    },
-                    "status": 401
-                })
-                .to_string(),
-            },
-        )));
+        let err = crate::error::user_error(anyhow::Error::new(crate::http::HttpError {
+            status: reqwest::StatusCode::UNAUTHORIZED,
+            body: serde_json::json!({
+                "error": {
+                    "message": "Incorrect API key provided: synthetic-key",
+                    "type": "invalid_request_error",
+                    "code": "invalid_api_key"
+                },
+                "status": 401
+            })
+            .to_string(),
+        }));
 
         assert_eq!(classify_error(&err, false), ExitCode::User);
         let payload = json_error_payload(&err);

--- a/src/main.rs
+++ b/src/main.rs
@@ -588,7 +588,7 @@ fn json_error_message(details: &serde_json::Value) -> Option<String> {
 
 fn print_error(err: &anyhow::Error, code: ExitCode, missing_credential: bool, json_output: bool) {
     if json_output {
-        eprintln!("{}", json_error_payload(err));
+        println!("{}", json_error_payload(err));
         return;
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,6 +8,7 @@ mod auth;
 mod config;
 mod datasets;
 mod env;
+mod error;
 #[cfg(unix)]
 mod eval;
 mod experiments;
@@ -461,9 +462,13 @@ fn classify_error(err: &anyhow::Error, missing_credential: bool) -> ExitCode {
         return ExitCode::from_process_code(err.1);
     }
 
+    if has_user_error(err) {
+        return ExitCode::User;
+    }
+
     if let Some(http_error) = find_http_error(err) {
         let status = http_error.status.as_u16();
-        if (status == 401 || status == 403) && !is_upstream_provider_auth_error(http_error) {
+        if status == 401 || status == 403 {
             return ExitCode::Auth;
         }
         if (400..=499).contains(&status) {
@@ -496,22 +501,6 @@ fn classify_error(err: &anyhow::Error, missing_credential: bool) -> ExitCode {
 fn find_http_error(err: &anyhow::Error) -> Option<&crate::http::HttpError> {
     err.chain()
         .find_map(|source| source.downcast_ref::<crate::http::HttpError>())
-}
-
-fn is_upstream_provider_auth_error(error: &crate::http::HttpError) -> bool {
-    let Ok(body) = serde_json::from_str::<serde_json::Value>(&error.body) else {
-        return false;
-    };
-    let provider_error = body.get("error").unwrap_or(&body);
-    provider_error.get("code").and_then(|value| value.as_str()) == Some("invalid_api_key")
-        || provider_error
-            .get("message")
-            .and_then(|value| value.as_str())
-            .is_some_and(|message| {
-                let message = message.to_ascii_lowercase();
-                message.contains("incorrect api key provided")
-                    || message.contains("llm provider") && message.contains("credential")
-            })
 }
 
 fn classify_sdk_error(err: &anyhow::Error) -> Option<ExitCode> {
@@ -557,6 +546,11 @@ fn has_io_error(err: &anyhow::Error) -> bool {
         .any(|source| source.downcast_ref::<std::io::Error>().is_some())
 }
 
+fn has_user_error(err: &anyhow::Error) -> bool {
+    err.chain()
+        .any(|source| source.downcast_ref::<crate::error::UserError>().is_some())
+}
+
 fn looks_like_user_error(err: &anyhow::Error) -> bool {
     let message = err.to_string().to_lowercase();
     message.contains("required")
@@ -566,14 +560,36 @@ fn looks_like_user_error(err: &anyhow::Error) -> bool {
 }
 
 fn json_error_payload(err: &anyhow::Error) -> serde_json::Value {
-    find_http_error(err)
-        .and_then(|error| serde_json::from_str(&error.body).ok())
-        .unwrap_or_else(|| serde_json::json!({ "error": { "message": err.to_string() } }))
+    let details = find_http_error(err)
+        .and_then(|error| serde_json::from_str::<serde_json::Value>(&error.body).ok());
+    let message = details
+        .as_ref()
+        .and_then(json_error_message)
+        .unwrap_or_else(|| err.to_string());
+
+    match details {
+        Some(details) => serde_json::json!({
+            "error": {
+                "message": message,
+                "details": details,
+            }
+        }),
+        None => serde_json::json!({ "error": { "message": message } }),
+    }
+}
+
+fn json_error_message(details: &serde_json::Value) -> Option<String> {
+    details
+        .pointer("/error/message")
+        .and_then(serde_json::Value::as_str)
+        .or_else(|| details.get("message").and_then(serde_json::Value::as_str))
+        .or_else(|| details.get("error").and_then(serde_json::Value::as_str))
+        .map(ToOwned::to_owned)
 }
 
 fn print_error(err: &anyhow::Error, code: ExitCode, missing_credential: bool, json_output: bool) {
     if json_output {
-        println!("{}", json_error_payload(err));
+        eprintln!("{}", json_error_payload(err));
         return;
     }
 
@@ -745,32 +761,76 @@ mod tests {
     }
 
     #[test]
-    fn provider_credential_errors_are_not_classified_as_bt_auth_errors() {
-        let err = anyhow::Error::new(crate::http::HttpError {
-            status: reqwest::StatusCode::UNAUTHORIZED,
-            body: serde_json::json!({
-                "error": {
-                    "message": "Incorrect API key provided: synthetic-key",
-                    "type": "invalid_request_error",
-                    "code": "invalid_api_key"
-                },
-                "status": 401
-            })
-            .to_string(),
-        });
+    fn typed_user_errors_use_the_user_exit_code() {
+        let err = anyhow::Error::new(crate::error::UserError::from(anyhow::anyhow!(
+            "--temperature must be between 0 and 2"
+        )));
 
         assert_eq!(classify_error(&err, false), ExitCode::User);
-        assert_eq!(json_error_payload(&err)["error"]["code"], "invalid_api_key");
+    }
+
+    #[test]
+    fn provider_credential_errors_are_not_classified_as_bt_auth_errors() {
+        let err = anyhow::Error::new(crate::error::UserError::from(anyhow::Error::new(
+            crate::http::HttpError {
+                status: reqwest::StatusCode::UNAUTHORIZED,
+                body: serde_json::json!({
+                    "error": {
+                        "message": "Incorrect API key provided: synthetic-key",
+                        "type": "invalid_request_error",
+                        "code": "invalid_api_key"
+                    },
+                    "status": 401
+                })
+                .to_string(),
+            },
+        )));
+
+        assert_eq!(classify_error(&err, false), ExitCode::User);
+        let payload = json_error_payload(&err);
+        assert_eq!(
+            payload["error"]["message"],
+            "Incorrect API key provided: synthetic-key"
+        );
+        assert_eq!(
+            payload["error"]["details"]["error"]["code"],
+            "invalid_api_key"
+        );
+    }
+
+    #[test]
+    fn json_http_errors_use_a_stable_envelope() {
+        let err = anyhow::Error::new(crate::http::HttpError {
+            status: reqwest::StatusCode::BAD_REQUEST,
+            body: serde_json::json!(["synthetic", "details"]).to_string(),
+        });
+
+        let payload = json_error_payload(&err);
+        assert!(payload["error"]["message"].is_string());
+        assert_eq!(
+            payload["error"]["details"],
+            serde_json::json!(["synthetic", "details"])
+        );
     }
 
     #[test]
     fn bt_unauthorized_errors_remain_auth_errors() {
-        let err = anyhow::Error::new(crate::http::HttpError {
-            status: reqwest::StatusCode::UNAUTHORIZED,
-            body: r#"{"error":"Unauthorized"}"#.to_string(),
-        });
+        for body in [
+            serde_json::json!({ "error": "Unauthorized" }),
+            serde_json::json!({
+                "error": {
+                    "message": "Invalid Braintrust API key",
+                    "code": "invalid_api_key"
+                }
+            }),
+        ] {
+            let err = anyhow::Error::new(crate::http::HttpError {
+                status: reqwest::StatusCode::UNAUTHORIZED,
+                body: body.to_string(),
+            });
 
-        assert_eq!(classify_error(&err, false), ExitCode::Auth);
+            assert_eq!(classify_error(&err, false), ExitCode::Auth);
+        }
     }
 
     #[test]

--- a/src/scorers.rs
+++ b/src/scorers.rs
@@ -96,26 +96,4 @@ mod tests {
             Some(ScorersCommands::Create(_))
         ));
     }
-
-    #[test]
-    fn parses_create_classifier() {
-        let parsed = ScorersArgsHarness::try_parse_from([
-            "bt-scorers",
-            "create",
-            "Test classifier",
-            "--model",
-            "gpt-test",
-            "--messages",
-            r#"[{"role":"user","content":"Classify {{output}}"}]"#,
-            "--classifications",
-            r#"["safe","unsafe"]"#,
-            "--allow-no-match",
-        ])
-        .expect("parse create classifier");
-
-        assert!(matches!(
-            parsed.args.command,
-            Some(ScorersCommands::Create(_))
-        ));
-    }
 }

--- a/src/scorers.rs
+++ b/src/scorers.rs
@@ -11,6 +11,7 @@ Examples:
   bt scorers view my-scorer
   bt scorers create \"Helpfulness\" --model gpt-5.4-nano --messages @messages.json \\
     --choice-scores '{\"A\":1,\"B\":0}'
+  bt scorers update my-scorer --messages @messages.json
   bt scorers delete my-scorer
 
 TypeScript and Python code scorers:
@@ -47,30 +48,11 @@ mod tests {
     use clap::Parser;
 
     use super::*;
-    use crate::args::CLIArgs;
 
     #[derive(Debug, Parser)]
     struct ScorersArgsHarness {
         #[command(flatten)]
         args: ScorersArgs,
-    }
-
-    #[test]
-    fn invoke_accepts_global_json_flag() {
-        #[derive(Debug, Parser)]
-        struct Harness {
-            #[command(flatten)]
-            command: CLIArgs<ScorersArgs>,
-        }
-
-        let parsed = Harness::try_parse_from(["bt-scorers", "invoke", "test-scorer", "--json"])
-            .expect("parse scorer invoke with global JSON output");
-
-        assert!(parsed.command.base.json);
-        assert!(matches!(
-            parsed.command.args.command,
-            Some(ScorersCommands::Function(FunctionCommands::Invoke(_)))
-        ));
     }
 
     #[test]
@@ -94,6 +76,46 @@ mod tests {
         assert!(matches!(
             parsed.args.command,
             Some(ScorersCommands::Create(_))
+        ));
+    }
+
+    #[test]
+    fn parses_create_classifier() {
+        let parsed = ScorersArgsHarness::try_parse_from([
+            "bt-scorers",
+            "create",
+            "Test classifier",
+            "--model",
+            "gpt-test",
+            "--messages",
+            r#"[{"role":"user","content":"Classify {{output}}"}]"#,
+            "--classifications",
+            r#"["safe","unsafe"]"#,
+            "--allow-no-match",
+        ])
+        .expect("parse create classifier");
+
+        assert!(matches!(
+            parsed.args.command,
+            Some(ScorersCommands::Create(_))
+        ));
+    }
+
+    #[test]
+    fn still_parses_shared_scorer_commands() {
+        let parsed = ScorersArgsHarness::try_parse_from([
+            "bt-scorers",
+            "update",
+            "test-scorer",
+            "--model",
+            "gpt-test",
+            "--yes",
+        ])
+        .expect("parse update");
+
+        assert!(matches!(
+            parsed.args.command,
+            Some(ScorersCommands::Function(FunctionCommands::Update(_)))
         ));
     }
 }

--- a/src/scorers.rs
+++ b/src/scorers.rs
@@ -2,7 +2,7 @@ use anyhow::Result;
 use clap::{Args, Subcommand};
 
 use crate::args::BaseArgs;
-use crate::functions::{self, FunctionCommands, FunctionTypeFilter};
+use crate::functions::{self, ScorerFunctionCommands};
 
 #[derive(Debug, Clone, Args)]
 #[command(after_help = "\
@@ -30,16 +30,16 @@ enum ScorersCommands {
     /// Create an LLM scorer or classifier
     Create(Box<functions::create::CreateArgs>),
     #[command(flatten)]
-    Function(FunctionCommands),
+    Function(ScorerFunctionCommands),
 }
 
 pub async fn run(base: BaseArgs, args: ScorersArgs) -> Result<()> {
     match args.command {
         Some(ScorersCommands::Create(create)) => functions::run_scorer_create(base, *create).await,
         Some(ScorersCommands::Function(command)) => {
-            functions::run_typed_command(base, Some(command), FunctionTypeFilter::Scorer).await
+            functions::run_scorer_command(base, Some(command)).await
         }
-        None => functions::run_typed_command(base, None, FunctionTypeFilter::Scorer).await,
+        None => functions::run_scorer_command(base, None).await,
     }
 }
 
@@ -115,7 +115,7 @@ mod tests {
 
         assert!(matches!(
             parsed.args.command,
-            Some(ScorersCommands::Function(FunctionCommands::Update(_)))
+            Some(ScorersCommands::Function(ScorerFunctionCommands::Update(_)))
         ));
     }
 }

--- a/src/utils/text_source.rs
+++ b/src/utils/text_source.rs
@@ -1,4 +1,4 @@
-use std::io::Read;
+use std::io::{IsTerminal, Read};
 use std::sync::Mutex;
 
 use anyhow::{bail, Context, Result};
@@ -20,6 +20,8 @@ fn read_text_source_with_stdin_guard(
     stdin_reader: &Mutex<Option<String>>,
 ) -> Result<String> {
     if value == "-" {
+        ensure_stdin_is_piped(label, std::io::stdin().is_terminal())?;
+
         // The second reader would otherwise see "" and call it malformed input.
         let mut reader = stdin_reader
             .lock()
@@ -50,6 +52,15 @@ fn read_text_source_with_stdin_guard(
     }
 
     Ok(value.to_string())
+}
+
+fn ensure_stdin_is_piped(label: &str, stdin_is_terminal: bool) -> Result<()> {
+    if stdin_is_terminal {
+        bail!(
+            "cannot read {label} from interactive stdin; pipe input or use an inline value or @PATH"
+        );
+    }
+    Ok(())
 }
 
 #[cfg(test)]
@@ -89,6 +100,17 @@ mod tests {
     fn rejects_empty_file_reference() {
         let error = read_text_source("@", "prompt").expect_err("empty path should fail");
         assert!(error.to_string().contains("cannot be empty"));
+    }
+
+    #[test]
+    fn rejects_interactive_stdin_source() {
+        let error = ensure_stdin_is_piped("messages", true)
+            .expect_err("interactive stdin should not wait for EOF");
+
+        assert_eq!(
+            error.to_string(),
+            "cannot read messages from interactive stdin; pipe input or use an inline value or @PATH"
+        );
     }
 
     #[test]

--- a/src/utils/text_source.rs
+++ b/src/utils/text_source.rs
@@ -20,15 +20,18 @@ fn read_text_source_with_stdin_guard(
     stdin_reader: &Mutex<Option<String>>,
 ) -> Result<String> {
     if value == "-" {
-        ensure_stdin_is_piped(label, std::io::stdin().is_terminal())?;
-
-        // The second reader would otherwise see "" and call it malformed input.
+        // Check this first so a duplicate source reports the actual conflict,
+        // even when the process's stdin is an interactive terminal.
         let mut reader = stdin_reader
             .lock()
             .map_err(|_| anyhow::anyhow!("stdin guard poisoned"))?;
         if let Some(previous) = reader.as_deref() {
             bail!("stdin was already read for {previous}; only one source can be '-'");
         }
+
+        ensure_stdin_is_piped(label, std::io::stdin().is_terminal())?;
+
+        // The second reader would otherwise see "" and call it malformed input.
         *reader = Some(label.to_string());
         drop(reader);
 

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -10,6 +10,8 @@ fn bt_command() -> Command {
 fn clear_braintrust_auth_env(cmd: &mut Command) {
     for key in [
         "BRAINTRUST_API_KEY",
+        "BRAINTRUST_API_URL",
+        "BRAINTRUST_APP_URL",
         "BRAINTRUST_PROFILE",
         "BRAINTRUST_ORG_NAME",
         "BRAINTRUST_DEFAULT_PROJECT",

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -1228,6 +1228,21 @@ fn scorers_create_help_includes_llm_judge_configuration() {
 }
 
 #[test]
+fn scorer_update_help_is_conflict_free() {
+    bt_command()
+        .args(["scorers", "update", "--help"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("--patch <SOURCE>"))
+        .stdout(predicate::str::contains("--patch-file").not())
+        .stdout(predicate::str::contains("--messages <SOURCE>"))
+        .stdout(predicate::str::contains("--temperature"))
+        .stdout(predicate::str::contains("--classifications"))
+        .stdout(predicate::str::contains("--pass-threshold"))
+        .stdout(predicate::str::contains("--metadata"));
+}
+
+#[test]
 fn topics_report_help_accepts_global_org_short_conflict_free() {
     bt_command()
         .args([

--- a/tests/datasets-fixtures/snapshots-create/fixture.json
+++ b/tests/datasets-fixtures/snapshots-create/fixture.json
@@ -126,7 +126,7 @@
         "baseline"
       ],
       "expect_success": false,
-      "stderr_contains": [
+      "stdout_contains": [
         "snapshot delete requires --force in non-interactive mode"
       ]
     },
@@ -169,7 +169,7 @@
         "snapshot-source"
       ],
       "expect_success": false,
-      "stderr_contains": [
+      "stdout_contains": [
         "dataset delete requires --force in non-interactive mode"
       ]
     },

--- a/tests/datasets-fixtures/snapshots-create/fixture.json
+++ b/tests/datasets-fixtures/snapshots-create/fixture.json
@@ -126,7 +126,7 @@
         "baseline"
       ],
       "expect_success": false,
-      "stdout_contains": [
+      "stderr_contains": [
         "snapshot delete requires --force in non-interactive mode"
       ]
     },
@@ -169,7 +169,7 @@
         "snapshot-source"
       ],
       "expect_success": false,
-      "stdout_contains": [
+      "stderr_contains": [
         "dataset delete requires --force in non-interactive mode"
       ]
     },

--- a/tests/functions.rs
+++ b/tests/functions.rs
@@ -728,7 +728,7 @@ fn root_login_refresh_uses_selected_profile() {
 
     let output = cmd.output().expect("run bt login --refresh");
     assert!(!output.status.success());
-    assert!(String::from_utf8_lossy(&output.stdout)
+    assert!(String::from_utf8_lossy(&output.stderr)
         .contains("`bt login --refresh` only applies to oauth profiles"));
 }
 

--- a/tests/functions.rs
+++ b/tests/functions.rs
@@ -562,6 +562,39 @@ fn functions_push_help_includes_expected_flags() {
 }
 
 #[test]
+fn update_help_is_specific_to_each_function_kind() {
+    let help = |resource: &str| {
+        let output = Command::new(bt_binary_path())
+            .args([resource, "update", "--help"])
+            .output()
+            .unwrap_or_else(|error| panic!("run bt {resource} update --help: {error}"));
+        assert!(output.status.success());
+        String::from_utf8(output.stdout).expect("UTF-8 help output")
+    };
+
+    let tools = help("tools");
+    assert!(tools.contains("--name"));
+    assert!(tools.contains("--new-slug"));
+    assert!(tools.contains("--prompt"));
+    assert!(tools.contains("--messages"));
+    assert!(!tools.contains("--choice-scores"));
+    assert!(!tools.contains("--pass-threshold"));
+
+    let functions = help("functions");
+    assert!(functions.contains("--name"));
+    assert!(functions.contains("--new-slug"));
+    assert!(functions.contains("--description"));
+    assert!(functions.contains("--patch"));
+    assert!(!functions.contains("--model"));
+    assert!(!functions.contains("--choice-scores"));
+
+    let scorers = help("scorers");
+    assert!(scorers.contains("--new-slug"));
+    assert!(scorers.contains("--model"));
+    assert!(scorers.contains("--choice-scores"));
+}
+
+#[test]
 fn functions_pull_help_includes_expected_flags() {
     let output = Command::new(bt_binary_path())
         .arg("functions")

--- a/tests/functions.rs
+++ b/tests/functions.rs
@@ -130,15 +130,7 @@ fn find_tsc() -> Option<PathBuf> {
     } else {
         repo_root().join("node_modules").join(".bin").join("tsc")
     };
-    if local.is_file() {
-        return Some(local);
-    }
-
-    if command_exists("tsc") {
-        return Some(PathBuf::from("tsc"));
-    }
-
-    None
+    local.is_file().then_some(local)
 }
 
 #[cfg(unix)]
@@ -724,12 +716,22 @@ fn root_login_refresh_uses_selected_profile() {
         .env("APPDATA", config_dir.path())
         .env("BRAINTRUST_NO_COLOR", "1")
         .env_remove("BRAINTRUST_API_KEY")
+        .env_remove("BRAINTRUST_API_URL")
+        .env_remove("BRAINTRUST_APP_URL")
         .env_remove("BRAINTRUST_ORG_NAME");
 
     let output = cmd.output().expect("run bt login --refresh");
     assert!(!output.status.success());
-    assert!(String::from_utf8_lossy(&output.stderr)
-        .contains("`bt login --refresh` only applies to oauth profiles"));
+    let payload: Value = serde_json::from_slice(&output.stdout)
+        .expect("JSON failures should emit a machine-readable payload on stdout");
+    assert!(payload["error"]["message"].as_str().is_some_and(
+        |message| message.contains("`bt login --refresh` only applies to oauth profiles")
+    ));
+    assert!(
+        output.stderr.is_empty(),
+        "JSON failure should not be emitted on stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
 }
 
 #[test]


### PR DESCRIPTION
#### `scorers.sh`:

<details>

```bash
# Command examples for `bt scorers update`.
#
# Run these one at a time from the repository root. Replace the synthetic
# slugs with scorers from your test environment.

SCORER="test-update-scorer"
CLASSIFIER="test-update-classifier"

# Inspect a scorer before changing it.
bt scorers view "$SCORER"

# Update fields shared by prompt- and code-backed scorers.
bt scorers update "$SCORER" \
  --name "Test update scorer renamed" \
  --new-slug test-update-scorer-renamed \
  --description "Synthetic scorer updated from bt" \
  --yes
SCORER="test-update-scorer-renamed"

# Change only the model and model parameters. Existing messages and parser
# configuration are preserved.
bt scorers update "$SCORER" \
  --model gpt-5.4-nano \
  --reasoning-effort none \
  --temperature 0.1 \
  --yes

# Replace chat messages from a JSON file.
bt scorers update "$SCORER" \
  --messages @messages.json \
  --yes

# Replace score choices and set the passing threshold.
bt scorers update "$SCORER" \
  --choice-scores @choice-scores.json \
  --pass-threshold 0.7 \
  --use-cot=false \
  --yes

# Replace classifier labels and permit no matching label.
bt scorers update "$CLASSIFIER" \
  --classifications @classifications.json \
  --allow-no-match \
  --yes

# Deep-merge metadata without removing the pass threshold or existing keys.
bt scorers update "$SCORER" \
  --metadata @metadata.json \
  --yes

# Configure a structured model response.
bt scorers update "$SCORER" \
  --response-format @response-format.json \
  --yes

# Apply fields without dedicated flags through an arbitrary JSON patch.
bt scorers update "$SCORER" \
  --patch @scorer-patch.json \
  --yes

# Inspect the resulting definition and verify unchanged prompt fields remain.
bt scorers view "$SCORER"
```

</details>

The JSON files:

<details>

`choice-scores.json`:

```json
{
  "PASS": 1,
  "FAIL": 0
}
```

`classifications.json`:

```json
["safe", "unsafe", "uncertain"]
```

`messages.json`:

```json
[
  {
    "role": "system",
    "content": "You are a strict evaluator. Return exactly PASS or FAIL."
  },
  {
    "role": "user",
    "content": "Question: {{input.question}}\nExpected: {{expected}}\nCandidate: {{output}}"
  }
]
```

`metadata.json`:

```json
{
  "owner": "test-team",
  "purpose": "synthetic-update-example"
}
```

`response-format.json`:

```json
{
  "type": "json_schema",
  "json_schema": {
    "name": "grader_result",
    "description": "A synthetic grading result",
    "schema": {
      "type": "object",
      "properties": {
        "label": {
          "type": "string",
          "enum": ["PASS", "FAIL"]
        }
      },
      "required": ["label"],
      "additionalProperties": false
    },
    "strict": true
  }
}
```

`scorer-patch.json`:

```json
{
  "prompt_data": {
    "options": {
      "params": {
        "use_cache": false
      }
    }
  }
}
```

</details>

And its output:

<details>

```text
Viewing Test update scorer
Slug: test-update-scorer
Type: scorer
Description: Synthetic scorer for bt update testing
Model: gpt-4o-mini

✓ Updated 'Test update scorer'
Run `bt scorers view test-update-scorer-renamed` to inspect the updated definition.
✓ Updated 'Test update scorer renamed'
Run `bt scorers view test-update-scorer-renamed` to inspect the updated definition.
✓ Updated 'Test update scorer renamed'
Run `bt scorers view test-update-scorer-renamed` to inspect the updated definition.

Viewing Test update scorer renamed
Slug: test-update-scorer-renamed
Type: scorer
Description: Synthetic scorer updated from bt
Model: gpt-5.4-nano
  reasoning_effort:       none
  temperature:            0.1
  use_cache:              false

Metadata: {
  "__pass_threshold": 0.7,
  "owner": "test-team",
  "purpose": "synthetic-update-example"
}
```

</details>

#### `functions.sh`:

<details>

```bash
# Command examples for `bt functions update`.
#
# `bt functions update` intentionally exposes common function fields and the
# arbitrary patch escape hatch, rather than scorer-only prompt/parser flags.

FUNCTION="test-update-function"

bt functions view "$FUNCTION"

# Update common fields and select the existing function by slug.
bt functions update "$FUNCTION" \
  --name "Test update function renamed" \
  --new-slug test-update-function-renamed \
  --description "Synthetic function description" \
  --metadata @metadata.json \
  --yes
FUNCTION="test-update-function-renamed"

# Restrict lookup to a function type when needed.
bt functions update "$FUNCTION" \
  --type task \
  --patch @function-patch.json \
  --yes

# Function IDs are also accepted.
bt functions update --id fn_test_function \
  --description "Updated by id" \
  --yes

bt functions view "$FUNCTION"
```

</details>

The JSON file:

<details>

`function-patch.json`:

```json
{
  "tags": ["synthetic", "updated-from-cli"]
}
```

</details>

And its output:

<details>

```text
Viewing Test update function
Slug: test-update-function
Type: task
Description: Synthetic code-backed resource for bt update examples
Runtime: node 22.15.0

✓ Updated 'Test update function'
Run `bt functions view test-update-function-renamed` to inspect the updated definition.
✓ Updated 'Test update function renamed'
Run `bt functions view test-update-function-renamed` to inspect the updated definition.

Viewing Test update function renamed
Slug: test-update-function-renamed
Type: task
Description: Synthetic function description
Runtime: node 22.15.0

Tags: synthetic, updated-from-cli
```

</details>

#### `tools.sh`:

<details>

```bash
# Command examples for `bt tools update`.
#
# Code-backed tools support common fields and arbitrary patches. Prompt-backed
# tools additionally support completion prompts and chat messages.

TOOL="test-update-tool"
PROMPT_TOOL="test-prompt-tool"

bt tools view "$TOOL"

# Update common fields on a code-backed tool.
bt tools update "$TOOL" \
  --name "Test update tool renamed" \
  --new-slug test-update-tool-renamed \
  --description "Synthetic tool description" \
  --metadata @metadata.json \
  --yes
TOOL="test-update-tool-renamed"

# Apply fields without dedicated flags through a JSON patch.
bt tools update "$TOOL" \
  --patch @tool-patch.json \
  --yes

# Replace a completion prompt on a prompt-backed tool.
bt tools update "$PROMPT_TOOL" \
  --prompt @tool-prompt.txt \
  --yes

# Or switch the prompt-backed tool to chat messages from JSON or YAML.
bt tools update "$PROMPT_TOOL" \
  --messages @tool-messages.yaml \
  --yes

bt tools view "$TOOL"
bt tools view "$PROMPT_TOOL"
```

</details>

The supporting files:

<details>

`tool-patch.json`:

```json
{
  "tags": ["synthetic", "updated-from-cli"]
}
```

`tool-prompt.txt`:

```text
Look up the synthetic value: {{value}}
```

`tool-messages.yaml`:

```yaml
- role: system
  content: Use the supplied value.
- role: user
  content: "{{value}}"
```

</details>

And its output:

<details>

```text
Viewing Test update tool
Slug: test-update-tool
Type: tool
Description: Synthetic code-backed tool for bt update testing
Runtime: node 22.15.0

✓ Updated 'Test update tool'
Run `bt tools view test-update-tool-renamed` to inspect the updated definition.
✓ Updated 'Test update tool renamed'
Run `bt tools view test-update-tool-renamed` to inspect the updated definition.
✓ Updated 'Test prompt tool'
Run `bt tools view test-prompt-tool` to inspect the updated definition.
✓ Updated 'Test prompt tool'
Run `bt tools view test-prompt-tool` to inspect the updated definition.

Viewing Test update tool renamed
Slug: test-update-tool-renamed
Type: tool
Description: Synthetic tool description
Runtime: node 22.15.0

Tags: synthetic, updated-from-cli

Viewing Test prompt tool
Slug: test-prompt-tool
Type: tool
Model: gpt-4o-mini

┃ system
│ Use the supplied value.

┃ user
│ {{value}}
```

</details>

## AI Summary

- add distinct update interfaces for functions, tools, and scorers instead of exposing scorer-only flags in every namespace
- add common `--name`, `--new-slug`, `--description`, `--metadata`, and `--patch` options across all three update commands
- keep model, prompt-parser, score, and classification configuration on `bt scorers update`
- add `--prompt` and JSON/YAML `--messages` to `bt tools update` for prompt-backed tools
- support selection by slug or function ID, including interactive selection when no selector is provided
- preserve unchanged `prompt_data` and deep-merge metadata before calling the PATCH API

## Behavior

- `bt functions update` exposes common function fields, `--type`, and the arbitrary JSON patch escape hatch
- `bt tools update` supports common fields for code-backed tools and prompt replacement for prompt-backed tools
- `bt scorers update` supports common fields for code scorers and full prompt/parser configuration for LLM scorers and classifiers
- `--slug` identifies the current resource; `--new-slug` changes it and preflights collisions
- switching between completion and chat prompts replaces the discriminated prompt block without leaving fields from the previous prompt kind
- rejects prompt updates for code-backed resources with an actionable `bt functions push` hint
- rejects incompatible scorer/classifier output changes and reports expected validation failures as user errors
- supports confirmation prompts, `--yes`, and machine-readable `--json` output
- keeps progress and status output on stderr
