### PR TITLE
chore(status): bt status prints which secret storage is used

### DIFF
--- a/README.md
+++ b/README.md
@@ -352,7 +352,7 @@ Local version and pagination-key conversion helpers:
   - `bt profiles` or `bt profiles list`
   - `bt profiles delete work`
   - `bt profiles rename work renamed-work`
-- Check every profile's connection status and the current context:
+- Check every profile's connection status, the current context, and the secret-storage backend:
   - `bt status --all`
 - Log out (remove a saved profile):
   - `bt logout`
@@ -369,7 +369,7 @@ Auth resolution order for commands is:
 5. Single-profile auto-select (if only one compatible profile exists)
 6. Interactive profile picker (if multiple compatible profiles exist and a TTY is available)
 
-On Linux, secure storage uses `secret-tool` (libsecret) with a running Secret Service daemon. On macOS, it uses the `security` keychain utility. If a secure store is unavailable, `bt` falls back to a plaintext secrets file with `0600` permissions.
+On Linux, secure storage uses `secret-tool` (libsecret) with a running Secret Service daemon. On macOS, secure storage uses the `security` keychain utility. Windows Credential Manager integration is not currently implemented. If a secure store is unavailable or unsupported, `bt` falls back to a plaintext `secrets.json` file with `0600` permissions where supported. `bt status --all` reports the backend in use (and the path when plaintext storage is in use).
 
 ## `bt switch`
 

