### PR TITLE
fix(test): cargo test passes

### DIFF
--- a/src/eval.rs
+++ b/src/eval.rs
@@ -4102,12 +4102,9 @@ mod tests {
         fs::write(dir.join("a.eval.ts"), "").unwrap();
         fs::write(nm.join("b.eval.ts"), "").unwrap();
 
-        let orig = std::env::current_dir().unwrap();
-        std::env::set_current_dir(&dir).unwrap();
-        let mut result =
-            expand_eval_file_globs(&[".".to_string()]).expect("defaults should expand");
+        let mut result = expand_eval_file_globs(&[dir.to_string_lossy().into_owned()])
+            .expect("defaults should expand");
         result.retain(|p| !is_excluded_by_default(p));
-        std::env::set_current_dir(orig).unwrap();
 
         assert_eq!(
             result.len(),

--- a/tests/datasets-fixtures/snapshots-create/fixture.json
+++ b/tests/datasets-fixtures/snapshots-create/fixture.json
@@ -126,7 +126,7 @@
         "baseline"
       ],
       "expect_success": false,
-      "stderr_contains": [
+      "stdout_contains": [
         "snapshot delete requires --force in non-interactive mode"
       ]
     },
@@ -169,7 +169,7 @@
         "snapshot-source"
       ],
       "expect_success": false,
-      "stderr_contains": [
+      "stdout_contains": [
         "dataset delete requires --force in non-interactive mode"
       ]
     },

--- a/tests/functions.rs
+++ b/tests/functions.rs
@@ -141,6 +141,45 @@ fn find_tsc() -> Option<PathBuf> {
     None
 }
 
