### PR TITLE
fix(functions): allow forced interactive deletion

### DIFF
--- a/src/functions/delete.rs
+++ b/src/functions/delete.rs
@@ -12,13 +12,6 @@ pub async fn run(
     force: bool,
     ft: Option<FunctionTypeFilter>,
 ) -> Result<()> {
-    if force && slug.is_none() {
-        bail!(
-            "slug required when using --force. Use: bt {} delete <slug> --force",
-            label_plural(ft),
-        );
-    }
-
     let project_id = &ctx.project.id;
 
     let function = match slug {


### PR DESCRIPTION
- allow `--force` when selecting a function or scorer interactively
- remove the unnecessary requirement that force mode include a slug

Affects `bt scorers/tools/functions delete`.

Before:
```
❯ bt scorers delete -f
error: slug required when using --force. Use: bt scorers delete <slug> --force
```

After:
```
❯ bt scorers delete -f
✔ Select scorer · test gemini [slug: test-gemini]
✓ Deleted 'test gemini'
Run `bt scorers list` to see remaining scorers.
```