### PR TITLE
chore: instruct the agent to add an env variable only for configurations

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,7 +5,7 @@
 - Do not introduce new ad-hoc configuration reads via `std::env::var(...)` / `process.env` / `os.getenv(...)` in command logic.
 - All user-facing/runtime configuration must be defined in `clap` arguments:
   - a CLI flag, and
-  - a corresponding environment variable (`#[arg(env = ...)]`).
+  - for persistent configuration, a corresponding environment variable (`#[arg(env = ...)]`).
 - Entry points/runners should receive configuration from the CLI layer (via args/env that the CLI owns), not from independent, undocumented env lookups.
 - Extreme edge-case exceptions are allowed only when a flag is not feasible (for example, process-internal plumbing), and must be:
   - documented inline with a short rationale, and


### PR DESCRIPTION
### You can stamp this.

Multiple times when adding a command to bt, the agent would add many unnecessary env variables (like prompt name or environment description).
Hopefully this won't be the case in the future.

Technically this could be evaled but the time spent on the eval would trump the time saved by checking it works.