### PR TITLE
chore: update coding-agent plugins, and resolve trace orgs interactively

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -593,7 +593,7 @@ dependencies = [
 [[package]]
 name = "bt-daemon"
 version = "0.1.0"
-source = "git+https://github.com/braintrustdata/braintrust-coding-agent-plugins?rev=2bb3baf91ecfbe29103b6ff5a201e966a5d56bd9#2bb3baf91ecfbe29103b6ff5a201e966a5d56bd9"
+source = "git+https://github.com/braintrustdata/braintrust-coding-agent-plugins?rev=1ca65d4381acbed0610797c4f8825556b9b6cf10#1ca65d4381acbed0610797c4f8825556b9b6cf10"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1181,7 +1181,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1573,7 +1573,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.5.10",
+ "socket2 0.6.5",
  "tokio",
  "tower-service",
  "tracing",
@@ -2060,7 +2060,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2381,7 +2381,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls",
- "socket2 0.5.10",
+ "socket2 0.6.5",
  "thiserror 2.0.19",
  "tokio",
  "tracing",
@@ -2419,9 +2419,9 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.5.10",
+ "socket2 0.6.5",
  "tracing",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2692,7 +2692,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3198,10 +3198,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.3.4",
+ "getrandom 0.4.3",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -593,7 +593,7 @@ dependencies = [
 [[package]]
 name = "bt-daemon"
 version = "0.1.0"
-source = "git+https://github.com/braintrustdata/braintrust-coding-agent-plugins?rev=5fbfb5e2f322522a2b50cf0e089081b42a9b1559#5fbfb5e2f322522a2b50cf0e089081b42a9b1559"
+source = "git+https://github.com/braintrustdata/braintrust-coding-agent-plugins?rev=2bb3baf91ecfbe29103b6ff5a201e966a5d56bd9#2bb3baf91ecfbe29103b6ff5a201e966a5d56bd9"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1181,7 +1181,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1573,7 +1573,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.6.5",
+ "socket2 0.5.10",
  "tokio",
  "tower-service",
  "tracing",
@@ -2381,7 +2381,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls",
- "socket2 0.6.5",
+ "socket2 0.5.10",
  "thiserror 2.0.19",
  "tokio",
  "tracing",
@@ -2419,7 +2419,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.6.5",
+ "socket2 0.5.10",
  "tracing",
  "windows-sys 0.61.2",
 ]
@@ -2679,7 +2679,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.4.15",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2692,7 +2692,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3198,7 +3198,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.4.3",
+ "getrandom 0.3.4",
  "once_cell",
  "rustix 1.1.4",
  "windows-sys 0.61.2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ actix-web = "4.11.0"
 anyhow = "1.0.89"
 backoff = { version = "0.4.0", features = ["tokio"] }
 braintrust-sdk-rust = { git = "https://github.com/braintrustdata/braintrust-sdk-rust", rev = "43ba73edbf5220b57090e049feb094b60a92fcd4" }
-bt-daemon = { git = "https://github.com/braintrustdata/braintrust-coding-agent-plugins", rev = "2bb3baf91ecfbe29103b6ff5a201e966a5d56bd9" }
+bt-daemon = { git = "https://github.com/braintrustdata/braintrust-coding-agent-plugins", rev = "1ca65d4381acbed0610797c4f8825556b9b6cf10" }
 async-trait = "0.1"
 clap = { version = "4.5.20", features = ["derive", "env"] }
 crossterm = "0.28.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ actix-web = "4.11.0"
 anyhow = "1.0.89"
 backoff = { version = "0.4.0", features = ["tokio"] }
 braintrust-sdk-rust = { git = "https://github.com/braintrustdata/braintrust-sdk-rust", rev = "43ba73edbf5220b57090e049feb094b60a92fcd4" }
-bt-daemon = { git = "https://github.com/braintrustdata/braintrust-coding-agent-plugins", rev = "5fbfb5e2f322522a2b50cf0e089081b42a9b1559" }
+bt-daemon = { git = "https://github.com/braintrustdata/braintrust-coding-agent-plugins", rev = "2bb3baf91ecfbe29103b6ff5a201e966a5d56bd9" }
 async-trait = "0.1"
 clap = { version = "4.5.20", features = ["derive", "env"] }
 crossterm = "0.28.1"

--- a/src/trace_host.rs
+++ b/src/trace_host.rs
@@ -39,6 +39,49 @@ fn session_route(base: &BaseArgs) -> SessionRoute {
     }
 }
 
