### PR TITLE
chore: repin bt-daemon to pick up the memory fix

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -593,7 +593,7 @@ dependencies = [
 [[package]]
 name = "bt-daemon"
 version = "0.1.0"
-source = "git+https://github.com/braintrustdata/braintrust-coding-agent-plugins?rev=1ca65d4381acbed0610797c4f8825556b9b6cf10#1ca65d4381acbed0610797c4f8825556b9b6cf10"
+source = "git+https://github.com/braintrustdata/braintrust-coding-agent-plugins?rev=abd6756ab36776e893c65d2edd96c5968d75e552#abd6756ab36776e893c65d2edd96c5968d75e552"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ actix-web = "4.11.0"
 anyhow = "1.0.89"
 backoff = { version = "0.4.0", features = ["tokio"] }
 braintrust-sdk-rust = { git = "https://github.com/braintrustdata/braintrust-sdk-rust", rev = "43ba73edbf5220b57090e049feb094b60a92fcd4" }
-bt-daemon = { git = "https://github.com/braintrustdata/braintrust-coding-agent-plugins", rev = "1ca65d4381acbed0610797c4f8825556b9b6cf10" }
+bt-daemon = { git = "https://github.com/braintrustdata/braintrust-coding-agent-plugins", rev = "abd6756ab36776e893c65d2edd96c5968d75e552" }
 async-trait = "0.1"
 clap = { version = "4.5.20", features = ["derive", "env"] }
 crossterm = "0.28.1"


### PR DESCRIPTION
Moves the `bt-daemon` pin from `1ca65d4` to [`abd6756`](https://github.com/braintrustdata/braintrust-coding-agent-plugins/commit/abd6756ab36776e893c65d2edd96c5968d75e552), which is braintrustdata/braintrust-coding-agent-plugins#23 — *"bound daemon memory so a long session cannot exhaust it"*.

## Why

A user reported the daemon reaching **20 GB** before crashing. Every Claude lifecycle event had been reading the whole transcript into memory and journaling it verbatim, so a session re-recorded its growing transcript on every turn — an 18 MB transcript produced a **1.6 GB** journal (142 snapshot lines accounted for 1.54 GB; all 5,852 other lines totalled 19 MB). Replay then loaded that file with `read_to_string` and parsed every line into a `Vec` held at once.

The daemon now:
- mirrors transcript bytes once into daemon-owned storage and journals only a reference plus a high-water offset,
- streams journal replay entry by entry instead of materializing it,
- retires idle sessions so translator state, sink handles, and credential leases are released rather than held for the process lifetime,
- applies backpressure on session queues instead of using an unbounded channel.

Nothing on disk is capped or truncated — only in-memory caches are bounded, and each is re-derivable from disk.

## Scope

No source changes are needed in `bt`. It only constructs bt-daemon's clap-parsed command schema (`TraceArgs`), and the one new field (`ServeArgs::session_idle_timeout_secs`) carries a `default_value_t`, so this is not a breaking API change. It surfaces as a new hidden flag:

```
bt trace daemon --session-idle-timeout-secs <SECS>   [default: 300]
    Retire a session's in-memory state after this many seconds without traffic.
    A later event rebuilds it from the journal. 0 disables retirement.
```

The `Cargo.lock` change is deliberately limited to the one `source` line. `cargo update -p bt-daemon` also re-resolved unrelated transitive picks (`windows-sys`, `socket2`, `getrandom`), which I reverted — the bump adds no dependencies, and pristine `main` passes `--locked` cleanly, so that churn was noise.

## Verification

- `cargo check --locked --all-targets` — clean
- `cargo test auth::tests` — 77 passed (what CI runs)
- `cargo test trace` — 40 passed
- `cargo clippy --locked --all-targets --all-features -- -D warnings` — 14 findings, identical before and after the bump. They are pre-existing `collapsible_if` lints in `src/traces.rs`, `src/sql.rs`, and `src/datasets/pipeline.rs` from a newer local clippy than CI's pinned toolchain; untouched here.
- Confirmed the new flag and its default surface through the real `bt` binary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)