### PR TITLE
chore(evals): improve error message for remote evals when they do not successfully connect

### DIFF
--- a/scripts/eval-runner-impl.ts
+++ b/scripts/eval-runner-impl.ts
@@ -1331,7 +1331,7 @@ function isNodeErrorCode(err: unknown, code: string): boolean {
 
 function formatError(err: unknown): string {
   if (err instanceof Error) {
-    return err.message;
+    return err.stack ?? err.message;
   }
   return String(err);
 }
@@ -2264,7 +2264,10 @@ function mergeProgress(
   };
 }
 
-async function createEvalRunner(config: RunnerConfig): Promise<EvalRunner> {
+async function createEvalRunner(
+  config: RunnerConfig,
+  sse: SseWriter | null,
+): Promise<EvalRunner> {
   const braintrust = await loadBraintrust();
   const Eval = braintrust.Eval;
   if (typeof Eval !== "function") {
@@ -2274,7 +2277,6 @@ async function createEvalRunner(config: RunnerConfig): Promise<EvalRunner> {
   const initDataset = braintrust.initDataset;
   const invoke = braintrust.invoke;
 
-  const sse = createSseWriter();
   const noSendLogs = shouldDisableSendLogs();
   const parseParent = loadBraintrustUtilParseParent();
   const getState = extractGlobalStateGetter(braintrust);
@@ -2439,7 +2441,7 @@ async function createEvalRunner(config: RunnerConfig): Promise<EvalRunner> {
   };
 }
 
-export async function main() {
+async function runMain(sse: SseWriter | null) {
   const config = readRunnerConfig();
   const files = process.argv.slice(2);
   if (files.length === 0) {
@@ -2473,7 +2475,7 @@ export async function main() {
   const modules = await loadFiles(normalized);
   const btEvalMains = collectBtEvalMains(modules);
 
-  const runner = await createEvalRunner(config);
+  const runner = await createEvalRunner(config, sse);
   if (!runner.noSendLogs && typeof runner.login === "function") {
     try {
       await runner.login({});
@@ -2611,5 +2613,24 @@ export async function main() {
     collectRequireCacheDependencies();
     await collectDenoInfoDependencies(normalized);
     runner.finish(ok);
+  }
+}
+
+export async function main() {
+  let sse: SseWriter | null = null;
+  try {
+    sse = createSseWriter();
+    await runMain(sse);
+  } catch (err) {
+    const serialized = serializeError(err);
+    // The structured event preserves the stack in dev-server logs. Only print
+    // it directly without a parent connection to avoid duplicate tracebacks.
+    if (sse) {
+      sse.send("error", { ...serialized, status: 500 });
+      sse.close();
+    } else {
+      console.error(serialized.stack ?? serialized.message);
+    }
+    process.exitCode = 1;
   }
 }

--- a/scripts/eval-runner.py
+++ b/scripts/eval-runner.py
@@ -1436,13 +1436,23 @@ def main(argv: list[str] | None = None) -> int:
     if config.num_workers is not None:
         set_thread_pool_max_workers(config.num_workers)
 
-    if not local:
-        login(api_key=args.api_key, org_name=args.org_name, app_url=args.app_url)
-
     sse = create_sse_writer()
     cwd = os.path.abspath(os.getcwd())
+    success = False
     try:
-        success = asyncio.run(run_once(files, local, sse, config))
+        try:
+            if not local:
+                login(api_key=args.api_key, org_name=args.org_name, app_url=args.app_url)
+            success = asyncio.run(run_once(files, local, sse, config))
+        except Exception as exc:
+            stack = traceback.format_exc()
+            # The structured event preserves the traceback in dev-server logs.
+            # Only print it directly when no parent SSE connection is present,
+            # otherwise every traceback would be logged twice.
+            if sse:
+                send_eval_error(sse, str(exc), stack, 500)
+            else:
+                eprint(stack.rstrip())
 
         if not local:
             try:

--- a/src/eval.rs
+++ b/src/eval.rs
@@ -1398,6 +1398,44 @@ async fn resolve_dataset_ref_for_eval_request(
     Ok(())
 }
 
+fn select_effective_dev_api_url<'a>(
+    configured: Option<&'a str>,
+    authenticated_org: Option<&'a str>,
+) -> Option<(&'a str, &'static str)> {
+    configured
+        .map(|url| (url, "--api-url/BRAINTRUST_API_URL"))
+        .or_else(|| authenticated_org.map(|url| (url, "authenticated org")))
+}
+
+fn effective_dev_api_url<'a>(
+    state: &'a DevServerState,
+    auth: &'a DevAuthContext,
+) -> Option<(&'a str, &'static str)> {
+    select_effective_dev_api_url(state.base.api_url.as_deref(), auth.api_url.as_deref())
+}
+
+fn api_url_for_log(url: &str) -> String {
+    reqwest::Url::parse(url)
+        .ok()
+        .and_then(|parsed| {
+            let origin = parsed.origin();
+            origin.is_tuple().then(|| origin.ascii_serialization())
+        })
+        .unwrap_or_else(|| "<invalid URL>".to_string())
+}
+
+fn log_dev_api_url(request_id: &str, state: &DevServerState, auth: &DevAuthContext) {
+    match effective_dev_api_url(state, auth) {
+        Some((api_url, source)) => eprintln!(
+            "[remote-eval request_id={request_id} config] api_url={} source={source:?}",
+            api_url_for_log(api_url)
+        ),
+        None => eprintln!(
+            "[remote-eval request_id={request_id} config] api_url=<SDK discovery/default> source=\"SDK\""
+        ),
+    }
+}
+
 fn make_dev_mode_env(
     auth: &DevAuthContext,
     state: &DevServerState,
@@ -1410,8 +1448,8 @@ fn make_dev_mode_env(
         ("BRAINTRUST_APP_URL".to_string(), state.app_url.clone()),
         ("BT_EVAL_DEV_MODE".to_string(), dev_mode.to_string()),
     ];
-    if let Some(api_url) = auth.api_url.as_ref() {
-        env.push(("BRAINTRUST_API_URL".to_string(), api_url.clone()));
+    if let Some((api_url, _source)) = effective_dev_api_url(state, auth) {
+        env.push(("BRAINTRUST_API_URL".to_string(), api_url.to_string()));
     }
     if let Some(request) = request {
         let serialized =
@@ -1435,6 +1473,11 @@ fn dev_request_id(req: &HttpRequest) -> String {
 fn log_dev_runner_console(request_id: &str, stream: &str, message: &str) {
     for line in message.lines() {
         eprintln!("[remote-eval request_id={request_id} runner_{stream}] {line}");
+    }
+    if stream == "stderr" && message.contains("Warning: no data rows found for evaluator") {
+        eprintln!(
+            "[remote-eval request_id={request_id} hint] Braintrust datasets are fetched by the remote eval runner. Verify that --api-url / BRAINTRUST_API_URL points to your data-plane API (see the request's config log above)."
+        );
     }
 }
 
@@ -1598,6 +1641,7 @@ async fn dev_server_list(state: web::Data<DevServerState>, req: HttpRequest) -> 
         Ok(auth) => auth,
         Err(response) => return response,
     };
+    log_dev_api_url(&request_id, &state, &auth);
     let extra_env = match make_dev_mode_env(&auth, &state, None, "list") {
         Ok(extra_env) => extra_env,
         Err(err) => {
@@ -1731,6 +1775,7 @@ async fn dev_server_eval(
         Err(response) => return response,
     };
 
+    log_dev_api_url(&request_id, &state, &auth);
     let mut eval_request: EvalRequest = match serde_json::from_slice(&body) {
         Ok(eval_request) => eval_request,
         Err(err) => {
@@ -1915,6 +1960,14 @@ async fn run_dev_server(state: DevServerState) -> Result<()> {
         "Starting eval dev server on http://{}:{} (app URL: {})",
         state.host, state.port, state.app_url
     );
+    if let Some(api_url) = state.base.api_url.as_deref() {
+        println!(
+            "Remote eval API URL: {} (source: --api-url/BRAINTRUST_API_URL)",
+            api_url_for_log(api_url)
+        );
+    } else {
+        println!("Remote eval API URL: discovered per request from the authenticated org");
+    }
     let host = state.host.clone();
     let port = state.port;
     HttpServer::new(move || {
@@ -3652,6 +3705,33 @@ mod tests {
         assert!(excerpt.starts_with("…[stderr truncated]"));
         assert!(excerpt.ends_with("final traceback"));
         assert!(excerpt.len() <= DEV_RUNNER_STDERR_EXCERPT_MAX_BYTES + 32);
+    }
+
+    #[test]
+    fn dev_api_url_logging_strips_paths_queries_and_credentials() {
+        assert_eq!(
+            api_url_for_log("https://user:secret@api.example.test:8443/private?token=secret"),
+            "https://api.example.test:8443"
+        );
+        assert_eq!(api_url_for_log("not a URL"), "<invalid URL>");
+    }
+
+    #[test]
+    fn configured_dev_api_url_takes_precedence_over_org_discovery() {
+        assert_eq!(
+            select_effective_dev_api_url(
+                Some("http://internal-api.example.test"),
+                Some("https://public-api.example.test"),
+            ),
+            Some((
+                "http://internal-api.example.test",
+                "--api-url/BRAINTRUST_API_URL"
+            ))
+        );
+        assert_eq!(
+            select_effective_dev_api_url(None, Some("https://public-api.example.test")),
+            Some(("https://public-api.example.test", "authenticated org"))
+        );
     }
 
     #[test]

--- a/src/eval.rs
+++ b/src/eval.rs
@@ -5,7 +5,7 @@ use std::path::{Path, PathBuf};
 use std::process::{ExitStatus, Stdio};
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
-use std::time::{Duration, SystemTime};
+use std::time::{Duration, Instant, SystemTime};
 
 use actix_web::dev::Service;
 use actix_web::http::header::{
@@ -13,7 +13,7 @@ use actix_web::http::header::{
     ACCESS_CONTROL_ALLOW_METHODS, ACCESS_CONTROL_ALLOW_ORIGIN, ACCESS_CONTROL_EXPOSE_HEADERS,
     ACCESS_CONTROL_MAX_AGE, AUTHORIZATION, CACHE_CONTROL, CONNECTION, CONTENT_TYPE, ORIGIN, VARY,
 };
-use actix_web::{guard, web, App, HttpRequest, HttpResponse, HttpServer};
+use actix_web::{guard, web, App, HttpMessage, HttpRequest, HttpResponse, HttpServer};
 use anyhow::{Context, Result};
 use clap::{Args, ValueEnum};
 use crossterm::style::Stylize;
@@ -26,7 +26,7 @@ use tokio::process::Command;
 use tokio::sync::mpsc;
 
 use crate::args::BaseArgs;
-use crate::auth::resolved_runner_env;
+use crate::auth::{resolve_auth, resolved_runner_env};
 use crate::js_runner;
 use crate::python_runner;
 use crate::runner_sse;
@@ -43,7 +43,7 @@ const BRAINTRUSTDATA_ORIGIN: &str = "https://www.braintrustdata.com";
 const CORS_METHODS: &str = "GET, PATCH, POST, PUT, DELETE, OPTIONS";
 const CORS_ALLOWED_HEADERS: &str = "Content-Type, X-Amz-Date, Authorization, X-Api-Key, X-Amz-Security-Token, x-bt-auth-token, x-bt-parent, x-bt-org-name, x-bt-project-id, x-bt-stream-fmt, x-bt-use-cache, x-bt-use-gateway, x-stainless-os, x-stainless-lang, x-stainless-package-version, x-stainless-runtime, x-stainless-runtime-version, x-stainless-arch";
 const CORS_EXPOSED_HEADERS: &str =
-    "x-bt-cursor, x-bt-found-existing-experiment, x-bt-span-id, x-bt-span-export";
+    "x-bt-cursor, x-bt-found-existing-experiment, x-bt-span-id, x-bt-span-export, x-bt-request-id";
 const HEADER_BT_AUTH_TOKEN: &str = "x-bt-auth-token";
 const HEADER_BT_ORG_NAME: &str = "x-bt-org-name";
 const HEADER_CORS_REQ_PRIVATE_NETWORK: &str = "access-control-request-private-network";
@@ -62,6 +62,8 @@ const EVAL_TOTAL_SMOOTH_INTERVAL: Duration = Duration::from_millis(100);
 const EVAL_TOTAL_SMOOTH_DELTA_DIVISOR: u64 = 50;
 const EVAL_TOTAL_SMOOTH_MIN_STEP: u64 = 2;
 const EVAL_MIN_DETERMINATE_TOTAL: u64 = 2;
+const DEV_RUNNER_STDERR_EXCERPT_MAX_BYTES: usize = 8 * 1024;
+const HEADER_BT_REQUEST_ID: &str = "x-bt-request-id";
 
 fn parse_positive_usize(value: &str) -> std::result::Result<usize, String> {
     let parsed = value
@@ -194,6 +196,12 @@ struct DevAuthContext {
     org_name: String,
     api_url: Option<String>,
 }
+
+#[derive(Clone)]
+struct DevRequestId(String);
+
+#[derive(Clone)]
+struct DevEvalName(String);
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 struct RunnerFilter {
@@ -511,7 +519,11 @@ pub async fn run(base: BaseArgs, args: EvalArgs) -> Result<()> {
 
     if args.dev {
         let language = detect_eval_language(&files, args.language)?;
-        let app_url = resolve_app_url(&base);
+        let app_url = resolve_auth(&base)
+            .await
+            .context("failed to resolve eval dev server authentication")?
+            .app_url
+            .unwrap_or_else(|| "https://www.braintrust.dev".to_string());
         let state = DevServerState {
             base: base.clone(),
             language_override: Some(language),
@@ -1022,11 +1034,15 @@ where
             }
             EvalEvent::Console { stream, message } => {
                 if stream == "stderr"
-                    && !message.starts_with("Warning:")
-                    && matches!(console_policy, ConsolePolicy::BufferStderr)
+                    && (!message.starts_with("Warning:")
+                        || matches!(console_policy, ConsolePolicy::Forward))
                 {
-                    stderr_lines.push(message);
-                } else {
+                    stderr_lines.push(message.clone());
+                }
+                if stream != "stderr"
+                    || message.starts_with("Warning:")
+                    || matches!(console_policy, ConsolePolicy::Forward)
+                {
                     on_event(EvalEvent::Console { stream, message });
                 }
             }
@@ -1117,13 +1133,6 @@ fn is_esm_interop_error(message: &str) -> bool {
     ];
 
     PATTERNS.iter().any(|pattern| message.contains(pattern))
-}
-
-fn resolve_app_url(base: &BaseArgs) -> String {
-    if let Some(app_url) = base.app_url.as_ref() {
-        return app_url.clone();
-    }
-    "https://www.braintrust.dev".to_string()
 }
 
 fn app_origin_from_url(url: &str) -> Option<String> {
@@ -1243,6 +1252,9 @@ async fn authenticate_dev_request(
         .http_client
         .post(login_url)
         .bearer_auth(&token)
+        // The Next.js login endpoint only falls back to the Authorization
+        // header when the request body was parsed as an object.
+        .header("Content-Type", "application/json")
         .send()
         .await
         .map_err(|_| {
@@ -1413,6 +1425,70 @@ fn serialize_sse_event(event: &str, data: &str) -> String {
     format!("event: {event}\ndata: {data}\n\n")
 }
 
+fn dev_request_id(req: &HttpRequest) -> String {
+    req.extensions()
+        .get::<DevRequestId>()
+        .map(|value| value.0.clone())
+        .unwrap_or_else(|| uuid::Uuid::new_v4().to_string())
+}
+
+fn log_dev_runner_console(request_id: &str, stream: &str, message: &str) {
+    for line in message.lines() {
+        eprintln!("[remote-eval request_id={request_id} runner_{stream}] {line}");
+    }
+}
+
+fn log_dev_runner_error(request_id: &str, message: &str, stack: Option<&str>) {
+    eprintln!("[remote-eval request_id={request_id} runner_error] {message}");
+    if let Some(stack) = stack {
+        for line in stack.lines() {
+            eprintln!("[remote-eval request_id={request_id} runner_error] {line}");
+        }
+    }
+}
+
+fn bounded_stderr_excerpt(lines: &[String]) -> Option<String> {
+    let stderr = lines.join("\n");
+    if stderr.is_empty() {
+        return None;
+    }
+    if stderr.len() <= DEV_RUNNER_STDERR_EXCERPT_MAX_BYTES {
+        return Some(stderr);
+    }
+
+    let mut start = stderr.len() - DEV_RUNNER_STDERR_EXCERPT_MAX_BYTES;
+    while !stderr.is_char_boundary(start) {
+        start += 1;
+    }
+    Some(format!("…[stderr truncated]\n{}", &stderr[start..]))
+}
+
+fn unstructured_runner_error(status: ExitStatus, stderr_lines: &[String]) -> String {
+    let mut message = format!("Eval runner exited with {status}.");
+    if let Some(stderr) = bounded_stderr_excerpt(stderr_lines) {
+        message.push_str("\nRunner stderr:\n");
+        message.push_str(&stderr);
+    }
+    message
+}
+
+enum DevListManifestOutput {
+    Line { index: usize, manifest: Value },
+    Joined(Value),
+}
+
+fn parse_dev_list_manifest(stdout_lines: &[String]) -> Option<DevListManifestOutput> {
+    for (index, line) in stdout_lines.iter().enumerate().rev() {
+        if let Ok(manifest) = serde_json::from_str::<Value>(line) {
+            return Some(DevListManifestOutput::Line { index, manifest });
+        }
+    }
+
+    serde_json::from_str::<Value>(&stdout_lines.join("\n"))
+        .ok()
+        .map(DevListManifestOutput::Joined)
+}
+
 fn is_eval_progress_payload(progress: &SseProgressEventData) -> bool {
     serde_json::from_str::<EvalProgressData>(&progress.data)
         .map(|payload| payload.kind_type == "eval_progress")
@@ -1517,6 +1593,7 @@ fn apply_cors_headers(
 }
 
 async fn dev_server_list(state: web::Data<DevServerState>, req: HttpRequest) -> HttpResponse {
+    let request_id = dev_request_id(&req);
     let auth = match authenticate_dev_request(&req, &state).await {
         Ok(auth) => auth,
         Err(response) => return response,
@@ -1568,14 +1645,24 @@ async fn dev_server_list(state: web::Data<DevServerState>, req: HttpRequest) -> 
             spawned.process,
             ConsolePolicy::Forward,
             |event| match event {
-                EvalEvent::Console { stream, message } if stream == "stdout" => {
-                    stdout_lines.push(message);
+                EvalEvent::Console { stream, message } => {
+                    if stream == "stdout" {
+                        // Defer stdout logging until the evaluator manifest has
+                        // been identified. The manifest can contain parameter
+                        // defaults and is protocol output, not a user log.
+                        stdout_lines.push(message);
+                    } else {
+                        log_dev_runner_console(&request_id, &stream, &message);
+                    }
                 }
                 EvalEvent::Error {
                     message,
-                    stack: _,
+                    stack,
                     status,
-                } => errors.push((message, status)),
+                } => {
+                    log_dev_runner_error(&request_id, &message, stack.as_deref());
+                    errors.push((message, status));
+                }
                 _ => {}
             },
         )
@@ -1590,6 +1677,24 @@ async fn dev_server_list(state: web::Data<DevServerState>, req: HttpRequest) -> 
             }
         };
 
+    let parsed_manifest = if output.status.success() && errors.is_empty() {
+        parse_dev_list_manifest(&stdout_lines)
+    } else {
+        None
+    };
+    for (index, line) in stdout_lines.iter().enumerate() {
+        let is_manifest = matches!(
+            &parsed_manifest,
+            Some(DevListManifestOutput::Line {
+                index: manifest_index,
+                ..
+            }) if index == *manifest_index
+        ) || matches!(&parsed_manifest, Some(DevListManifestOutput::Joined(_)));
+        if !is_manifest {
+            log_dev_runner_console(&request_id, "stdout", line);
+        }
+    }
+
     if let Some((message, status)) = errors.first() {
         let status = status
             .and_then(|status| actix_web::http::StatusCode::from_u16(status).ok())
@@ -1599,26 +1704,15 @@ async fn dev_server_list(state: web::Data<DevServerState>, req: HttpRequest) -> 
     if !output.status.success() {
         return json_error_response(
             actix_web::http::StatusCode::INTERNAL_SERVER_ERROR,
-            "Eval runner exited with an error.",
+            &unstructured_runner_error(output.status, &output.stderr_lines),
         );
     }
 
-    let mut parsed_manifest: Option<Value> = None;
-    for line in stdout_lines.iter().rev() {
-        if let Ok(value) = serde_json::from_str::<Value>(line) {
-            parsed_manifest = Some(value);
-            break;
-        }
-    }
-    if parsed_manifest.is_none() {
-        let joined = stdout_lines.join("\n");
-        if let Ok(value) = serde_json::from_str::<Value>(&joined) {
-            parsed_manifest = Some(value);
-        }
-    }
-
     match parsed_manifest {
-        Some(manifest) => HttpResponse::Ok().json(manifest),
+        Some(DevListManifestOutput::Line { manifest, .. })
+        | Some(DevListManifestOutput::Joined(manifest)) => HttpResponse::Ok()
+            .append_header((CACHE_CONTROL, "no-store"))
+            .json(manifest),
         None => json_error_response(
             actix_web::http::StatusCode::INTERNAL_SERVER_ERROR,
             "Failed to parse evaluator manifest from runner output.",
@@ -1631,6 +1725,7 @@ async fn dev_server_eval(
     req: HttpRequest,
     body: web::Bytes,
 ) -> HttpResponse {
+    let request_id = dev_request_id(&req);
     let auth = match authenticate_dev_request(&req, &state).await {
         Ok(auth) => auth,
         Err(response) => return response,
@@ -1642,6 +1737,8 @@ async fn dev_server_eval(
             return json_error_response(actix_web::http::StatusCode::BAD_REQUEST, &err.to_string());
         }
     };
+    req.extensions_mut()
+        .insert(DevEvalName(eval_request.name.clone()));
     if let Err(response) =
         resolve_dataset_ref_for_eval_request(&state, &auth, &mut eval_request).await
     {
@@ -1694,8 +1791,14 @@ async fn dev_server_eval(
             let mut saw_error = false;
             let mut stderr_lines: Vec<String> = Vec::new();
             let output = drive_eval_runner(spawned.process, ConsolePolicy::Forward, |event| {
-                if matches!(event, EvalEvent::Error { .. }) {
+                if let EvalEvent::Error {
+                    ref message,
+                    ref stack,
+                    ..
+                } = event
+                {
                     saw_error = true;
+                    log_dev_runner_error(&request_id, message, stack.as_deref());
                 }
                 if matches!(event, EvalEvent::Done) {
                     return;
@@ -1705,6 +1808,7 @@ async fn dev_server_eval(
                     ref message,
                 } = event
                 {
+                    log_dev_runner_console(&request_id, stream, message);
                     for line in message.lines() {
                         let _ = tx.send(format!(": [{stream}] {line}\n"));
                     }
@@ -1722,11 +1826,7 @@ async fn dev_server_eval(
             match output {
                 Ok(output) => {
                     if !output.status.success() && !saw_error {
-                        let mut detail = format!("Eval runner exited with {}.", output.status);
-                        for line in stderr_lines.iter() {
-                            detail.push('\n');
-                            detail.push_str(line);
-                        }
+                        let detail = unstructured_runner_error(output.status, &stderr_lines);
                         let error =
                             serialize_sse_event("error", &json!({ "message": detail }).to_string());
                         let _ = tx.send(error);
@@ -1764,11 +1864,17 @@ async fn dev_server_eval(
             ConsolePolicy::Forward,
             |event| match event {
                 EvalEvent::Summary(current) => summary = Some(current),
+                EvalEvent::Console { stream, message } => {
+                    log_dev_runner_console(&request_id, &stream, &message);
+                }
                 EvalEvent::Error {
                     message,
-                    stack: _,
+                    stack,
                     status,
-                } => errors.push((message, status)),
+                } => {
+                    log_dev_runner_error(&request_id, &message, stack.as_deref());
+                    errors.push((message, status));
+                }
                 _ => {}
             },
         )
@@ -1795,7 +1901,7 @@ async fn dev_server_eval(
     if !output.status.success() {
         return json_error_response(
             actix_web::http::StatusCode::INTERNAL_SERVER_ERROR,
-            "Eval runner exited with an error.",
+            &unstructured_runner_error(output.status, &output.stderr_lines),
         );
     }
     json_error_response(
@@ -1806,8 +1912,8 @@ async fn dev_server_eval(
 
 async fn run_dev_server(state: DevServerState) -> Result<()> {
     println!(
-        "Starting eval dev server on http://{}:{}",
-        state.host, state.port
+        "Starting eval dev server on http://{}:{} (app URL: {})",
+        state.host, state.port, state.app_url
     );
     let host = state.host.clone();
     let port = state.port;
@@ -1818,6 +1924,20 @@ async fn run_dev_server(state: DevServerState) -> Result<()> {
                 let allowed_origins = allowed_origins.clone();
                 move |req, srv| {
                     let allowed_origins = allowed_origins.clone();
+                    let started = Instant::now();
+                    let method = req.method().clone();
+                    let route = req.path().to_string();
+                    let should_log = matches!(
+                        (method.as_str(), route.as_str()),
+                        ("GET", "/list") | ("POST", "/eval")
+                    );
+                    let request_id = uuid::Uuid::new_v4().to_string();
+                    req.extensions_mut().insert(DevRequestId(request_id.clone()));
+                    let org_name = req
+                        .headers()
+                        .get(HEADER_BT_ORG_NAME)
+                        .and_then(|value| value.to_str().ok())
+                        .map(str::to_owned);
                     let request_origin = req
                         .headers()
                         .get(ORIGIN)
@@ -1834,6 +1954,24 @@ async fn run_dev_server(state: DevServerState) -> Result<()> {
                             allow_private_network,
                             &allowed_origins,
                         );
+                        if let Ok(value) = HeaderValue::from_str(&request_id) {
+                            res.headers_mut()
+                                .insert(HeaderName::from_static(HEADER_BT_REQUEST_ID), value);
+                        }
+                        if should_log {
+                            let eval_name = res
+                                .request()
+                                .extensions()
+                                .get::<DevEvalName>()
+                                .map(|value| value.0.clone());
+                            eprintln!(
+                                "[remote-eval request_id={request_id}] method={method} route={route} status={} duration_ms={} org={:?} eval={:?}",
+                                res.status().as_u16(),
+                                started.elapsed().as_millis(),
+                                org_name,
+                                eval_name,
+                            );
+                        }
                         Ok::<_, actix_web::Error>(res)
                     }
                 }
@@ -3492,6 +3630,47 @@ mod tests {
 
     fn success_status() -> ExitStatus {
         exit_status(0)
+    }
+
+    #[test]
+    fn dev_runner_error_includes_stderr() {
+        let error = unstructured_runner_error(
+            exit_status(1),
+            &["import failed".to_string(), "traceback line".to_string()],
+        );
+        assert!(error.contains("Eval runner exited with"));
+        assert!(error.contains("Runner stderr:\nimport failed\ntraceback line"));
+    }
+
+    #[test]
+    fn dev_runner_stderr_excerpt_is_bounded_and_utf8_safe() {
+        let stderr = format!(
+            "old details{}final traceback",
+            "é".repeat(DEV_RUNNER_STDERR_EXCERPT_MAX_BYTES)
+        );
+        let excerpt = bounded_stderr_excerpt(&[stderr]).expect("stderr excerpt");
+        assert!(excerpt.starts_with("…[stderr truncated]"));
+        assert!(excerpt.ends_with("final traceback"));
+        assert!(excerpt.len() <= DEV_RUNNER_STDERR_EXCERPT_MAX_BYTES + 32);
+    }
+
+    #[test]
+    fn dev_list_manifest_is_identified_separately_from_user_stdout() {
+        let stdout = vec![
+            "user diagnostic".to_string(),
+            r#"{"test-eval":{"parameters":{"default":"private-value"}}}"#.to_string(),
+        ];
+        let parsed = parse_dev_list_manifest(&stdout).expect("manifest");
+        match parsed {
+            DevListManifestOutput::Line { index, manifest } => {
+                assert_eq!(index, 1);
+                assert_eq!(
+                    manifest["test-eval"]["parameters"]["default"],
+                    "private-value"
+                );
+            }
+            DevListManifestOutput::Joined(_) => panic!("expected a single-line manifest"),
+        }
     }
 
     fn get_command_env(command: &Command, key: &str) -> Option<String> {


### PR DESCRIPTION
**See also the [braintrust PR](https://github.com/braintrustdata/braintrust/pull/19218)**
Fix https://linear.app/braintrustdata/issue/SDK-150/improve-logging-and-error-surfacing-for-bt-eval-dev-remote-eval-server

`bt` now prints the API url it uses when specified by `--api-url` or BRAINTRUST_API_URL: `Remote eval API URL: http://localhost:8000 (source: --api-url/BRAINTRUST_API_URL)`.
If these aren't set, `Remote eval API URL: discovered per request from the authenticated org` is printed and in the logs printed by `bt eval`, the API will be subsequently printed:
`[remote-eval request_id=ef68ee9f-a6ae-400a-b162-5d3447535c0e config] api_url=http://127.0.0.1:8000 source="authenticated org"`

# AI summary

## Context

`bt eval --dev` remote eval servers currently provide very little diagnostic information. Requests to `/list` and `/eval` are not logged, child runner output can be hidden, and import/runtime failures may be reduced to a generic `Eval runner exited with an error.` response. This makes deployed remote eval failures difficult to diagnose and can leave the Playground reporting that an eval was not found.

This addresses SDK-150. The corresponding Playground error presentation is implemented in https://github.com/braintrustdata/braintrust/pull/19218.

## Description

- Log `/list` and `/eval` requests with a generated request ID, method, route, status, duration, org, and eval name when available.
- Return and CORS-expose `x-bt-request-id` so browser errors can be correlated with server logs.
- Re-emit runner stdout, stderr, structured errors, and stacks with request-ID prefixes.
- Normalize Python and JavaScript runner initialization/import failures into structured errors while preserving their traceback/stack in server logs.
- Include a bounded stderr excerpt when `/list` or non-streaming `/eval` exits unsuccessfully without a structured error.
- Preserve the existing streaming `/eval` SSE protocol and completion behavior.
- Avoid duplicate traceback output.
- Keep `/list` protocol output private: evaluator manifests, which may include parameter defaults, are returned to the caller but are not written to server logs; successful responses use `Cache-Control: no-store`.
- Resolve the configured profile/CLI app URL for dev-server authentication and send the JSON content type expected by the login endpoint.

The server does not add logging for auth tokens, request bodies, dataset rows, or request parameter values.