+fn compile_functions_runner(tsc: &Path, root: &Path, runner_dir: &Path) {
+    let mut command = Command::new(tsc);
+    command.current_dir(root).args([
+        "scripts/functions-runner.ts",
+        "scripts/runner-common.ts",
+        "--module",
+        "esnext",
+        "--target",
+        "es2020",
+        "--moduleResolution",
+        "bundler",
+        "--outDir",
+    ]);
+    command.arg(runner_dir);
+
+    let version = Command::new(tsc)
+        .arg("--version")
+        .output()
+        .ok()
+        .and_then(|output| String::from_utf8(output.stdout).ok())
+        .and_then(|output| {
+            output
+                .split_whitespace()
+                .find_map(|part| part.split('.').next()?.parse::<u32>().ok())
+        });
+    if version.is_some_and(|major| major >= 6) {
+        // TypeScript 6+ rejects explicit input files when a tsconfig is nearby.
+        // These are runtime tests, so compile independently and skip type checking.
+        command.args(["--ignoreConfig", "--noCheck"]);
+    }
+
+    let output = command.output().expect("compile functions runner");
+    if !output.status.success() {
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        panic!("tsc failed for functions runner:\nstdout:\n{stdout}\nstderr:\n{stderr}");
+    }
+}
+
 #[cfg(unix)]
 fn decode_uploaded_bundle(bundle: &[u8]) -> String {
     if bundle.starts_with(&[0x1f, 0x8b]) {
@@ -887,27 +926,7 @@ globalThis._evals.functions.push({
     .expect("write sample.js");
 
     let runner_dir = tmp.path().join("runner");
-    let compile_output = Command::new(&tsc)
-        .current_dir(&root)
-        .args([
-            "scripts/functions-runner.ts",
-            "scripts/runner-common.ts",
-            "--module",
-            "esnext",
-            "--target",
-            "es2020",
-            "--moduleResolution",
-            "bundler",
-            "--outDir",
-        ])
-        .arg(&runner_dir)
-        .output()
-        .expect("compile functions runner");
-    if !compile_output.status.success() {
-        let stdout = String::from_utf8_lossy(&compile_output.stdout);
-        let stderr = String::from_utf8_lossy(&compile_output.stderr);
-        panic!("tsc failed for functions runner:\nstdout:\n{stdout}\nstderr:\n{stderr}");
-    }
+    compile_functions_runner(&tsc, &root, &runner_dir);
 
     let runner_js = runner_dir.join("functions-runner.js");
     let runner_common_js = runner_dir.join("runner-common.js");
@@ -1076,27 +1095,7 @@ globalThis._evals.functions.push({{
     .expect("write sample.cjs");
 
     let runner_dir = tmp.path().join("runner");
-    let compile_output = Command::new(&tsc)
-        .current_dir(&root)
-        .args([
-            "scripts/functions-runner.ts",
-            "scripts/runner-common.ts",
-            "--module",
-            "esnext",
-            "--target",
-            "es2020",
-            "--moduleResolution",
-            "bundler",
-            "--outDir",
-        ])
-        .arg(&runner_dir)
-        .output()
-        .expect("compile functions runner");
-    if !compile_output.status.success() {
-        let stdout = String::from_utf8_lossy(&compile_output.stdout);
-        let stderr = String::from_utf8_lossy(&compile_output.stderr);
-        panic!("tsc failed for functions runner:\nstdout:\n{stdout}\nstderr:\n{stderr}");
-    }
+    compile_functions_runner(&tsc, &root, &runner_dir);
 
     let runner_js = runner_dir.join("functions-runner.js");
     let runner_common_js = runner_dir.join("runner-common.js");
@@ -1249,27 +1248,7 @@ globalThis._evals.functions.push({
     .expect("write sample-a.mjs");
 
     let runner_dir = tmp.path().join("runner");
-    let compile_output = Command::new(&tsc)
-        .current_dir(&root)
-        .args([
-            "scripts/functions-runner.ts",
-            "scripts/runner-common.ts",
-            "--module",
-            "esnext",
-            "--target",
-            "es2020",
-            "--moduleResolution",
-            "bundler",
-            "--outDir",
-        ])
-        .arg(&runner_dir)
-        .output()
-        .expect("compile functions runner");
-    if !compile_output.status.success() {
-        let stdout = String::from_utf8_lossy(&compile_output.stdout);
-        let stderr = String::from_utf8_lossy(&compile_output.stderr);
-        panic!("tsc failed for functions runner:\nstdout:\n{stdout}\nstderr:\n{stderr}");
-    }
+    compile_functions_runner(&tsc, &root, &runner_dir);
 
     let runner_js = runner_dir.join("functions-runner.js");
     let runner_common_js = runner_dir.join("runner-common.js");


### PR DESCRIPTION
eval, dataset and typescript tests fixed

Before the fixes, on branch main 62cf7a85da652516fb5a94505c76c5c7eeef6683:
<details>

```
❯ cargo test --test functions functions_js_runner_emits_valid_manifest
    Finished `test` profile [unoptimized + debuginfo] target(s) in 0.39s
     Running tests/functions.rs (target/debug/deps/functions-ae026ae47cde66da)

running 1 test
test functions_js_runner_emits_valid_manifest ... FAILED

failures:

---- functions_js_runner_emits_valid_manifest stdout ----

thread 'functions_js_runner_emits_valid_manifest' (207337) panicked at tests/functions.rs:909:9:
tsc failed for functions runner:
stdout:
error TS5112: tsconfig.json is present but will not be loaded if files are specified on commandline. Use '--ignoreConfig' to skip this error.

stderr:

note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace


failures:
    functions_js_runner_emits_valid_manifest

test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 28 filtered out; finished in 0.08s

error: test failed, to rerun pass `--test functions`
```

```
❯ cargo test --test functions functions_js_runner_reexecutes_imported_input_files
    Finished `test` profile [unoptimized + debuginfo] target(s) in 0.17s
     Running tests/functions.rs (target/debug/deps/functions-ae026ae47cde66da)

running 1 test
test functions_js_runner_reexecutes_imported_input_files ... FAILED

failures:

---- functions_js_runner_reexecutes_imported_input_files stdout ----

thread 'functions_js_runner_reexecutes_imported_input_files' (207509) panicked at tests/functions.rs:1271:9:
tsc failed for functions runner:
stdout:
error TS5112: tsconfig.json is present but will not be loaded if files are specified on commandline. Use '--ignoreConfig' to skip this error.

stderr:

note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace


failures:
    functions_js_runner_reexecutes_imported_input_files

test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 28 filtered out; finished in 0.04s

error: test failed, to rerun pass `--test functions`
```

```
❯ cargo test --test datasets datasets_fixtures
    Finished `test` profile [unoptimized + debuginfo] target(s) in 0.17s
     Running tests/datasets.rs (target/debug/deps/datasets-16c165cf3693e071)

running 1 test
test datasets_fixtures ... FAILED

failures:

---- datasets_fixtures stdout ----

thread 'datasets_fixtures' (212786) panicked at tests/datasets.rs:806:17:
Fixture snapshots-create step 7: stderr missing expected text: snapshot delete requires --force in non-interactive mode
stderr:

note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace


failures:
    datasets_fixtures

test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 0 filtered out; finished in 3.10s

error: test failed, to rerun pass `--test datasets`
```

```
❯ cargo test --test datasets
    Finished `test` profile [unoptimized + debuginfo] target(s) in 0.17s
     Running tests/datasets.rs (target/debug/deps/datasets-16c165cf3693e071)

running 1 test
test datasets_fixtures ... FAILED

failures:

---- datasets_fixtures stdout ----

thread 'datasets_fixtures' (217822) panicked at tests/datasets.rs:806:17:
Fixture snapshots-create step 7: stderr missing expected text: snapshot delete requires --force in non-interactive mode
stderr:

note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace


failures:
    datasets_fixtures

test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 0 filtered out; finished in 3.11s

error: test failed, to rerun pass `--test datasets`
```

</details>
