### PR TITLE
feat(prompts): update prompts

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,7 +149,7 @@ Remove-Item -Recurse -Force (Join-Path $env:APPDATA "bt") -ErrorAction SilentlyC
 | `bt view`      | View logs, traces, and spans                                       |
 | `bt projects`  | Manage projects (list, create, view, delete)                       |
 | `bt datasets`  | Manage remote datasets (list, create, update, view, delete)        |
-| `bt prompts`   | Manage prompts (list, view, delete)                                |
+| `bt prompts`   | Manage prompts (list, view, update, delete)                        |
 | `bt functions` | Manage functions (list, view, invoke, update, push, pull, delete)  |
 | `bt tools`     | Manage tools (list, view, invoke, update, delete)                  |
 | `bt scorers`   | Manage scorers (list, create, view, invoke, update, delete)        |
@@ -184,6 +184,7 @@ bt scorers update helpfulness --messages @messages.json
 bt scorers update helpfulness --new-slug answer-helpfulness
 bt functions update my-function --name "Updated function" --description "Updated"
 bt tools update my-tool --prompt @prompt.txt --new-slug lookup-order
+bt prompts update my-prompt --messages @messages.json
 ```
 
 The API replaces `prompt_data` rather than merging it, so `bt` reads the current definition and sends a materialized replacement with your changes. A concurrent edit can therefore be overwritten.

--- a/README.md
+++ b/README.md
@@ -149,7 +149,7 @@ Remove-Item -Recurse -Force (Join-Path $env:APPDATA "bt") -ErrorAction SilentlyC
 | `bt view`      | View logs, traces, and spans                                       |
 | `bt projects`  | Manage projects (list, create, view, delete)                       |
 | `bt datasets`  | Manage remote datasets (list, create, update, view, delete)        |
-| `bt prompts`   | Manage prompts (list, view, update, delete)                        |
+| `bt prompts`   | Manage prompts (list, create, view, update, delete)                |
 | `bt functions` | Manage functions (list, view, invoke, update, push, pull, delete)  |
 | `bt tools`     | Manage tools (list, view, invoke, update, delete)                  |
 | `bt scorers`   | Manage scorers (list, create, view, invoke, update, delete)        |

--- a/src/functions/create.rs
+++ b/src/functions/create.rs
@@ -247,7 +247,7 @@ fn resolve_slug(args: &CreateArgs, name: &str) -> Result<String> {
     Ok(slug)
 }
 
-fn slugify(value: &str) -> String {
+pub(crate) fn slugify(value: &str) -> String {
     let mut slug = String::new();
     let mut pending_separator = false;
 

--- a/src/functions/mod.rs
+++ b/src/functions/mod.rs
@@ -22,7 +22,7 @@ pub(crate) mod prompt_patch;
 mod pull;
 mod push;
 pub(crate) mod report;
-mod scorer_config;
+pub(crate) mod scorer_config;
 mod update;
 mod view;
 

--- a/src/functions/prompt_patch.rs
+++ b/src/functions/prompt_patch.rs
@@ -21,6 +21,20 @@ pub(crate) fn materialize_prompt_data_patch(
         .unwrap_or_default();
     merge_json_objects(&mut merged, &patch_prompt_data);
 
+    // Prompt blocks are a discriminated union. Deep-merging a completion block
+    // into a chat block (or vice versa) leaves fields from both variants and
+    // produces invalid prompt data.
+    if let Some(requested_prompt) = patch_prompt_data.get("prompt") {
+        let requested_type = requested_prompt.get("type").and_then(Value::as_str);
+        let existing_type = existing_prompt_data
+            .and_then(|data| data.get("prompt"))
+            .and_then(|prompt| prompt.get("type"))
+            .and_then(Value::as_str);
+        if requested_type.is_some() && requested_type != existing_type {
+            merged.insert("prompt".to_string(), requested_prompt.clone());
+        }
+    }
+
     if let (Some(requested), Some(parser)) = (
         patch_prompt_data.get("parser").and_then(Value::as_object),
         merged.get_mut("parser").and_then(Value::as_object_mut),
@@ -42,6 +56,33 @@ mod tests {
     use serde_json::json;
 
     use super::*;
+
+    #[test]
+    fn replaces_prompt_block_when_switching_prompt_kinds() {
+        let existing = json!({
+            "prompt": {"type": "completion", "content": "Original"},
+            "options": {"model": "test-model"}
+        });
+        let mut patch = json!({
+            "prompt_data": {
+                "prompt": {
+                    "type": "chat",
+                    "messages": [{"role": "user", "content": "Hello"}]
+                }
+            }
+        });
+
+        materialize_prompt_data_patch(&mut patch, Some(&existing));
+
+        assert_eq!(
+            patch["prompt_data"]["prompt"],
+            json!({
+                "type": "chat",
+                "messages": [{"role": "user", "content": "Hello"}]
+            })
+        );
+        assert_eq!(patch["prompt_data"]["options"]["model"], "test-model");
+    }
 
     #[test]
     fn materializes_complete_prompt_data_for_patch() {

--- a/src/functions/update.rs
+++ b/src/functions/update.rs
@@ -4,6 +4,7 @@ use dialoguer::Confirm;
 use serde_json::{Map, Value};
 
 use crate::{
+    error::user_error,
     ui::{is_interactive, print_command_status, with_spinner, CommandStatus},
     utils::{merge_json_objects, read_text_source},
 };
@@ -128,11 +129,21 @@ pub(crate) struct ToolUpdateArgs {
     common: CommonUpdateArgs,
 
     /// Replace a completion prompt from inline text, @PATH, or stdin (-).
-    #[arg(long, value_name = "SOURCE", conflicts_with = "messages")]
+    #[arg(
+        long,
+        value_name = "SOURCE",
+        conflicts_with = "messages",
+        allow_hyphen_values = true
+    )]
     prompt: Option<String>,
 
     /// Replace chat messages from inline JSON/YAML, @PATH, or stdin (-).
-    #[arg(long, value_name = "SOURCE", conflicts_with = "prompt")]
+    #[arg(
+        long,
+        value_name = "SOURCE",
+        conflicts_with = "prompt",
+        allow_hyphen_values = true
+    )]
     messages: Option<String>,
 }
 
@@ -179,7 +190,7 @@ pub(crate) async fn run_scorer(
     args: &ScorerUpdateArgs,
     json_output: bool,
 ) -> Result<()> {
-    let body = build_scorer_patch_body(args)?;
+    let body = build_scorer_patch_body(args).map_err(user_error)?;
     run_update(
         ctx,
         &args.common,
@@ -196,7 +207,7 @@ pub(crate) async fn run_tool(
     args: &ToolUpdateArgs,
     json_output: bool,
 ) -> Result<()> {
-    let body = build_tool_patch_body(args)?;
+    let body = build_tool_patch_body(args).map_err(user_error)?;
     run_update(
         ctx,
         &args.common,
@@ -214,7 +225,7 @@ pub(crate) async fn run_generic(
     json_output: bool,
     ft: Option<FunctionTypeFilter>,
 ) -> Result<()> {
-    let body = build_common_patch_body(&args.common)?;
+    let body = build_common_patch_body(&args.common).map_err(user_error)?;
     run_update(ctx, &args.common, body, json_output, ft, None).await
 }
 
@@ -228,7 +239,27 @@ async fn run_update(
 ) -> Result<()> {
     let function = resolve_target_function(ctx, common, ft).await?;
     if !function_matches_filter(&function, ft) {
-        bail!("'{}' is not a {}", function.name, label(ft));
+        return Err(user_error(anyhow!(
+            "'{}' is not a {}",
+            function.name,
+            label(ft)
+        )));
+    }
+
+    if let Some(new_slug) = common.new_slug.as_deref() {
+        if new_slug != function.slug {
+            if let Some(conflict) =
+                api::get_function_by_slug(&ctx.client, &ctx.project.id, new_slug, None).await?
+            {
+                if conflict.id != function.id {
+                    return Err(user_error(anyhow!(
+                        "--new-slug '{new_slug}' is already used by {} '{}'",
+                        conflict.function_type.as_deref().unwrap_or("function"),
+                        conflict.name
+                    )));
+                }
+            }
+        }
     }
 
     let implementation = function
@@ -238,11 +269,12 @@ async fn run_update(
         .and_then(Value::as_str)
         .unwrap_or("prompt");
     if body.get("prompt_data").is_some() && implementation != "prompt" {
-        bail!(
-            "prompt configuration cannot update {}-backed function '{}'",
+        return Err(user_error(anyhow!(
+            "prompt configuration cannot update {}-backed {} '{}'. Edit its source and run: bt functions push <path> --if-exists replace",
             implementation,
+            label(ft),
             function.name
-        );
+        )));
     }
 
     if let Some(args) = scorer_args {
@@ -255,17 +287,24 @@ async fn run_update(
             ),
             (Some("classifier"), true, _) | (Some("scorer"), _, true)
         ) {
-            bail!("PATCH cannot change between score and classification output");
+            return Err(user_error(anyhow!(
+                "cannot change between score and classification output"
+            )));
         }
         if args.allow_no_match.is_some() && function_type != Some("classifier") {
-            bail!("--allow-no-match applies only to classification output");
+            return Err(user_error(anyhow!(
+                "--allow-no-match applies only to classification output"
+            )));
         }
         if args.pass_threshold.is_some() && function_type == Some("classifier") {
-            bail!("--pass-threshold applies only to score output");
+            return Err(user_error(anyhow!(
+                "--pass-threshold applies only to score output"
+            )));
         }
     }
 
     materialize_prompt_data_patch(&mut body, function.prompt_data.as_ref());
+    materialize_metadata_patch(&mut body, function.metadata.as_ref());
 
     if !common.yes && is_interactive() {
         let confirm = Confirm::new()
@@ -423,14 +462,14 @@ fn merge_common_fields(
     args: &CommonUpdateArgs,
     include_metadata: bool,
 ) -> Result<()> {
-    for (key, value) in [
-        ("name", args.name.as_deref()),
-        ("slug", args.new_slug.as_deref()),
-        ("description", args.description.as_deref()),
+    for (key, flag, value) in [
+        ("name", "--name", args.name.as_deref()),
+        ("slug", "--new-slug", args.new_slug.as_deref()),
+        ("description", "--description", args.description.as_deref()),
     ] {
         if let Some(value) = value {
             if value.trim().is_empty() && key != "description" {
-                bail!("--{} cannot be empty", key.replace('_', "-"));
+                bail!("{flag} cannot be empty");
             }
             patch.insert(key.to_string(), Value::String(value.to_string()));
         }
@@ -447,6 +486,19 @@ fn merge_common_fields(
         merge_json_objects(patch, &extra_obj);
     }
     Ok(())
+}
+
+fn materialize_metadata_patch(patch: &mut Value, existing_metadata: Option<&Value>) {
+    let Some(patch_metadata) = patch.get("metadata").and_then(Value::as_object).cloned() else {
+        return;
+    };
+
+    let mut metadata = existing_metadata
+        .and_then(Value::as_object)
+        .cloned()
+        .unwrap_or_default();
+    merge_json_objects(&mut metadata, &patch_metadata);
+    patch["metadata"] = Value::Object(metadata);
 }
 
 fn finish_patch(patch: Map<String, Value>, help_command: &str) -> Result<Value> {
@@ -483,6 +535,12 @@ mod tests {
     struct ScorerUpdateArgsHarness {
         #[command(flatten)]
         args: ScorerUpdateArgs,
+    }
+
+    #[derive(Debug, Parser)]
+    struct ToolUpdateArgsHarness {
+        #[command(flatten)]
+        args: ToolUpdateArgs,
     }
 
     fn args(model: Option<&str>, description: Option<&str>) -> ScorerUpdateArgs {
@@ -669,15 +727,33 @@ mod tests {
     }
 
     #[test]
-    fn tool_messages_accept_yaml() {
-        let scorer = args(None, None);
-        let args = ToolUpdateArgs {
-            common: scorer.common,
-            prompt: None,
-            messages: Some("- role: user\n  content: Look up {{order_id}}\n".to_string()),
-        };
+    fn tool_prompt_accepts_text_beginning_with_a_dash() {
+        let parsed = ToolUpdateArgsHarness::try_parse_from([
+            "test",
+            "test-tool",
+            "--prompt",
+            "- instruction {{value}}",
+        ])
+        .expect("parse prompt beginning with a dash");
 
-        let body = build_tool_patch_body(&args).expect("patch body");
+        let body = build_tool_patch_body(&parsed.args).expect("patch body");
+        assert_eq!(
+            body["prompt_data"]["prompt"]["content"],
+            "- instruction {{value}}"
+        );
+    }
+
+    #[test]
+    fn tool_messages_accept_yaml() {
+        let parsed = ToolUpdateArgsHarness::try_parse_from([
+            "test",
+            "test-tool",
+            "--messages",
+            "- role: user\n  content: Look up {{order_id}}\n",
+        ])
+        .expect("parse inline YAML beginning with a dash");
+
+        let body = build_tool_patch_body(&parsed.args).expect("patch body");
         assert_eq!(body["prompt_data"]["prompt"]["type"], "chat");
         assert_eq!(body["prompt_data"]["prompt"]["messages"][0]["role"], "user");
     }
@@ -761,5 +837,31 @@ mod tests {
             target["prompt_data"]["options"]["temperature"],
             serde_json::json!(0)
         );
+    }
+
+    #[test]
+    fn metadata_patch_preserves_existing_fields() {
+        let mut patch = json!({"metadata": {"owner": "test-team"}});
+        let existing = json!({"__pass_threshold": 0.6, "phase": "test"});
+
+        materialize_metadata_patch(&mut patch, Some(&existing));
+
+        assert_eq!(
+            patch["metadata"],
+            json!({
+                "__pass_threshold": 0.6,
+                "phase": "test",
+                "owner": "test-team"
+            })
+        );
+    }
+
+    #[test]
+    fn empty_new_slug_names_the_correct_flag() {
+        let mut args = args(None, None);
+        args.common.new_slug = Some(String::new());
+
+        let error = build_scorer_patch_body(&args).expect_err("empty slug should fail");
+        assert_eq!(error.to_string(), "--new-slug cannot be empty");
     }
 }

--- a/src/prompts/api.rs
+++ b/src/prompts/api.rs
@@ -48,6 +48,10 @@ pub async fn get_prompt_by_slug(
     Ok(list.objects.into_iter().next())
 }
 
+pub async fn create_prompt(client: &ApiClient, body: &serde_json::Value) -> Result<Prompt> {
+    client.post("/v1/prompt", body).await
+}
+
 pub async fn delete_prompt(client: &ApiClient, prompt_id: &str) -> Result<()> {
     let path = format!("/v1/prompt/{}", encode(prompt_id));
     client.delete(&path).await

--- a/src/prompts/api.rs
+++ b/src/prompts/api.rs
@@ -1,5 +1,6 @@
 use anyhow::Result;
 use serde::{Deserialize, Serialize};
+use serde_json::Value;
 use urlencoding::encode;
 
 use crate::http::ApiClient;
@@ -50,4 +51,14 @@ pub async fn get_prompt_by_slug(
 pub async fn delete_prompt(client: &ApiClient, prompt_id: &str) -> Result<()> {
     let path = format!("/v1/prompt/{}", encode(prompt_id));
     client.delete(&path).await
+}
+
+/// Partially update a prompt by id via `PATCH /v1/prompt/{id}`.
+///
+/// Top-level fields are patched, but object-valued fields such as `prompt_data`
+/// are replaced wholesale. Callers updating `prompt_data` must materialize the
+/// complete value before sending the request.
+pub async fn patch_prompt(client: &ApiClient, prompt_id: &str, body: &Value) -> Result<Prompt> {
+    let path = format!("/v1/prompt/{}", encode(prompt_id));
+    client.patch(&path, body).await
 }

--- a/src/prompts/create.rs
+++ b/src/prompts/create.rs
@@ -1,0 +1,135 @@
+use anyhow::{bail, Result};
+use clap::Args;
+use dialoguer::Input;
+use serde_json::{json, Value};
+
+use crate::{
+    error::user_error,
+    functions::{
+        create::slugify,
+        prompt_config::PromptConfigArgs,
+        scorer_config::{build_scorer_config, ScorerConfig},
+    },
+    ui::{is_interactive, print_command_status, with_spinner, CommandStatus},
+};
+
+use super::{api, ResolvedContext};
+
+/// Create a prompt in the current project.
+#[derive(Debug, Clone, Args)]
+#[command(after_help = "\
+Examples:
+  bt prompts create \"Support reply\" --model gpt-5.4-nano --messages @messages.json
+  bt prompts create --name \"Summarize\" --slug summarize --model gpt-5.4-nano \\
+    --messages '[{\"role\":\"user\",\"content\":\"Summarize {{input}}\"}]'
+")]
+pub(crate) struct CreateArgs {
+    /// Prompt name.
+    #[arg(value_name = "NAME")]
+    name_positional: Option<String>,
+
+    /// Prompt name (named form).
+    #[arg(long, value_name = "NAME")]
+    name: Option<String>,
+
+    /// Unique prompt slug. Defaults to a slug generated from the name.
+    #[arg(long, short = 's')]
+    slug: Option<String>,
+
+    /// Prompt description.
+    #[arg(long, short = 'd')]
+    description: Option<String>,
+
+    /// Chat messages source: inline JSON, @PATH, or - for stdin.
+    #[arg(long, value_name = "SOURCE")]
+    messages: String,
+
+    /// Model used by the prompt.
+    #[arg(long, short = 'm', value_name = "MODEL")]
+    model: String,
+
+    #[command(flatten)]
+    prompt_config: PromptConfigArgs,
+}
+
+pub(crate) async fn run(ctx: &ResolvedContext, args: &CreateArgs, json_output: bool) -> Result<()> {
+    let name = resolve_name(args).map_err(user_error)?;
+    let slug = args
+        .slug
+        .as_deref()
+        .map(str::trim)
+        .filter(|slug| !slug.is_empty())
+        .map(ToOwned::to_owned)
+        .unwrap_or_else(|| slugify(&name));
+    if slug.is_empty() {
+        bail!("could not generate a slug from the prompt name; pass --slug explicitly");
+    }
+
+    let definition = build_definition(args, &ctx.project.id, &name, &slug).map_err(user_error)?;
+    let prompt = match with_spinner(
+        "Creating prompt...",
+        api::create_prompt(&ctx.client, &definition),
+    )
+    .await
+    {
+        Ok(prompt) => prompt,
+        Err(error) => {
+            print_command_status(CommandStatus::Error, &format!("Failed to create '{name}'"));
+            return Err(error);
+        }
+    };
+
+    if json_output {
+        println!("{}", serde_json::to_string(&prompt)?);
+    } else {
+        print_command_status(CommandStatus::Success, &format!("Created '{name}'"));
+    }
+    Ok(())
+}
+
+fn resolve_name(args: &CreateArgs) -> Result<String> {
+    let name = match args.name_positional.as_deref().or(args.name.as_deref()) {
+        Some(name) => name.trim().to_string(),
+        None if is_interactive() => Input::<String>::new()
+            .with_prompt("Prompt name")
+            .interact_text()?
+            .trim()
+            .to_string(),
+        None => bail!("prompt name required. Use: bt prompts create <name> ..."),
+    };
+    if name.is_empty() {
+        bail!("prompt name cannot be empty");
+    }
+    Ok(name)
+}
+
+fn build_definition(args: &CreateArgs, project_id: &str, name: &str, slug: &str) -> Result<Value> {
+    let config = build_scorer_config(
+        &ScorerConfig {
+            messages: Some(&args.messages),
+            model: Some(&args.model),
+            prompt_config: &args.prompt_config,
+            choice_scores: None,
+            classifications: None,
+            use_cot: None,
+            allow_no_match: None,
+            pass_threshold: None,
+            metadata: None,
+            metadata_label: "prompt metadata",
+        },
+        false,
+    )?;
+    let mut definition = json!({
+        "project_id": project_id,
+        "name": name,
+        "slug": slug,
+    });
+    definition
+        .as_object_mut()
+        .expect("prompt definition is an object")
+        .extend(config);
+    if let Some(description) = args.description.as_deref() {
+        definition["description"] = Value::String(description.to_string());
+    }
+    Ok(definition)
+}

--- a/src/prompts/mod.rs
+++ b/src/prompts/mod.rs
@@ -6,6 +6,7 @@ use crate::{args::BaseArgs, project_context::resolve_project_command_context_wit
 pub(crate) use crate::project_context::ProjectContext as ResolvedContext;
 
 mod api;
+mod create;
 mod delete;
 mod list;
 mod update;
@@ -15,6 +16,7 @@ mod view;
 #[command(after_help = "\
 Examples:
   bt prompts list
+  bt prompts create \"Support reply\" --model gpt-5.4-nano --messages @messages.json
   bt prompts view my-prompt
   bt prompts delete my-prompt
   bt prompts update my-prompt --messages @messages.json
@@ -28,6 +30,8 @@ pub struct PromptsArgs {
 enum PromptsCommands {
     /// List all prompts
     List,
+    /// Create a prompt
+    Create(Box<create::CreateArgs>),
     /// View a prompt's content
     View(ViewArgs),
     /// Update a prompt in place (prompt configuration, metadata, or arbitrary patch)
@@ -88,6 +92,7 @@ pub async fn run(base: BaseArgs, args: PromptsArgs) -> Result<()> {
 
     match args.command {
         None | Some(PromptsCommands::List) => list::run(&ctx, base.json).await,
+        Some(PromptsCommands::Create(p)) => create::run(&ctx, &p, base.json).await,
         Some(PromptsCommands::View(p)) => {
             view::run(&ctx, p.slug(), base.json, p.web, base.verbose).await
         }
@@ -129,7 +134,7 @@ mod tests {
     }
 
     #[test]
-    fn prompts_routes_delete_to_validated_auth() {
+    fn prompts_routes_mutations_to_validated_auth() {
         assert!(!prompts_command_is_read_only(Some(
             &PromptsCommands::Delete(DeleteArgs {
                 slug_positional: Some("my-prompt".to_string()),

--- a/src/prompts/mod.rs
+++ b/src/prompts/mod.rs
@@ -8,6 +8,7 @@ pub(crate) use crate::project_context::ProjectContext as ResolvedContext;
 mod api;
 mod delete;
 mod list;
+mod update;
 mod view;
 
 #[derive(Debug, Clone, Args)]
@@ -16,6 +17,7 @@ Examples:
   bt prompts list
   bt prompts view my-prompt
   bt prompts delete my-prompt
+  bt prompts update my-prompt --messages @messages.json
 ")]
 pub struct PromptsArgs {
     #[command(subcommand)]
@@ -28,6 +30,8 @@ enum PromptsCommands {
     List,
     /// View a prompt's content
     View(ViewArgs),
+    /// Update a prompt in place (prompt configuration, metadata, or arbitrary patch)
+    Update(Box<update::UpdateArgs>),
     /// Delete a prompt
     Delete(DeleteArgs),
 }
@@ -87,6 +91,7 @@ pub async fn run(base: BaseArgs, args: PromptsArgs) -> Result<()> {
         Some(PromptsCommands::View(p)) => {
             view::run(&ctx, p.slug(), base.json, p.web, base.verbose).await
         }
+        Some(PromptsCommands::Update(p)) => update::run(&ctx, &p, base.json).await,
         Some(PromptsCommands::Delete(p)) => delete::run(&ctx, p.slug(), p.force).await,
     }
 }
@@ -100,7 +105,15 @@ fn prompts_command_is_read_only(command: Option<&PromptsCommands>) -> bool {
 
 #[cfg(test)]
 mod tests {
+    use clap::Parser;
+
     use super::*;
+
+    #[derive(Debug, Parser)]
+    struct PromptsArgsHarness {
+        #[command(flatten)]
+        args: PromptsArgs,
+    }
 
     #[test]
     fn prompts_routes_list_and_view_to_read_only_auth() {
@@ -124,5 +137,20 @@ mod tests {
                 force: true,
             })
         )));
+    }
+
+    #[test]
+    fn prompts_routes_update_to_validated_auth() {
+        let parsed = PromptsArgsHarness::try_parse_from([
+            "bt-prompts",
+            "update",
+            "my-prompt",
+            "--description",
+            "updated",
+            "--yes",
+        ])
+        .expect("parse update");
+
+        assert!(!prompts_command_is_read_only(parsed.args.command.as_ref()));
     }
 }

--- a/src/prompts/update.rs
+++ b/src/prompts/update.rs
@@ -1,0 +1,412 @@
+use anyhow::{anyhow, bail, Context, Result};
+use clap::Args;
+use dialoguer::Confirm;
+use serde_json::{json, Map, Value};
+
+use crate::{
+    functions::{prompt_config::PromptConfigArgs, prompt_patch::materialize_prompt_data_patch},
+    ui::{is_interactive, print_command_status, with_spinner, CommandStatus},
+    utils::{merge_json_objects, read_text_source, read_yaml_object_source},
+};
+
+use super::{api, ResolvedContext};
+
+/// Update a prompt's configuration or metadata in place.
+///
+/// The endpoint replaces `prompt_data` wholesale, so the command reads the
+/// current prompt and materializes a complete replacement while changing only
+/// the fields requested by the user.
+#[derive(Debug, Clone, Args)]
+#[command(after_help = "\
+Examples:
+  bt prompts update my-prompt --messages @messages.json
+  bt prompts update my-prompt --model gpt-5.4-nano
+  bt prompts update my-prompt --description \"Customer support prompt\"
+  bt prompts update my-prompt --patch '{\"prompt_data\":{\"options\":{\"model\":\"gpt-5.4-nano\"}}}'
+  bt prompts update my-prompt --patch @prompt-patch.json
+")]
+pub struct UpdateArgs {
+    /// Prompt slug (positional)
+    #[arg(value_name = "SLUG", conflicts_with = "slug_flag")]
+    slug_positional: Option<String>,
+
+    /// Prompt slug (flag)
+    #[arg(long = "slug", short = 's')]
+    slug_flag: Option<String>,
+
+    /// Replacement chat messages source: inline JSON, @PATH to read from a
+    /// file, or - for stdin.
+    #[arg(long, value_name = "SOURCE")]
+    messages: Option<String>,
+
+    /// Update the model used by the prompt.
+    #[arg(long, short = 'm', value_name = "MODEL")]
+    model: Option<String>,
+
+    #[command(flatten)]
+    prompt_config: PromptConfigArgs,
+
+    /// Deep-merge metadata from inline YAML, @PATH, or stdin (-).
+    #[arg(long, value_name = "SOURCE")]
+    metadata: Option<String>,
+
+    /// Update the prompt description.
+    #[arg(long, short = 'd', value_name = "TEXT")]
+    description: Option<String>,
+
+    /// Arbitrary JSON object deep-merged into the prompt. Accepts inline JSON,
+    /// @PATH to read JSON from a file, or - for stdin.
+    #[arg(long, value_name = "SOURCE")]
+    patch: Option<String>,
+
+    /// Skip the confirmation prompt.
+    #[arg(long, short = 'y')]
+    yes: bool,
+}
+
+impl UpdateArgs {
+    fn slug(&self) -> Option<&str> {
+        self.slug_positional
+            .as_deref()
+            .or(self.slug_flag.as_deref())
+    }
+}
+
+pub async fn run(ctx: &ResolvedContext, args: &UpdateArgs, json_output: bool) -> Result<()> {
+    let project_name = &ctx.project.name;
+    let mut body = build_patch_body(args)?;
+
+    let prompt = match args.slug() {
+        Some(slug) => with_spinner(
+            "Loading prompt...",
+            api::get_prompt_by_slug(&ctx.client, project_name, slug),
+        )
+        .await?
+        .ok_or_else(|| anyhow!("prompt with slug '{slug}' not found"))?,
+        None => {
+            if !is_interactive() {
+                bail!("prompt slug required. Use: bt prompts update <slug> [--patch ...]");
+            }
+            super::delete::select_prompt_interactive(&ctx.client, project_name).await?
+        }
+    };
+
+    materialize_prompt_data_patch(&mut body, prompt.prompt_data.as_ref());
+
+    if !args.yes && is_interactive() {
+        let confirm = Confirm::new()
+            .with_prompt(format!(
+                "Update prompt '{}' in {}?",
+                prompt.name, project_name
+            ))
+            .default(false)
+            .interact()?;
+        if !confirm {
+            return Ok(());
+        }
+    }
+
+    let updated = match with_spinner(
+        "Updating prompt...",
+        api::patch_prompt(&ctx.client, &prompt.id, &body),
+    )
+    .await
+    {
+        Ok(value) => {
+            print_command_status(
+                CommandStatus::Success,
+                &format!("Updated '{}'", prompt.name),
+            );
+            value
+        }
+        Err(error) => {
+            print_command_status(
+                CommandStatus::Error,
+                &format!("Failed to update '{}'", prompt.name),
+            );
+            return Err(error);
+        }
+    };
+
+    if json_output {
+        println!("{}", serde_json::to_string(&updated)?);
+    } else if !crate::ui::is_quiet() {
+        eprintln!(
+            "Run `bt prompts view {}` to inspect the updated prompt.",
+            prompt.slug
+        );
+    }
+
+    Ok(())
+}
+
+fn build_patch_body(args: &UpdateArgs) -> Result<Value> {
+    let mut patch: Map<String, Value> = Map::new();
+
+    if let Some(description) = args.description.as_deref() {
+        patch.insert(
+            "description".to_string(),
+            Value::String(description.to_string()),
+        );
+    }
+
+    if let Some(source) = args.metadata.as_deref() {
+        patch.insert(
+            "metadata".to_string(),
+            Value::Object(read_yaml_object_source(source, "prompt metadata")?),
+        );
+    }
+
+    if let Some(messages) = resolve_messages(args)? {
+        let prompt_data_patch = json!({
+            "prompt_data": {
+                "prompt": { "type": "chat", "messages": messages },
+            },
+        });
+        merge_json_objects(
+            &mut patch,
+            prompt_data_patch
+                .as_object()
+                .expect("prompt data patch is an object"),
+        );
+    }
+
+    let prompt_config = args
+        .prompt_config
+        .build_prompt_data_patch(args.model.as_deref())?;
+    if !prompt_config.is_empty() {
+        let prompt_data_patch = json!({ "prompt_data": prompt_config });
+        merge_json_objects(
+            &mut patch,
+            prompt_data_patch
+                .as_object()
+                .expect("prompt data patch is an object"),
+        );
+    }
+
+    let extra = resolve_extra_patch(args)?;
+    if let Some(extra_obj) = extra {
+        merge_json_objects(&mut patch, &extra_obj);
+    }
+
+    if patch.is_empty() {
+        bail!("no updates requested. Pass an update flag; see `bt prompts update --help`");
+    }
+
+    Ok(Value::Object(patch))
+}
+
+fn resolve_messages(args: &UpdateArgs) -> Result<Option<Value>> {
+    match args.messages.as_deref() {
+        Some(source) => {
+            let raw = read_text_source(source, "messages")?;
+            let parsed: Value = serde_json::from_str(&raw).context("invalid JSON in --messages")?;
+            match parsed {
+                Value::Array(_) => Ok(Some(parsed)),
+                _ => bail!("--messages must be a JSON array of chat messages"),
+            }
+        }
+        None => Ok(None),
+    }
+}
+
+fn resolve_extra_patch(args: &UpdateArgs) -> Result<Option<Map<String, Value>>> {
+    let Some(source) = args.patch.as_deref() else {
+        return Ok(None);
+    };
+    let raw = read_text_source(source, "patch")?;
+    parse_patch_object(&raw).map(Some)
+}
+
+fn parse_patch_object(raw: &str) -> Result<Map<String, Value>> {
+    let value: Value = serde_json::from_str(raw).context("invalid JSON in --patch")?;
+    match value {
+        Value::Object(map) => Ok(map),
+        _ => bail!("--patch must be a JSON object"),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use clap::Parser;
+
+    use super::*;
+
+    #[derive(Debug, Parser)]
+    struct UpdateArgsHarness {
+        #[command(flatten)]
+        args: UpdateArgs,
+    }
+
+    fn args(model: Option<&str>, description: Option<&str>) -> UpdateArgs {
+        UpdateArgs {
+            slug_positional: Some("test-prompt".to_string()),
+            slug_flag: None,
+            messages: None,
+            model: model.map(ToOwned::to_owned),
+            prompt_config: PromptConfigArgs::default(),
+            metadata: None,
+            description: description.map(ToOwned::to_owned),
+            patch: None,
+            yes: true,
+        }
+    }
+
+    #[test]
+    fn build_patch_body_messages_writes_chat_block() {
+        let mut args = args(None, None);
+        args.messages = Some(r#"[{"role":"user","content":"hi"}]"#.to_string());
+        let body = build_patch_body(&args).expect("patch body");
+        assert_eq!(
+            body["prompt_data"]["prompt"]["type"],
+            serde_json::json!("chat")
+        );
+        assert_eq!(
+            body["prompt_data"]["prompt"]["messages"],
+            serde_json::json!([{"role":"user","content":"hi"}])
+        );
+    }
+
+    #[test]
+    fn build_patch_body_model_merges_into_prompt_data() {
+        let args = args(Some("gpt-4o-mini"), None);
+        let body = build_patch_body(&args).expect("patch body");
+        assert_eq!(
+            body["prompt_data"]["options"]["model"],
+            serde_json::json!("gpt-4o-mini")
+        );
+    }
+
+    #[test]
+    fn build_patch_body_messages_and_model_combine() {
+        let mut args = args(Some("gpt-4o-mini"), None);
+        args.messages = Some(r#"[{"role":"user","content":"Answer it."}]"#.to_string());
+        let body = build_patch_body(&args).expect("patch body");
+        assert_eq!(
+            body["prompt_data"]["prompt"]["messages"],
+            json!([{"role": "user", "content": "Answer it."}])
+        );
+        assert_eq!(
+            body["prompt_data"]["options"]["model"],
+            serde_json::json!("gpt-4o-mini")
+        );
+    }
+
+    #[test]
+    fn build_patch_body_updates_prompt_configuration_and_metadata() {
+        let parsed = UpdateArgsHarness::try_parse_from([
+            "test",
+            "test-prompt",
+            "--temperature",
+            "0.3",
+            "--max-tokens",
+            "100",
+            "--template-format",
+            "mustache",
+            "--metadata",
+            "owner: test-team",
+        ])
+        .expect("parse update");
+
+        let body = build_patch_body(&parsed.args).expect("patch body");
+        assert_eq!(body["prompt_data"]["options"]["params"]["temperature"], 0.3);
+        assert_eq!(body["prompt_data"]["options"]["params"]["max_tokens"], 100);
+        assert_eq!(body["prompt_data"]["template_format"], "mustache");
+        assert_eq!(body["metadata"]["owner"], "test-team");
+    }
+
+    #[test]
+    fn build_patch_body_description_is_top_level() {
+        let args = args(None, Some("Customer support prompt"));
+        let body = build_patch_body(&args).expect("patch body");
+        assert_eq!(
+            body["description"],
+            serde_json::json!("Customer support prompt")
+        );
+    }
+
+    #[test]
+    fn build_patch_body_reads_at_prefixed_messages_file() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("messages.json");
+        std::fs::write(
+            &path,
+            r#"[{"role":"user","content":"Answer from a file."}]"#,
+        )
+        .expect("write messages");
+        let source = format!("@{}", path.display());
+
+        let mut args = args(None, None);
+        args.messages = Some(source);
+        let body = build_patch_body(&args).expect("patch body");
+        assert_eq!(
+            body["prompt_data"]["prompt"]["messages"],
+            json!([{"role": "user", "content": "Answer from a file."}])
+        );
+    }
+
+    #[test]
+    fn build_patch_body_reads_at_prefixed_patch_file() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("patch.json");
+        std::fs::write(&path, r#"{"description":"From a file"}"#).expect("write patch");
+        let source = format!("@{}", path.display());
+
+        let mut args = args(None, None);
+        args.patch = Some(source);
+        let body = build_patch_body(&args).expect("patch body");
+        assert_eq!(body["description"], "From a file");
+    }
+
+    #[test]
+    fn build_patch_body_rejects_empty_update() {
+        let args = args(None, None);
+        let err = build_patch_body(&args).expect_err("should reject empty");
+        assert!(err.to_string().contains("no updates requested"));
+    }
+
+    #[test]
+    fn build_patch_body_extra_patch_merges_into_prompt_data() {
+        let mut args = args(None, None);
+        args.patch =
+            Some(r#"{"prompt_data":{"options":{"params":{"temperature":0}}}}"#.to_string());
+        let body = build_patch_body(&args).expect("patch body");
+        assert_eq!(
+            body["prompt_data"]["options"]["params"]["temperature"],
+            serde_json::json!(0)
+        );
+    }
+
+    #[test]
+    fn parse_patch_object_rejects_non_object() {
+        let err = parse_patch_object("[1,2,3]").expect_err("should reject");
+        assert!(err.to_string().contains("JSON object"));
+    }
+
+    #[test]
+    fn merge_objects_deep_merges_nested_maps() {
+        let mut target = serde_json::json!({
+            "prompt_data": { "options": { "model": "gpt-4o" } }
+        })
+        .as_object()
+        .expect("object")
+        .clone();
+        let source = serde_json::json!({
+            "prompt_data": { "options": { "temperature": 0 } }
+        })
+        .as_object()
+        .expect("object")
+        .clone();
+
+        merge_json_objects(&mut target, &source);
+
+        assert_eq!(
+            target["prompt_data"]["options"]["model"],
+            serde_json::json!("gpt-4o")
+        );
+        assert_eq!(
+            target["prompt_data"]["options"]["temperature"],
+            serde_json::json!(0)
+        );
+    }
+}

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -1228,6 +1228,17 @@ fn scorers_create_help_includes_llm_judge_configuration() {
 }
 
 #[test]
+fn prompt_create_help_includes_prompt_configuration() {
+    bt_command()
+        .args(["prompts", "create", "--help"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("--messages <SOURCE>"))
+        .stdout(predicate::str::contains("--model <MODEL>"))
+        .stdout(predicate::str::contains("--temperature <NUMBER>"));
+}
+
+#[test]
 fn scorer_update_help_is_conflict_free() {
     bt_command()
         .args(["scorers", "update", "--help"])

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -1243,6 +1243,20 @@ fn scorer_update_help_is_conflict_free() {
 }
 
 #[test]
+fn prompt_update_help_is_conflict_free() {
+    bt_command()
+        .args(["prompts", "update", "--help"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("--patch <SOURCE>"))
+        .stdout(predicate::str::contains("--patch-file").not())
+        .stdout(predicate::str::contains("--messages <SOURCE>"))
+        .stdout(predicate::str::contains("--temperature"))
+        .stdout(predicate::str::contains("--template-format"))
+        .stdout(predicate::str::contains("--metadata"));
+}
+
+#[test]
 fn topics_report_help_accepts_global_org_short_conflict_free() {
     bt_command()
         .args([


### PR DESCRIPTION
This pr will be a follow-up to https://github.com/braintrustdata/bt/pull/330
# Add version assignment in `bt prompts update`

## Summary

- add `bt prompts create`
- add `bt prompts update`
- add direct prompt create and PATCH API support
- route prompt mutations through validated authentication

## Create

- accepts a positional name or `--name`, with interactive fallback
- generates a slug by default or accepts `--slug`
- requires `--model` and `--messages`
- reads messages from inline JSON, `@PATH`, or stdin
- reuses the shared prompt configuration flags for temperature, token limits, response format, reasoning, caching, and template format
- supports descriptions and machine-readable `--json` output

## Update

- updates messages, model configuration, description, and metadata
- supports arbitrary JSON updates through `--patch`
- materializes complete `prompt_data` replacements so unspecified prompt fields are preserved
- supports interactive selection, confirmation, `--yes`, and `--json`

## Validation

- `mise exec -- cargo fmt -- --check`
- `mise exec -- cargo clippy --all-targets --all-features -- -D warnings`
- `mise exec -- cargo test`
- `git diff --check`

<sub>Stacked on #309.</sub>