+/// Ensure the route carries an organization, the way `resolve_trace_project`
+/// ensures it carries a project. Tracing has no later opportunity to ask: the
+/// org is baked into the route before the daemon sees a single event, so a
+/// credential that resolves no default org has to be settled here or not at
+/// all. That is a real gap rather than a corner case — a default org comes
+/// from `--org`, the config file `bt init` and `bt switch` write, or an
+/// org-bound API key profile, and an OAuth profile carries none of them.
+///
+/// Idempotent, so the project flow can call it before listing projects and
+/// `resolve_route` can call it again for the paths that skip project selection.
+async fn resolve_trace_org(mut base: BaseArgs) -> anyhow::Result<BaseArgs> {
+    if base
+        .org_name
+        .as_deref()
+        .is_some_and(|org| !org.trim().is_empty())
+    {
+        return Ok(base);
+    }
+
+    let auth = crate::auth::resolve_auth(&base)
+        .await
+        .map_err(|error| anyhow::anyhow!("resolve auth: {error}"))?;
+    if let Some(profile) = auth.profile.clone() {
+        base.profile = Some(profile);
+        base.profile_explicit = true;
+        base.prefer_profile = true;
+    }
+    if let Some(org_name) = auth.org_name.clone().filter(|org| !org.trim().is_empty()) {
+        base.org_name = Some(org_name);
+        return Ok(base);
+    }
+
+    if !crate::ui::is_interactive() {
+        anyhow::bail!(
+            "organization choice required in non-interactive mode; pass --org <NAME> or set BRAINTRUST_ORG_NAME"
+        );
+    }
+
+    let (_, org) = crate::switch::select_org_for_switch(&base, None).await?;
+    base.org_name = Some(org.name);
+    Ok(base)
+}
+
 async fn resolve_trace_project(mut base: BaseArgs) -> anyhow::Result<BaseArgs> {
     if base
         .project
@@ -79,6 +122,10 @@ async fn resolve_trace_project(mut base: BaseArgs) -> anyhow::Result<BaseArgs> {
         return Ok(base);
     }
 
+    // Settle the org before listing projects so the picker offers the projects
+    // of the org the traces will actually land in.
+    base = resolve_trace_org(base).await?;
+
     let login = crate::auth::login_read_only(&base).await?;
     let client = crate::http::ApiClient::new(&login)?;
     let project = crate::ui::select_project(
@@ -102,11 +149,17 @@ impl TraceHostServices for BtTraceHost {
         if !requirements.interactive_auth {
             crate::ui::set_no_input(true);
         }
-        let base = if requirements.destination_required {
+        let mut base = if requirements.destination_required {
             resolve_trace_project(self.base.clone()).await?
         } else {
             self.base.clone()
         };
+        // Hooks tolerate an unresolved org — the daemon accepts their events
+        // without one — but setup, managed run, and import bake the org into a
+        // stored route, so they have to settle it now rather than fail later.
+        if requirements.interactive_auth {
+            base = resolve_trace_org(base).await?;
+        }
         Ok(session_route(&base))
     }
 

--- a/src/trace_host.rs
+++ b/src/trace_host.rs
@@ -10,7 +10,8 @@ use std::sync::Arc;
 use async_trait::async_trait;
 use bt_daemon::wire::{AuthSelection, BackendAuth, FlushMode, SessionRoute, TraceDestination};
 use bt_daemon::{
-    AuthLease, AuthResolveReason, OutputFormat, RunHookCommand, TraceHostContext, TraceHostServices,
+    AuthLease, AuthResolveReason, OutputFormat, RouteRequirements, RunHookCommand,
+    TraceHostContext, TraceHostServices,
 };
 
 use crate::args::BaseArgs;
@@ -93,8 +94,15 @@ async fn resolve_trace_project(mut base: BaseArgs) -> anyhow::Result<BaseArgs> {
 
 #[async_trait]
 impl TraceHostServices for BtTraceHost {
-    async fn resolve_route(&self, destination_required: bool) -> anyhow::Result<SessionRoute> {
-        let base = if destination_required {
+    async fn resolve_route(&self, requirements: RouteRequirements) -> anyhow::Result<SessionRoute> {
+        // Commands that run inside an agent's turn (hooks) leave this false so
+        // no missing profile or org can block the turn on a prompt. bt gates
+        // every prompt on this global, including the ones `resolve_auth`
+        // reaches later in the same process.
+        if !requirements.interactive_auth {
+            crate::ui::set_no_input(true);
+        }
+        let base = if requirements.destination_required {
             resolve_trace_project(self.base.clone()).await?
         } else {
             self.base.clone()

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -427,14 +427,8 @@ fn trace_run_uses_the_invocation_project_without_changing_setup() {
             "--",
             "--version",
         ])
-        // The fake agent emits no hook events, so the managed run reports an
-        // empty trace once it exits. Everything asserted below is written
-        // before that check.
         .assert()
-        .failure()
-        .stderr(predicate::str::contains(
-            "managed run produced no accepted trace events",
-        ));
+        .success();
 
     let args = fs::read_to_string(run_log).expect("read run args");
     assert!(args.contains("--version"));
@@ -482,10 +476,7 @@ fn trace_run_opencode_injects_the_npm_plugin_without_changing_global_config() {
             "--version",
         ])
         .assert()
-        .failure()
-        .stderr(predicate::str::contains(
-            "managed run produced no accepted trace events",
-        ));
+        .success();
 
     let inline: serde_json::Value =
         serde_json::from_slice(&fs::read(run_config).expect("read OpenCode inline config"))
@@ -536,10 +527,7 @@ fn trace_run_pi_injects_the_npm_extension_for_only_that_process() {
             "--version",
         ])
         .assert()
-        .failure()
-        .stderr(predicate::str::contains(
-            "managed run produced no accepted trace events",
-        ));
+        .success();
 
     assert!(fs::read_to_string(run_log)
         .expect("read Pi arguments")

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -18,6 +18,17 @@ fn clear_braintrust_auth_env(cmd: &mut Command) {
     }
 }
 
+/// Setup, managed run, and import resolve a Braintrust credential and org
+/// before writing a route, so those tests supply a synthetic one rather than
+/// depending on whatever auth the ambient environment happens to carry.
+fn bt_trace_command() -> Command {
+    let mut cmd = bt_command();
+    clear_braintrust_auth_env(&mut cmd);
+    cmd.env("BRAINTRUST_API_KEY", "test-api-key")
+        .env("BRAINTRUST_ORG_NAME", "test-org");
+    cmd
+}
+
 fn write_executable(path: &Path) {
     fs::write(path, "#!/bin/sh\nexit 0\n").expect("write executable");
     #[cfg(unix)]
@@ -83,6 +94,20 @@ fn write_auth_store(config_home: &Path, profiles: &[(&str, &str)]) {
 
     let body = format!("{{\"profiles\":{{{}}}}}", entries.join(","));
     fs::write(auth_dir.join("auth.json"), body).expect("write auth store");
+}
+
+/// Store a synthetic credential for each profile so commands that resolve a
+/// credential (rather than only listing profiles) can run offline.
+fn write_profile_secrets(config_home: &Path, profiles: &[&str]) {
+    let auth_dir = config_home.join("bt");
+    fs::create_dir_all(&auth_dir).expect("create auth dir");
+
+    let entries: Vec<String> = profiles
+        .iter()
+        .map(|profile| format!("\"{profile}\":\"test-api-key\""))
+        .collect();
+    let body = format!("{{\"secrets\":{{{}}}}}", entries.join(","));
+    fs::write(auth_dir.join("secrets.json"), body).expect("write secret store");
 }
 
 #[test]
@@ -223,7 +248,8 @@ fn trace_help_exposes_user_commands_and_hides_internal_commands() {
         .assert()
         .success()
         .stdout(predicate::str::contains("<SOURCE>"))
-        .stdout(predicate::str::contains("<SESSION_ID>"))
+        .stdout(predicate::str::contains("[SESSION_ID]..."))
+        .stdout(predicate::str::contains("--all"))
         .stdout(predicate::str::contains("codex"))
         .stdout(predicate::str::contains("claude"));
 
@@ -292,7 +318,7 @@ fn trace_run_uses_the_invocation_project_without_changing_setup() {
     let setup_settings = state_dir.path().join("setup-settings.json");
     write_run_agent(&bin_dir.path().join("codex"));
 
-    bt_command()
+    bt_trace_command()
         .env("HOME", home.path())
         .env("PATH", bin_dir.path())
         .env("AGENT_RUN_LOG", &run_log)
@@ -307,8 +333,14 @@ fn trace_run_uses_the_invocation_project_without_changing_setup() {
             "--",
             "--version",
         ])
+        // The fake agent emits no hook events, so the managed run reports an
+        // empty trace once it exits. Everything asserted below is written
+        // before that check.
         .assert()
-        .success();
+        .failure()
+        .stderr(predicate::str::contains(
+            "managed run produced no accepted trace events",
+        ));
 
     let args = fs::read_to_string(run_log).expect("read run args");
     assert!(args.contains("--version"));
@@ -340,7 +372,7 @@ fn trace_run_opencode_injects_the_npm_plugin_without_changing_global_config() {
     fs::write(&global_config, r#"{"trace_to_braintrust":true}"#).expect("seed global config");
     write_run_agent(&bin_dir.path().join("opencode"));
 
-    bt_command()
+    bt_trace_command()
         .env("HOME", home.path())
         .env("OPENCODE_BIN", bin_dir.path().join("opencode"))
         .env("AGENT_RUN_LOG", &run_log)
@@ -356,7 +388,10 @@ fn trace_run_opencode_injects_the_npm_plugin_without_changing_global_config() {
             "--version",
         ])
         .assert()
-        .success();
+        .failure()
+        .stderr(predicate::str::contains(
+            "managed run produced no accepted trace events",
+        ));
 
     let inline: serde_json::Value =
         serde_json::from_slice(&fs::read(run_config).expect("read OpenCode inline config"))
@@ -392,7 +427,7 @@ fn trace_run_pi_injects_the_npm_extension_for_only_that_process() {
     fs::write(&global_config, r#"{"trace_to_braintrust":true}"#).expect("seed global config");
     write_run_agent(&bin_dir.path().join("pi"));
 
-    bt_command()
+    bt_trace_command()
         .env("HOME", home.path())
         .env("PI_BIN", bin_dir.path().join("pi"))
         .env("AGENT_RUN_LOG", &run_log)
@@ -407,7 +442,10 @@ fn trace_run_pi_injects_the_npm_extension_for_only_that_process() {
             "--version",
         ])
         .assert()
-        .success();
+        .failure()
+        .stderr(predicate::str::contains(
+            "managed run produced no accepted trace events",
+        ));
 
     assert!(fs::read_to_string(run_log)
         .expect("read Pi arguments")
@@ -540,8 +578,11 @@ fn trace_status_and_stop_honor_global_json_when_daemon_is_absent() {
 #[test]
 fn trace_setup_codex_installs_plugin_and_preserves_existing_settings() {
     let home = tempfile::tempdir().expect("home tempdir");
+    let config_home = tempfile::tempdir().expect("config tempdir");
     let bin_dir = tempfile::tempdir().expect("bin tempdir");
     let state_dir = tempfile::tempdir().expect("state tempdir");
+    write_auth_store(config_home.path(), &[("test-profile", "test-org")]);
+    write_profile_secrets(config_home.path(), &["test-profile"]);
     let log = state_dir.path().join("codex.log");
     let config = state_dir.path().join("config.json");
     write_agent_cli(
@@ -561,8 +602,9 @@ fn trace_setup_codex_installs_plugin_and_preserves_existing_settings() {
     )
     .expect("seed config");
 
-    bt_command()
+    bt_trace_command()
         .env("HOME", home.path())
+        .env("XDG_CONFIG_HOME", config_home.path())
         .env("PATH", bin_dir.path())
         .env("AGENT_SETUP_LOG", &log)
         .env("BT_DAEMON_CONFIG", &config)
@@ -614,7 +656,7 @@ fn trace_setup_claude_installs_plugin_and_writes_selected_project() {
     let config = state_dir.path().join("config.json");
     write_agent_cli(&bin_dir.path().join("claude"), "[]", "[]");
 
-    bt_command()
+    bt_trace_command()
         .env("HOME", home.path())
         .env("PATH", bin_dir.path())
         .env("AGENT_SETUP_LOG", &log)
@@ -650,8 +692,10 @@ fn trace_setup_opencode_configures_the_npm_plugin_and_selected_route() {
         r#"{"plugin":["other-plugin","@braintrust/trace-opencode@0.9.0"],"model":"test/model"}"#,
     )
     .expect("seed OpenCode config");
+    write_auth_store(config_home.path(), &[("work", "acme")]);
+    write_profile_secrets(config_home.path(), &["work"]);
 
-    bt_command()
+    bt_trace_command()
         .env("HOME", home.path())
         .env("XDG_CONFIG_HOME", config_home.path())
         .args([
@@ -696,7 +740,7 @@ fn trace_setup_opencode_configures_the_npm_plugin_and_selected_route() {
 fn trace_setup_honors_global_json() {
     let home = tempfile::tempdir().expect("home tempdir");
     let config_home = tempfile::tempdir().expect("config tempdir");
-    let stdout = bt_command()
+    let stdout = bt_trace_command()
         .env("HOME", home.path())
         .env("XDG_CONFIG_HOME", config_home.path())
         .args([
@@ -737,7 +781,7 @@ fn trace_setup_pi_installs_the_npm_extension_and_selected_route() {
     let log = state_dir.path().join("pi.log");
     write_agent_cli(&bin_dir.path().join("pi"), "{}", "{}");
 
-    bt_command()
+    bt_trace_command()
         .env("HOME", home.path())
         .env("PATH", bin_dir.path())
         .env("AGENT_SETUP_LOG", &log)
@@ -774,7 +818,7 @@ fn trace_setup_keeps_each_agents_persistent_selection_independent() {
         r#"{"installed":[]}"#,
     );
 
-    bt_command()
+    bt_trace_command()
         .env("HOME", home.path())
         .env("XDG_CONFIG_HOME", config_home.path())
         .env("PATH", bin_dir.path())
@@ -782,7 +826,7 @@ fn trace_setup_keeps_each_agents_persistent_selection_independent() {
         .args(["trace", "setup", "codex", "--project", "codex-project"])
         .assert()
         .success();
-    bt_command()
+    bt_trace_command()
         .env("HOME", home.path())
         .env("XDG_CONFIG_HOME", config_home.path())
         .args([

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -96,6 +96,17 @@ fn write_auth_store(config_home: &Path, profiles: &[(&str, &str)]) {
     fs::write(auth_dir.join("auth.json"), body).expect("write auth store");
 }
 
+/// Record a default org the way `bt init` and `bt switch` do.
+fn write_config_org(config_home: &Path, org: &str) {
+    let config_dir = config_home.join("bt");
+    fs::create_dir_all(&config_dir).expect("create config dir");
+    fs::write(
+        config_dir.join("config.json"),
+        format!("{{\"org\":\"{org}\"}}"),
+    )
+    .expect("write config");
+}
+
 /// Store a synthetic credential for each profile so commands that resolve a
 /// credential (rather than only listing profiles) can run offline.
 fn write_profile_secrets(config_home: &Path, profiles: &[&str]) {
@@ -305,6 +316,89 @@ fn trace_commands_require_a_project_non_interactively() {
             ))
             .stderr(predicate::str::contains("--project <NAME>"));
     }
+}
+
+/// A default org comes from `--org`/`BRAINTRUST_ORG_NAME`, the config file
+/// `bt init` and `bt switch` write, or an org-bound API key profile. A bare
+/// API key in the environment has none of those, so tracing has to ask.
+/// Non-interactively it says so instead of failing inside the trace runtime.
+#[test]
+fn trace_commands_require_an_org_when_the_credential_resolves_none() {
+    for args in [
+        vec![
+            "trace",
+            "setup",
+            "codex",
+            "--project",
+            "test-project",
+            "--no-input",
+        ],
+        vec![
+            "trace",
+            "run",
+            "codex",
+            "--project",
+            "test-project",
+            "--no-input",
+        ],
+    ] {
+        let home = tempfile::tempdir().expect("home tempdir");
+        let config_home = tempfile::tempdir().expect("config tempdir");
+        let mut cmd = bt_command();
+        clear_braintrust_auth_env(&mut cmd);
+        cmd.env("HOME", home.path())
+            .env("XDG_CONFIG_HOME", config_home.path())
+            .env("BRAINTRUST_API_KEY", "test-api-key")
+            .args(args)
+            .assert()
+            .failure()
+            .stderr(predicate::str::contains(
+                "organization choice required in non-interactive mode",
+            ))
+            .stderr(predicate::str::contains("--org <NAME>"));
+    }
+}
+
+/// The other half: the org `bt init` and `bt switch` record in the config file
+/// is adopted without asking. `--no-input` makes any attempt to prompt a
+/// failure rather than a hang.
+#[cfg(unix)]
+#[test]
+fn trace_setup_adopts_the_configured_org_without_prompting() {
+    let home = tempfile::tempdir().expect("home tempdir");
+    let config_home = tempfile::tempdir().expect("config tempdir");
+    let bin_dir = tempfile::tempdir().expect("bin tempdir");
+    let state_dir = tempfile::tempdir().expect("state tempdir");
+    let config = state_dir.path().join("config.json");
+    write_agent_cli(
+        &bin_dir.path().join("codex"),
+        r#"{"marketplaces":[]}"#,
+        r#"{"installed":[]}"#,
+    );
+    write_config_org(config_home.path(), "test-org");
+
+    let mut cmd = bt_command();
+    clear_braintrust_auth_env(&mut cmd);
+    cmd.env("HOME", home.path())
+        .env("XDG_CONFIG_HOME", config_home.path())
+        .env("PATH", bin_dir.path())
+        .env("BRAINTRUST_API_KEY", "test-api-key")
+        .env("AGENT_SETUP_LOG", state_dir.path().join("codex.log"))
+        .env("BT_DAEMON_CONFIG", &config)
+        .args([
+            "trace",
+            "setup",
+            "codex",
+            "--project",
+            "test-project",
+            "--no-input",
+        ])
+        .assert()
+        .success();
+
+    let settings: serde_json::Value =
+        serde_json::from_slice(&fs::read(config).expect("read config")).expect("parse config");
+    assert_eq!(settings["route"]["auth"]["org_name"], "test-org");
 }
 
 #[cfg(unix)]


### PR DESCRIPTION
Bumps the `bt-daemon` dependency on [braintrust-coding-agent-plugins](https://github.com/braintrustdata/braintrust-coding-agent-plugins) to `1ca65d4` (latest `main`), picking up:

- Improve hook routing handling (#21)
- Support bulk transcript imports (#13)
- Keep managed runs fail-open when nothing was traced (#22)

Adapting to those changes surfaced two problems worth fixing rather than absorbing. One was fixed upstream in plugins#22, which has landed and is included in this pin; the other is fixed here.

## 1. `resolve_route` takes `RouteRequirements`

`TraceHostServices::resolve_route` now takes a struct instead of a `destination_required` bool. Its new `interactive_auth` field is false for hooks, so `bt` suppresses every prompt for the rest of the process when it is unset — a missing profile or org can no longer block an agent's turn on a prompt.

`base.no_input = true` in `resolve_auth` did not already do this: `bt` gates prompts on a process global, which `crate::auth::resolve_auth` consults later in the same run, so that assignment was inert.

## 2. Orgs now resolve interactively instead of hard-failing

Reproduced against the built binary before the fix:

```
$ HOME=$tmp BRAINTRUST_API_KEY=test-api-key bt trace setup codex --project test-project
error: organization choice required for tracing; pass --org <NAME> or select an organization during setup
```

`require_resolved_org` rejects a route with no org, but `bt` never offered a way to choose one — and the advice to "select an organization during setup" is circular when setup is the command that just failed. Projects already resolve interactively through `ui::select_project`; orgs now do the same via `switch::select_org_for_switch`, which auto-selects when the credential has exactly one org and prompts otherwise. This is what upstream's `interactive_auth` was added to allow — hooks leave it false and keep tolerating an unresolved org, since the daemon accepts their events without one.

Org resolution runs before the project picker, so the projects offered belong to the org the traces will actually land in.

**Where a default org actually comes from.** Only three sources:

1. `--org` / `BRAINTRUST_ORG_NAME`
2. the config file `bt init` and `bt switch` write (`config/mod.rs`, `init.rs:78`)
3. an **org-bound API key** profile — `org_constraint()` requires `auth_kind == ApiKey && org_bound == Some(true)`

`commit_oauth_profile` stores `org_name: None, org_bound: Some(false)`, so an **OAuth profile carries no org at all**. This was never an API-key-only gap: anyone who authenticated without running `bt init` hit it, OAuth included.

Non-interactively it now reports `organization choice required in non-interactive mode; pass --org <NAME> or set BRAINTRUST_ORG_NAME`, mirroring the existing project message.

## 3. Test changes

**Credentials.** Setup, managed run, and import now resolve a credential and require a resolved org before writing a route. The affected tests previously ran with no auth at all; they now go through `bt_trace_command()`, which supplies a synthetic key and org. The two that pass an explicit `--profile` also seed a synthetic auth store and secret so they resolve offline.

**Import help.** Bulk import made session ids variadic, so the assertions moved from `<SESSION_ID>` to `[SESSION_ID]...` and now also cover `--all`.

**Added.**

- `trace_commands_require_an_org_when_the_credential_resolves_none` — bare API key, no org, `--no-input`, across setup and run
- `trace_setup_adopts_the_configured_org_without_prompting` — the config-file org is adopted silently; `--no-input` makes any attempted prompt a failure rather than a hang

The interactive org prompt itself is not covered — that needs a TTY and a live org list, which would mean faking `resolve_org_options` behind a seam.

The three `trace run` tests still assert `.success()`. Their fake agents emit no hook events, which is precisely the case plugins#22 fixed, so they double as end-to-end confirmation that the fail-open fix works through `bt`.

## Testing

`cargo build`, `cargo clippy --all-targets` (no new warnings), `cargo fmt --check`, and `cargo test` all pass — 810 tests, including all 41 CLI tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)