--- a/src/auth.rs
+++ b/src/auth.rs
@@ -38,6 +38,12 @@ use crate::{
 
 #[cfg(any(target_os = "macos", target_os = "linux"))]
 const KEYCHAIN_SERVICE: &str = "com.braintrust.bt.cli";
+#[cfg(target_os = "macos")]
+const SECURE_STORAGE_BACKEND: Option<&str> = Some("macOS Keychain");
+#[cfg(target_os = "linux")]
+const SECURE_STORAGE_BACKEND: Option<&str> = Some("Linux Secret Service (via secret-tool)");
+#[cfg(not(any(target_os = "macos", target_os = "linux")))]
+const SECURE_STORAGE_BACKEND: Option<&str> = None;
 const OAUTH_SCOPE: &str = "mcp";
 const OAUTH_CALLBACK_TIMEOUT: Duration = Duration::from_secs(300);
 const OAUTH_REFRESH_SAFETY_WINDOW_SECONDS: u64 = 60;
@@ -2154,6 +2160,32 @@ pub(crate) async fn profile_verifications() -> Result<Vec<ProfileVerification>> 
 
 pub(crate) fn credentials_path() -> Result<PathBuf> {
     auth_store_path()
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub(crate) struct SecretStorageInfo {
+    pub backend: &'static str,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub path: Option<PathBuf>,
+}
+
+pub(crate) fn secret_storage_info() -> SecretStorageInfo {
+    let path = secret_store_path().ok();
+    let plaintext = path.as_ref().is_some_and(|path| {
+        load_secret_store()
+            .map(|store| !store.secrets.is_empty())
+            .unwrap_or_else(|_| path.exists())
+    });
+    if plaintext || SECURE_STORAGE_BACKEND.is_none() {
+        return SecretStorageInfo {
+            backend: "plaintext secrets.json",
+            path,
+        };
+    }
+    SecretStorageInfo {
+        backend: SECURE_STORAGE_BACKEND.expect("secure storage backend checked above"),
+        path: None,
+    }
 }
 
 pub(crate) fn format_verification_line(v: &ProfileVerification) -> String {

--- a/src/status.rs
+++ b/src/status.rs
@@ -42,6 +42,8 @@ struct StatusOutput {
     source: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     profiles: Option<Vec<auth::ProfileVerification>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    secret_storage: Option<auth::SecretStorageInfo>,
 }
 
 fn format_identity(p: &auth::ProfileInfo) -> Option<String> {
@@ -120,6 +122,7 @@ pub async fn run(base: BaseArgs, args: StatusArgs) -> Result<()> {
     } else {
         None
     };
+    let secret_storage = args.all.then(auth::secret_storage_info);
 
     if base.json {
         let output = StatusOutput {
@@ -135,6 +138,7 @@ pub async fn run(base: BaseArgs, args: StatusArgs) -> Result<()> {
             api_key_hint: profile_info.as_ref().and_then(|p| p.api_key_hint.clone()),
             source,
             profiles,
+            secret_storage,
         };
         println!("{}", serde_json::to_string(&output)?);
         return Ok(());
@@ -152,9 +156,17 @@ pub async fn run(base: BaseArgs, args: StatusArgs) -> Result<()> {
                 };
                 crate::ui::print_command_status(status, &auth::format_verification_line(profile));
             }
-            if let Ok(path) = auth::credentials_path() {
-                eprintln!("\nCredentials: {}\n", path.display());
+        }
+        if let Some(storage) = secret_storage.as_ref() {
+            match &storage.path {
+                Some(path) => {
+                    eprintln!("\nSecret storage: {} ({})", storage.backend, path.display())
+                }
+                None => eprintln!("\nSecret storage: {}", storage.backend),
             }
+        }
+        if let Ok(path) = auth::credentials_path() {
+            eprintln!("Profile metadata: {}\n", path.display());
         }
     }
 

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -434,16 +434,17 @@ fn profiles_rename_moves_oauth_credentials() {
 }
 
 #[test]
-fn status_all_json_includes_profile_urls() {
+fn status_all_includes_profile_urls_and_secret_storage() {
     let home = tempfile::tempdir().expect("home tempdir");
     let config_home = tempfile::tempdir().expect("config tempdir");
     let auth_dir = config_home.path().join("bt");
     fs::create_dir_all(&auth_dir).expect("create auth dir");
     fs::write(
         auth_dir.join("auth.json"),
-        r#"{"profiles":{"test-profile":{"auth_kind":"oauth","api_url":"https://oauth-api.test.example","app_url":"https://app.test.example","oauth_client_id":"bt_cli_test"}}}"#,
+        r#"{"profiles":{"test-profile":{"auth_kind":"oauth","api_url":"https://oauth-api.test.example","app_url":"https://app.test.example","oauth_client_id":"bt_cli_test","oauth_access_expires_at":1}}}"#,
     )
     .expect("write auth store");
+    write_profile_secrets(config_home.path(), &["oauth_access::test-profile"]);
 
     let mut cmd = bt_command();
     clear_braintrust_auth_env(&mut cmd);
@@ -457,6 +458,21 @@ fn status_all_json_includes_profile_urls() {
         ))
         .stdout(predicate::str::contains(
             "\"api_url\":\"https://oauth-api.test.example\"",
+        ))
+        .stdout(predicate::str::contains(
+            r#""secret_storage":{"backend":"plaintext secrets.json","path":"#,
+        ));
+
+    let mut cmd = bt_command();
+    clear_braintrust_auth_env(&mut cmd);
+    cmd.env("HOME", home.path())
+        .env("XDG_CONFIG_HOME", config_home.path())
+        .args(["status", "--all"])
+        .assert()
+        .success()
+        .stderr(predicate::str::contains("Secret storage:").count(1))
+        .stderr(predicate::str::contains(
+            "Secret storage: plaintext secrets.json (",
         ));
 }
 


### PR DESCRIPTION
clarifies that config.json is metadata and not secrets

Read the description of https://github.com/braintrustdata/bt/pull/344, this PR might need tweaking to better support Windows.

Before:
```
✓ cedric — https://www.braintrust.dev — oauth — api: https://api.braintrust.dev — Cedric Halber (cedric@braintrustdata.com)
✓ cedric-2 — http://localhost:3000 — oauth — api: http://localhost:8000 — Cédric Halber (cedric@braintrustdata.com)
✓ profile — https://www.braintrust.dev — api_key — bt-****vVjh3

Credentials: /Users/cedric@braintrustdata.com/.config/bt/auth.json

org: ced
project: My Project
project_id: 8bd69204-1f16-4eef-b8ce-74f20bede6f7
profile: cedric-2
app_url: http://localhost:3000
api_url: http://localhost:8000
auth: oauth — Cédric Halber (cedric@braintrustdata.com)
source: /Users/cedric@braintrustdata.com/.bt/config.json
```

After:
```
✓ cedric — https://www.braintrust.dev — oauth — api: https://api.braintrust.dev — Cedric Halber (cedric@braintrustdata.com)
✓ cedric-2 — http://localhost:3000 — oauth — api: http://localhost:8000 — Cédric Halber (cedric@braintrustdata.com)
✓ profile — https://www.braintrust.dev — api_key — bt-****vVjh3

Secret storage: macOS Keychain
Profile metadata: /Users/cedric@braintrustdata.com/.config/bt/auth.json

org: ced
project: My Project
project_id: e52400bc-f0f5-4d60-81ce-c1dd7aa933d1
profile: cedric-2
app_url: http://localhost:3000
api_url: http://localhost:8000
auth: oauth — Cédric Halber (cedric@braintrustdata.com)
source: /Users/cedric@braintrustdata.com/.config/bt/config.json
```