### PR TITLE
chore: deduplicate datasets in the root help message

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -68,7 +68,6 @@ Core
 Projects & resources
   projects     Manage projects
   topics       Inspect and control Topics automation
-  datasets     Manage datasets
   prompts      Manage prompts
   functions    Manage functions (tools, scorers, and more)
   tools        Manage tools


### PR DESCRIPTION
### You can just stamp this.

Before:
```
❯ bt
...
Projects & resources
  projects     Manage projects
  topics       Inspect and control Topics automation
  datasets     Manage datasets <- datasets are printed twice, once in 'Projects & resources and once in 'Data & evaluation'
  prompts      Manage prompts
  functions    Manage functions (tools, scorers, and more)
  tools        Manage tools
  scorers      Manage scorers
  experiments  Manage experiments

Data & evaluation
  datasets     Manage datasets
  eval         Run eval files
  sql          Run SQL queries against Braintrust
  sync         Synchronize project logs between Braintrust and local NDJSON files
...
```

After:
```
❯ bt
...
Projects & resources
  projects     Manage projects
  topics       Inspect and control Topics automation
  prompts      Manage prompts
  functions    Manage functions (tools, scorers, and more)
  tools        Manage tools
  scorers      Manage scorers
  experiments  Manage experiments

Data & evaluation
  datasets     Manage datasets
  eval         Run eval files
  sql          Run SQL queries against Braintrust
  sync         Synchronize project logs between Braintrust and local NDJSON files
...
```