### PR TITLE
chore: disable signing the commits in git commit in the test

### DIFF
--- a/src/utils/git.rs
+++ b/src/utils/git.rs
@@ -144,7 +144,7 @@ mod tests {
         let file = root.join("tracked.txt");
         fs::write(&file, "v1\n").expect("write tracked file");
         run_git(&root, &["add", "tracked.txt"]);
-        run_git(&root, &["commit", "-m", "init"]);
+        run_git(&root, &["commit", "--no-gpg-sign", "-m", "init"]);
 
         fs::write(&file, "v2\n").expect("modify tracked file");
 
@@ -170,7 +170,7 @@ mod tests {
         let tracked = root.join("tracked.txt");
         fs::write(&tracked, "v1\n").expect("write tracked file");
         run_git(&root, &["add", "tracked.txt"]);
-        run_git(&root, &["commit", "-m", "init"]);
+        run_git(&root, &["commit", "--no-gpg-sign", "-m", "init"]);
 
         let untracked = root.join("untracked.txt");
         fs::write(&untracked, "local-only\n").expect("write untracked file");


### PR DESCRIPTION
Running `cargo test` with `commit.gpgsign=true` in the `git config` and needing to enter the PGP key password makes the tests fail:
<details>

```
❯ cargo test utils::git::tests
    Finished `test` profile [unoptimized + debuginfo] target(s) in 0.16s
     Running unittests src/main.rs (target/debug/deps/bt-e661fa17e65f74b2)

running 4 tests
test utils::git::tests::find_repo_root_detects_git_dir ... ok
test utils::git::tests::find_repo_root_detects_git_file ... ok
Initialized empty Git repository in /private/var/folders/sm/rcfl1zsj1l5_nk7gg8jldzwh0000gn/T/bt-git-dirty-1786752459442274000/.git/
Initialized empty Git repository in /private/var/folders/sm/rcfl1zsj1l5_nk7gg8jldzwh0000gn/T/bt-git-untracked-1786752459442275000/.git/
error: gpg failed to sign the data:
[GNUPG:] KEY_CONSIDERED 416E4B8398BC423593DD6BE69527FD70D5AF503F 2
[GNUPG:] BEGIN_SIGNING H10
[GNUPG:] PINENTRY_LAUNCHED 27796 curses 1.3.3 - xterm-kitty - - 501/20 0
gpg: signing failed: Inappropriate ioctl for device
[GNUPG:] FAILURE sign 83918950
gpg: signing failed: Inappropriate ioctl for device

fatal: failed to write commit object
test utils::git::tests::untracked_file_is_treated_as_dirty ... FAILED
error: gpg failed to sign the data:
[GNUPG:] KEY_CONSIDERED 416E4B8398BC423593DD6BE69527FD70D5AF503F 2
[GNUPG:] BEGIN_SIGNING H10
[GNUPG:] PINENTRY_LAUNCHED 27797 curses 1.3.3 - xterm-kitty - - 501/20 0
gpg: signing failed: Inappropriate ioctl for device
[GNUPG:] FAILURE sign 83918950
gpg: signing failed: Inappropriate ioctl for device

fatal: failed to write commit object
test utils::git::tests::tracked_modifications_are_reported_dirty ... FAILED

failures:

---- utils::git::tests::untracked_file_is_treated_as_dirty stdout ----

thread 'utils::git::tests::untracked_file_is_treated_as_dirty' (2496786) panicked at src/utils/git.rs:90:9:
git command failed: git commit -m init
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace

---- utils::git::tests::tracked_modifications_are_reported_dirty stdout ----

thread 'utils::git::tests::tracked_modifications_are_reported_dirty' (2496785) panicked at src/utils/git.rs:90:9:
git command failed: git commit -m init


failures:
    utils::git::tests::tracked_modifications_are_reported_dirty
    utils::git::tests::untracked_file_is_treated_as_dirty

test result: FAILED. 2 passed; 2 failed; 0 ignored; 0 measured; 715 filtered out; finished in 3.46s

error: test failed, to rerun pass `--bin bt`
```

</details>

This PR simply add the `--no-gpg-sign` argument to the `git commit` calls to prevent this issue.