### PR TITLE
Fix profile + org logic while resolving traces

### DIFF
--- a/src/args.rs
+++ b/src/args.rs
@@ -151,6 +151,23 @@ impl std::ops::DerefMut for BaseArgs {
     }
 }
 
+impl BaseArgs {
+    pub(crate) fn apply_url_org_hint(&mut self, url_org: Option<&str>) {
+        if self
+            .org_name
+            .as_deref()
+            .map(str::trim)
+            .is_some_and(|org| !org.is_empty())
+        {
+            return;
+        }
+
+        if let Some(url_org) = url_org.map(str::trim).filter(|org| !org.is_empty()) {
+            self.org_name = Some(url_org.to_string());
+        }
+    }
+}
+
 impl From<LoginBaseArgs> for BaseArgs {
     fn from(login: LoginBaseArgs) -> Self {
         Self {

--- a/src/experiments/mod.rs
+++ b/src/experiments/mod.rs
@@ -219,26 +219,7 @@ fn apply_experiment_url_hints_to_base(
         }
     }
 
-    let has_profile_override = base
-        .profile
-        .as_deref()
-        .map(str::trim)
-        .is_some_and(|v| !v.is_empty());
-    let has_org_override = base
-        .org_name
-        .as_deref()
-        .map(str::trim)
-        .is_some_and(|v| !v.is_empty());
-    if !has_profile_override && !has_org_override {
-        if let Some(org) = parsed_url
-            .org
-            .as_deref()
-            .map(str::trim)
-            .filter(|v| !v.is_empty())
-        {
-            base.org_name = Some(org.to_string());
-        }
-    }
+    base.apply_url_org_hint(parsed_url.org.as_deref());
 
     base
 }
@@ -403,5 +384,48 @@ mod tests {
 
         assert_eq!(parsed.base_experiment.as_deref(), Some("baseline"));
         assert_eq!(parsed.comparison_experiment.as_deref(), Some("challenger"));
+    }
+
+    #[test]
+    fn experiment_url_hints_use_url_org_with_explicit_profile() {
+        let base = BaseArgs {
+            login: crate::args::LoginBaseArgs {
+                profile: Some("test-profile".to_string()),
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+        let parsed = parse_experiment_compare_url(
+            "https://www.example.test/app/url-org/p/url-project/experiments/baseline?c=challenger",
+        )
+        .expect("parse url");
+
+        let updated = apply_experiment_url_hints_to_base(base, Some(&parsed));
+
+        assert_eq!(updated.profile.as_deref(), Some("test-profile"));
+        assert_eq!(updated.org_name.as_deref(), Some("url-org"));
+        assert_eq!(updated.project.as_deref(), Some("url-project"));
+    }
+
+    #[test]
+    fn experiment_url_hints_preserve_explicit_org_and_project() {
+        let base = BaseArgs {
+            login: crate::args::LoginBaseArgs {
+                profile: Some("test-profile".to_string()),
+                ..Default::default()
+            },
+            org_name: Some("explicit-org".to_string()),
+            project: Some("explicit-project".to_string()),
+        };
+        let parsed = parse_experiment_compare_url(
+            "https://www.example.test/app/url-org/p/url-project/experiments/baseline?c=challenger",
+        )
+        .expect("parse url");
+
+        let updated = apply_experiment_url_hints_to_base(base, Some(&parsed));
+
+        assert_eq!(updated.profile.as_deref(), Some("test-profile"));
+        assert_eq!(updated.org_name.as_deref(), Some("explicit-org"));
+        assert_eq!(updated.project.as_deref(), Some("explicit-project"));
     }
 }

--- a/src/traces.rs
+++ b/src/traces.rs
@@ -5716,32 +5716,7 @@ fn parse_startup_trace_url_from_view_args(args: &ViewArgs) -> Result<Option<Pars
 }
 
 fn apply_url_hints_to_base(mut base: BaseArgs, parsed_url: Option<&ParsedTraceUrl>) -> BaseArgs {
-    let Some(parsed) = parsed_url else {
-        return base;
-    };
-    let Some(url_org) = parsed
-        .org
-        .as_deref()
-        .map(str::trim)
-        .filter(|v| !v.is_empty())
-    else {
-        return base;
-    };
-
-    let has_profile_override = base
-        .profile
-        .as_deref()
-        .map(str::trim)
-        .is_some_and(|v| !v.is_empty());
-    let has_org_override = base
-        .org_name
-        .as_deref()
-        .map(str::trim)
-        .is_some_and(|v| !v.is_empty());
-
-    if !has_org_override && !has_profile_override {
-        base.org_name = Some(url_org.to_string());
-    }
+    base.apply_url_org_hint(parsed_url.and_then(|parsed| parsed.org.as_deref()));
     base
 }
 
@@ -6925,7 +6900,7 @@ mod tests {
     }
 
     #[test]
-    fn apply_url_hints_keeps_profile_independent_from_url_org() {
+    fn apply_url_hints_uses_url_org() {
         let base = base_args();
         let parsed = parsed_url_with_org("Lovable");
 
@@ -6936,7 +6911,7 @@ mod tests {
     }
 
     #[test]
-    fn apply_url_hints_preserves_explicit_profile() {
+    fn apply_url_hints_uses_url_org_with_explicit_profile() {
         let mut base = base_args();
         base.profile = Some("explicit-profile".to_string());
         let parsed = parsed_url_with_org("Lovable");
@@ -6944,7 +6919,20 @@ mod tests {
         let updated = apply_url_hints_to_base(base, Some(&parsed));
 
         assert_eq!(updated.profile.as_deref(), Some("explicit-profile"));
-        assert!(updated.org_name.is_none());
+        assert_eq!(updated.org_name.as_deref(), Some("Lovable"));
+    }
+
+    #[test]
+    fn apply_url_hints_preserves_explicit_org() {
+        let mut base = base_args();
+        base.profile = Some("explicit-profile".to_string());
+        base.org_name = Some("explicit-org".to_string());
+        let parsed = parsed_url_with_org("url-org");
+
+        let updated = apply_url_hints_to_base(base, Some(&parsed));
+
+        assert_eq!(updated.profile.as_deref(), Some("explicit-profile"));
+        assert_eq!(updated.org_name.as_deref(), Some("explicit-org"));
     }
 
     #[test]


### PR DESCRIPTION
This got a bit messed up when we disentangled profiles and orgs. We still need to use the org name from the URL to resolve the trace (which was being ignored if the `profile` arg was present)